### PR TITLE
HADOOP-19740. S3A: add explicit "sdk" region for region resolution.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1530,6 +1530,26 @@ public final class Constants {
   public static final String AWS_S3_ACCESSPOINT_REQUIRED = "fs.s3a.accesspoint.required";
 
   /**
+   * Explicit request for the SDK region resolution.
+   * Value: {@code}.
+   */
+  public static final String SDK_REGION = "sdk";
+
+  /**
+   * Declare as running in EC2.
+   * Currently hands off to the SDK for resolution; it may change in future.
+   * Value: {@code}.
+   */
+  public static final String EC2_REGION = "ec2";
+
+  /**
+   * An empty region is the historic fall-through to the SDK.
+   * Value: ""
+   */
+  public static final String EMPTY_REGION = "";
+
+
+  /**
    * Flag for create performance.
    * This can be set in the {code createFile()} builder.
    * Value {@value}.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1536,18 +1536,10 @@ public final class Constants {
   public static final String SDK_REGION = "sdk";
 
   /**
-   * Declare as running in EC2.
-   * Currently hands off to the SDK for resolution; it may change in future.
-   * Value: {@code}.
-   */
-  public static final String EC2_REGION = "ec2";
-
-  /**
    * An empty region is the historic fall-through to the SDK.
    * Value: ""
    */
   public static final String EMPTY_REGION = "";
-
 
   /**
    * Flag for create performance.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -68,6 +68,7 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
 import static org.apache.hadoop.fs.s3a.auth.SignerFactory.createHttpSigner;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AUTH_SCHEME_AWS_SIGV_4;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.Ec2Metadata;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.Sdk;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
 
@@ -313,7 +314,15 @@ public class DefaultS3ClientFactory extends Configured
     // which tests expect.
     builder.fipsEnabled(resolution.isUseFips());
 
-    if (Sdk != resolution.getMechanism()) {
+    final RegionResolution.RegionResolutionMechanism mechanism = resolution.getMechanism();
+    if (Sdk == mechanism) {
+      // handing off all resolution to SDK.
+      // region configuration was set to empty string.
+      // allow this if people really want it; it is OK to rely on this
+      // when deployed in EC2.
+      DEFAULT_REGION_CHAIN.info(SDK_REGION_CHAIN_IN_USE);
+      LOG.debug(SDK_REGION_CHAIN_IN_USE);
+    } else {
       final Region region = resolution.getRegion();
       builder.region(requireNonNull(region));
       // s3 cross region access
@@ -327,13 +336,6 @@ public class DefaultS3ClientFactory extends Configured
           LOG.debug("Setting endpoint to {}", endpointUri);
         }
       }
-    } else {
-      // handing off all resolution to SDK.
-      // region configuration was set to empty string.
-      // allow this if people really want it; it is OK to rely on this
-      // when deployed in EC2.
-      DEFAULT_REGION_CHAIN.info(SDK_REGION_CHAIN_IN_USE);
-      LOG.debug(SDK_REGION_CHAIN_IN_USE);
     }
     return resolution;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -323,18 +323,20 @@ public class DefaultS3ClientFactory extends Configured
       DEFAULT_REGION_CHAIN.info(SDK_REGION_CHAIN_IN_USE);
       LOG.debug(SDK_REGION_CHAIN_IN_USE);
     } else {
+
+      // a region has been determined from configuration,
+      // or it is falling back to central region.
+
       final Region region = resolution.getRegion();
       builder.region(requireNonNull(region));
       // s3 cross region access
       if (resolution.isCrossRegionAccessEnabled()) {
         builder.crossRegionAccessEnabled(true);
       }
-      if (!resolution.isUseCentralEndpoint()) {
-        final URI endpointUri = resolution.getEndpointUri();
-        if  (endpointUri != null) {
-          builder.endpointOverride(endpointUri);
-          LOG.debug("Setting endpoint to {}", endpointUri);
-        }
+      final URI endpointUri = resolution.getEndpointUri();
+      if (endpointUri != null && !resolution.isUseCentralEndpoint()) {
+        LOG.debug("Setting endpoint to {}", endpointUri);
+        builder.endpointOverride(endpointUri);
       }
     }
     return resolution;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -68,7 +68,6 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
 import static org.apache.hadoop.fs.s3a.auth.SignerFactory.createHttpSigner;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AUTH_SCHEME_AWS_SIGV_4;
-import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.Ec2Metadata;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.Sdk;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -286,9 +286,9 @@ public class DefaultS3ClientFactory extends Configured
    * @throws IllegalArgumentException if endpoint is set when FIPS is enabled.
    */
   private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> RegionResolution.Resolution
-  configureEndpointAndRegion(BuilderT builder,
-      S3ClientCreationParameters parameters,
-      Configuration conf) throws IOException {
+      configureEndpointAndRegion(BuilderT builder,
+        S3ClientCreationParameters parameters,
+        Configuration conf) throws IOException {
 
     final RegionResolution.Resolution resolution =
         calculateRegion(parameters, conf);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -20,16 +20,10 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.fs.s3a.impl.AWSClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -57,17 +51,13 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.s3a.impl.AWSClientConfig;
+import org.apache.hadoop.fs.s3a.impl.RegionResolution;
 import org.apache.hadoop.fs.s3a.statistics.impl.AwsStatisticsCollector;
 import org.apache.hadoop.fs.store.LogExactlyOnce;
 
-import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_FALLBACK_TO_IAM_ENABLED;
-import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED;
-import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT;
-import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_DEFAULT_REGION;
-import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
-import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_CLASS_NAME;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_ENABLED_DEFAULT;
@@ -77,7 +67,7 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
 import static org.apache.hadoop.fs.s3a.auth.SignerFactory.createHttpSigner;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AUTH_SCHEME_AWS_SIGV_4;
-import static org.apache.hadoop.util.Preconditions.checkArgument;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
 
 
 /**
@@ -92,40 +82,11 @@ public class DefaultS3ClientFactory extends Configured
 
   private static final String REQUESTER_PAYS_HEADER_VALUE = "requester";
 
-  private static final String S3_SERVICE_NAME = "s3";
-
-  private static final Pattern VPC_ENDPOINT_PATTERN =
-          Pattern.compile("^(?:.+\\.)?([a-z0-9-]+)\\.vpce\\.amazonaws\\.(?:com|com\\.cn)$");
-
   /**
    * Subclasses refer to this.
    */
   protected static final Logger LOG =
       LoggerFactory.getLogger(DefaultS3ClientFactory.class);
-
-  /**
-   * A one-off warning of default region chains in use.
-   */
-  private static final LogExactlyOnce WARN_OF_DEFAULT_REGION_CHAIN =
-      new LogExactlyOnce(LOG);
-
-  /**
-   * Warning message printed when the SDK Region chain is in use.
-   */
-  private static final String SDK_REGION_CHAIN_IN_USE =
-      "S3A filesystem client is using"
-          + " the SDK region resolution chain.";
-
-
-  /** Exactly once log to inform about ignoring the AWS-SDK Warnings for CSE. */
-  private static final LogExactlyOnce IGNORE_CSE_WARN = new LogExactlyOnce(LOG);
-
-  /**
-   * Error message when an endpoint is set with FIPS enabled: {@value}.
-   */
-  @VisibleForTesting
-  public static final String ERROR_ENDPOINT_WITH_FIPS =
-      "Non central endpoint cannot be set when " + FIPS_ENDPOINT + " is true";
 
   /**
    * A one-off log stating whether S3 Access Grants are enabled.
@@ -329,152 +290,39 @@ public class DefaultS3ClientFactory extends Configured
    */
   private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> void configureEndpointAndRegion(
       BuilderT builder, S3ClientCreationParameters parameters, Configuration conf) {
-    final String endpointStr = parameters.getEndpoint();
-    final URI endpoint = getS3Endpoint(endpointStr, conf);
 
-    final String configuredRegion = parameters.getRegion();
-    Region region = null;
-    String origin = "";
+    final RegionResolution.Resolution resolution =
+        calculateRegion(parameters, conf);
+    LOG.debug("Region Resolution: {}", resolution);
 
-    // If the region was configured, set it.
-    if (configuredRegion != null && !configuredRegion.isEmpty()) {
-      origin = AWS_REGION;
-      region = Region.of(configuredRegion);
-    }
-
-    // FIPs? Log it, then reject any attempt to set an endpoint
-    final boolean fipsEnabled = parameters.isFipsEnabled();
-    if (fipsEnabled) {
-      LOG.debug("Enabling FIPS mode");
-    }
-    // always setting it guarantees the value is non-null,
+    // always setting to true or false guarantees the value is non-null,
     // which tests expect.
-    builder.fipsEnabled(fipsEnabled);
-
-    if (endpoint != null) {
-      boolean endpointEndsWithCentral =
-          endpointStr.endsWith(CENTRAL_ENDPOINT);
-      checkArgument(!fipsEnabled || endpointEndsWithCentral, "%s : %s",
-          ERROR_ENDPOINT_WITH_FIPS,
-          endpoint);
-
-      // No region was configured,
-      // determine the region from the endpoint.
-      if (region == null) {
-        region = getS3RegionFromEndpoint(endpointStr,
-            endpointEndsWithCentral);
-        if (region != null) {
-          origin = "endpoint";
-        }
-      }
-
-      // No need to override endpoint with "s3.amazonaws.com".
-      // Let the client take care of endpoint resolution. Overriding
-      // the endpoint with "s3.amazonaws.com" causes 400 Bad Request
-      // errors for non-existent buckets and objects.
-      // ref: https://github.com/aws/aws-sdk-java-v2/issues/4846
-      if (!endpointEndsWithCentral) {
-        builder.endpointOverride(endpoint);
-        LOG.debug("Setting endpoint to {}", endpoint);
-      } else {
-        origin = "central endpoint with cross region access";
-        LOG.debug("Enabling cross region access for endpoint {}",
-            endpointStr);
-      }
-    }
-
+    builder.fipsEnabled(resolution.isUseFips());
+    final Region region = resolution.getRegion();
     if (region != null) {
       builder.region(region);
-    } else if (configuredRegion == null) {
-      // no region is configured, and none could be determined from the endpoint.
-      // Use US_EAST_2 as default.
-      region = Region.of(AWS_S3_DEFAULT_REGION);
-      builder.region(region);
-      origin = "cross region access fallback";
-    } else if (configuredRegion.isEmpty()) {
-      // region configuration was set to empty string.
-      // allow this if people really want it; it is OK to rely on this
-      // when deployed in EC2.
-      WARN_OF_DEFAULT_REGION_CHAIN.warn(SDK_REGION_CHAIN_IN_USE);
-      LOG.debug(SDK_REGION_CHAIN_IN_USE);
-      origin = "SDK region chain";
     }
-    boolean isCrossRegionAccessEnabled = conf.getBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED,
-        AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT);
     // s3 cross region access
-    if (isCrossRegionAccessEnabled) {
+    if (resolution.isCrossRegionAccessEnabled()) {
       builder.crossRegionAccessEnabled(true);
     }
-    LOG.debug("Setting region to {} from {} with cross region access {}",
-        region, origin, isCrossRegionAccessEnabled);
+    if (!resolution.isUseCentralEndpoint()) {
+      final URI endpointUri = resolution.getEndpointUri();
+      builder.endpointOverride(endpointUri);
+      LOG.debug("Setting endpoint to {}", endpointUri);
+    }
   }
 
   /**
    * Given a endpoint string, create the endpoint URI.
-   *
+   * <p>Kept in as subclasses use it.
    * @param endpoint possibly null endpoint.
    * @param conf config to build the URI from.
    * @return an endpoint uri
    */
   protected static URI getS3Endpoint(String endpoint, final Configuration conf) {
-
     boolean secureConnections = conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS);
-
-    String protocol = secureConnections ? "https" : "http";
-
-    if (endpoint == null || endpoint.isEmpty()) {
-      // don't set an endpoint if none is configured, instead let the SDK figure it out.
-      return null;
-    }
-
-    if (!endpoint.contains("://")) {
-      endpoint = String.format("%s://%s", protocol, endpoint);
-    }
-
-    try {
-      return new URI(endpoint);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
-    }
-  }
-
-  /**
-   * Parses the endpoint to get the region.
-   * If endpoint is the central one, use US_EAST_2.
-   *
-   * @param endpoint the configure endpoint.
-   * @param endpointEndsWithCentral true if the endpoint is configured as central.
-   * @return the S3 region, null if unable to resolve from endpoint.
-   */
-  @VisibleForTesting
-  static Region getS3RegionFromEndpoint(final String endpoint,
-      final boolean endpointEndsWithCentral) {
-
-    if (!endpointEndsWithCentral) {
-      // S3 VPC endpoint parsing
-      Matcher matcher = VPC_ENDPOINT_PATTERN.matcher(endpoint);
-      if (matcher.find()) {
-        LOG.debug("Mapping to VPCE");
-        LOG.debug("Endpoint {} is vpc endpoint; parsing region as {}", endpoint, matcher.group(1));
-        return Region.of(matcher.group(1));
-      }
-
-      LOG.debug("Endpoint {} is not the default; parsing", endpoint);
-      return AwsHostNameUtils.parseSigningRegion(endpoint, S3_SERVICE_NAME).orElse(null);
-    }
-
-    // Select default region here to enable cross-region access.
-    // If both "fs.s3a.endpoint" and "fs.s3a.endpoint.region" are empty,
-    // Spark sets "fs.s3a.endpoint" to "s3.amazonaws.com".
-    // This applies to Spark versions with the changes of SPARK-35878.
-    // ref:
-    // https://github.com/apache/spark/blob/v3.5.0/core/
-    // src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala#L528
-    // If we do not allow cross region access, Spark would not be able to
-    // access any bucket that is not present in the given region.
-    // Hence, we should use default region us-east-2 to allow cross-region
-    // access.
-    return Region.of(AWS_S3_DEFAULT_REGION);
+    return RegionResolution.buildEndpointUri(endpoint, secureConnections);
   }
 
   private static <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> void

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -285,8 +285,10 @@ public class DefaultS3ClientFactory extends Configured
    * @return how the region was resolved.
    * @throws IllegalArgumentException if endpoint is set when FIPS is enabled.
    */
-  private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> RegionResolution.Resolution configureEndpointAndRegion(
-      BuilderT builder, S3ClientCreationParameters parameters, Configuration conf)  throws IOException {
+  private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> RegionResolution.Resolution
+  configureEndpointAndRegion(BuilderT builder,
+      S3ClientCreationParameters parameters,
+      Configuration conf) throws IOException {
 
     final RegionResolution.Resolution resolution =
         calculateRegion(parameters, conf);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -91,12 +91,6 @@ public class DefaultS3ClientFactory extends Configured
       LoggerFactory.getLogger(DefaultS3ClientFactory.class);
 
   /**
-   * Message printed when the SDK Region chain is in use.
-   */
-  private static final String SDK_REGION_CHAIN_IN_USE =
-      "S3A filesystem client is using the SDK region resolution chain.";
-
-  /**
    * A one-off log stating whether S3 Access Grants are enabled.
    */
   private static final LogExactlyOnce LOG_S3AG_ENABLED = new LogExactlyOnce(LOG);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -92,12 +92,6 @@ public class DefaultS3ClientFactory extends Configured
       LoggerFactory.getLogger(DefaultS3ClientFactory.class);
 
   /**
-   * A one-off warning of default region chains in use.
-   */
-  private static final LogExactlyOnce DEFAULT_REGION_CHAIN =
-      new LogExactlyOnce(LOG);
-
-  /**
    * Message printed when the SDK Region chain is in use.
    */
   private static final String SDK_REGION_CHAIN_IN_USE =
@@ -283,18 +277,7 @@ public class DefaultS3ClientFactory extends Configured
 
   /**
    * This method configures the endpoint and region for a S3 client.
-   * The order of configuration is:
-   *
-   * <ol>
-   * <li>If region is configured via fs.s3a.endpoint.region, use it.</li>
-   * <li>If endpoint is configured via via fs.s3a.endpoint, set it.
-   *     If no region is configured, try to parse region from endpoint. </li>
-   * <li> If no region is configured, and it could not be parsed from the endpoint,
-   *     set the default region as US_EAST_2</li>
-   * <li> If configured region is empty, fallback to SDK resolution chain. </li>
-   * <li> S3 cross region is enabled by default irrespective of region or endpoint
-   *      is set or not.</li>
-   * </ol>
+   * See {@link RegionResolution} for the details.
    * @param builder S3 client builder.
    * @param parameters parameter object
    * @param conf conf configuration object
@@ -314,15 +297,7 @@ public class DefaultS3ClientFactory extends Configured
     // which tests expect.
     builder.fipsEnabled(resolution.isUseFips());
 
-    final RegionResolution.RegionResolutionMechanism mechanism = resolution.getMechanism();
-    if (Sdk == mechanism) {
-      // handing off all resolution to SDK.
-      // region configuration was set to empty string.
-      // allow this if people really want it; it is OK to rely on this
-      // when deployed in EC2.
-      DEFAULT_REGION_CHAIN.info(SDK_REGION_CHAIN_IN_USE);
-      LOG.debug(SDK_REGION_CHAIN_IN_USE);
-    } else {
+    if (Sdk != resolution.getMechanism()) {
 
       // a region has been determined from configuration,
       // or it is falling back to central region.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.fs.s3a.impl.RegionResolution;
 import org.apache.hadoop.fs.s3a.statistics.impl.AwsStatisticsCollector;
 import org.apache.hadoop.fs.store.LogExactlyOnce;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_FALLBACK_TO_IAM_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_CLASS_NAME;
@@ -67,6 +68,7 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
 import static org.apache.hadoop.fs.s3a.auth.SignerFactory.createHttpSigner;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AUTH_SCHEME_AWS_SIGV_4;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.Sdk;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
 
 
@@ -87,6 +89,18 @@ public class DefaultS3ClientFactory extends Configured
    */
   protected static final Logger LOG =
       LoggerFactory.getLogger(DefaultS3ClientFactory.class);
+
+  /**
+   * A one-off warning of default region chains in use.
+   */
+  private static final LogExactlyOnce DEFAULT_REGION_CHAIN =
+      new LogExactlyOnce(LOG);
+
+  /**
+   * Message printed when the SDK Region chain is in use.
+   */
+  private static final String SDK_REGION_CHAIN_IN_USE =
+      "S3A filesystem client is using the SDK region resolution chain.";
 
   /**
    * A one-off log stating whether S3 Access Grants are enabled.
@@ -280,16 +294,16 @@ public class DefaultS3ClientFactory extends Configured
    * <li> S3 cross region is enabled by default irrespective of region or endpoint
    *      is set or not.</li>
    * </ol>
-   *
    * @param builder S3 client builder.
    * @param parameters parameter object
-   * @param conf  conf configuration object
+   * @param conf conf configuration object
    * @param <BuilderT> S3 client builder type
    * @param <ClientT> S3 client type
+   * @return how the region was resolved.
    * @throws IllegalArgumentException if endpoint is set when FIPS is enabled.
    */
-  private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> void configureEndpointAndRegion(
-      BuilderT builder, S3ClientCreationParameters parameters, Configuration conf) {
+  private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> RegionResolution.Resolution configureEndpointAndRegion(
+      BuilderT builder, S3ClientCreationParameters parameters, Configuration conf)  throws IOException {
 
     final RegionResolution.Resolution resolution =
         calculateRegion(parameters, conf);
@@ -298,19 +312,30 @@ public class DefaultS3ClientFactory extends Configured
     // always setting to true or false guarantees the value is non-null,
     // which tests expect.
     builder.fipsEnabled(resolution.isUseFips());
-    final Region region = resolution.getRegion();
-    if (region != null) {
-      builder.region(region);
+
+    if (Sdk != resolution.getMechanism()) {
+      final Region region = resolution.getRegion();
+      builder.region(requireNonNull(region));
+      // s3 cross region access
+      if (resolution.isCrossRegionAccessEnabled()) {
+        builder.crossRegionAccessEnabled(true);
+      }
+      if (!resolution.isUseCentralEndpoint()) {
+        final URI endpointUri = resolution.getEndpointUri();
+        if  (endpointUri != null) {
+          builder.endpointOverride(endpointUri);
+          LOG.debug("Setting endpoint to {}", endpointUri);
+        }
+      }
+    } else {
+      // handing off all resolution to SDK.
+      // region configuration was set to empty string.
+      // allow this if people really want it; it is OK to rely on this
+      // when deployed in EC2.
+      DEFAULT_REGION_CHAIN.info(SDK_REGION_CHAIN_IN_USE);
+      LOG.debug(SDK_REGION_CHAIN_IN_USE);
     }
-    // s3 cross region access
-    if (resolution.isCrossRegionAccessEnabled()) {
-      builder.crossRegionAccessEnabled(true);
-    }
-    if (!resolution.isUseCentralEndpoint()) {
-      final URI endpointUri = resolution.getEndpointUri();
-      builder.endpointOverride(endpointUri);
-      LOG.debug("Setting endpoint to {}", endpointUri);
-    }
+    return resolution;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/NetworkBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/NetworkBinding.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,13 +100,14 @@ public final class NetworkBinding {
 
   /**
    * Is this an AWS endpoint? looks at end of FQDN.
-   * @param endpoint endpoint
-   * @return true if the endpoint matches the requirements for an aws endpoint.
+   * @param endpoint endpoint.
+   * @return true iff this is non-empty or ends with amazonaws.com or amazonaws.com.cn
    */
   public static boolean isAwsEndpoint(final String endpoint) {
+    final String host = endpoint.toLowerCase(Locale.ROOT);
     return (endpoint.isEmpty()
-        || endpoint.endsWith(".amazonaws.com")
-        || endpoint.endsWith(".amazonaws.com.cn"));
+        || host.endsWith(".amazonaws.com")
+        || host.endsWith(".amazonaws.com.cn"));
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
+import software.amazon.awssdk.regions.Region;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT;
+import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.EC2_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.EMPTY_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
+import static org.apache.hadoop.util.Preconditions.checkArgument;
+import static software.amazon.awssdk.regions.Region.US_EAST_2;
+
+/**
+ * Region resolution.
+ * <p>This is complicated and can be a source of support escalations.
+ * <p>The V1 SDK was happy to take an endpoint and
+ * work details out from there, possibly probing us-central-1 and cacheing
+ * the result.
+ * <p>The V2 SDK like the signing region and endpoint to be declared.
+ * The S3A connector has tried to mimic the V1 code, but lacks some features
+ * (use of environment variables, probing of EC2 IAM details) for which
+ * the SDK is better.
+ *
+ */
+public class RegionResolution {
+
+  protected static final Logger LOG =
+      LoggerFactory.getLogger(RegionResolution.class);
+
+  /**
+   * Service to ask SDK to parse.
+   */
+  private static final String S3_SERVICE_NAME = "s3";
+
+  /**
+   * Pattern to match vpce endpoints on.
+   */
+  private static final Pattern VPC_ENDPOINT_PATTERN =
+      Pattern.compile("^(?:.+\\.)?([a-z0-9-]+)\\.vpce\\.amazonaws\\.(?:com|com\\.cn)$");
+
+ /**
+  * Error message when an endpoint is set with FIPS enabled: {@value}.
+  */
+ @VisibleForTesting
+ public static final String ERROR_ENDPOINT_WITH_FIPS =
+     "Only S3 central endpoint cannot be set when " + FIPS_ENDPOINT + " is true";
+
+  /**
+   * Virtual hostnames MUST be used when using the FIPS endpoint.
+   */
+ public static final String FIPS_PATH_ACCESS_INCOMPATIBLE =
+     "Path style access must be disabled when "+ FIPS_ENDPOINT + " is true";
+
+  /**
+   * How was the region resolved?
+   */
+ public enum RegionResolutionMechanism {
+
+   CalculatedFromEndpoint("Calculated from endpoint"),
+   FallbackToCentral("Fallback to central endpoint"),
+   ParseVpceEndpoint("Parse VPCE Endpoint"),
+   Sdk("SDK resolution chain"),
+   Specified("region specified");
+
+   /**
+    * Text of the mechanism.
+    */
+   private final String mechanism;
+
+   RegionResolutionMechanism(String mechanism) {
+     this.mechanism = mechanism;
+   }
+
+    /**
+     * String value of the resolution mechanism.
+     * @return the resolution mechanism.
+     */
+   public String getMechanism() {
+     return mechanism;
+   }
+
+   @Override
+   public String toString() {
+     final StringBuilder sb = new StringBuilder("RegionResolutionMechanism{");
+     sb.append("mechanism='").append(mechanism).append('\'');
+     sb.append('}');
+     return sb.toString();
+   }
+ }
+
+  /**
+   * The resolution of a region and endpoint..
+   */
+  public static final class Resolution {
+
+    /**
+     * Region: if null hand down to the SDK.
+     */
+    private Region region;
+
+    /**
+     * How was the region resolved?
+     * Null means unresolved.
+     */
+    private RegionResolutionMechanism resolution;
+
+    /**
+     * Should FIPS be enabled?
+     */
+    private boolean useFips;
+
+    /**
+     * Should cross-region access be enabled?
+     */
+    private boolean crossRegionAccessEnabled;
+
+    /**
+     * Endpoint as string.
+     */
+    private String endpointStr;
+
+    /**
+     * Endpoint URI.
+     */
+    private URI endpointUri;
+
+    /**
+     * Use the central endpoint?
+     */
+    private boolean useCentralEndpoint;
+
+    /**
+     * Set the region.
+     * Declares the region as resolved even when the value is null (i.e. resolve to SDK).
+     * @param region new value
+     * @return the builder
+     */
+    public Resolution withRegion(
+        @Nullable final Region region,
+        final RegionResolutionMechanism resolutionMechanism) {
+      this.region = region;
+      this.resolution = requireNonNull(resolutionMechanism);
+      return this;
+    }
+
+    /**
+     * Set builder value.
+     * @param value new value
+     * @return the builder
+     */
+    public Resolution withUseFips(final boolean value) {
+      useFips = value;
+      return this;
+    }
+
+    /**
+     * Set builder value.
+     * @param value new value
+     * @return the builder
+     */
+    public Resolution withCrossRegionAccessEnabled(final boolean value) {
+      crossRegionAccessEnabled = value;
+      return this;
+    }
+
+    /**
+     * Set builder value.
+     * @param value new value
+     * @return the builder
+     */
+    public Resolution withEndpointStr(final String value) {
+      endpointStr = value;
+      return this;
+    }
+
+    public URI getEndpointUri() {
+      return endpointUri;
+    }
+
+    /**
+     * Set builder value.
+     * @param value new value
+     * @return the builder
+     */
+    public Resolution withEndpointUri(final URI value) {
+      endpointUri = value;
+      return this;
+    }
+
+    public Region getRegion() {
+      return region;
+    }
+
+    public boolean isUseFips() {
+      return useFips;
+    }
+
+    public boolean isCrossRegionAccessEnabled() {
+      return crossRegionAccessEnabled;
+    }
+
+    public RegionResolutionMechanism getResolution() {
+      return resolution;
+    }
+
+    public String getEndpointStr() {
+      return endpointStr;
+    }
+
+    public boolean isRegionResolved() {
+      return resolution != null;
+    }
+
+    public boolean isUseCentralEndpoint() {
+      return useCentralEndpoint;
+    }
+
+    /**
+     * Set builder value.
+     * @param value new value
+     * @return the builder
+     */
+    public Resolution withUseCentralEndpoint(final boolean value) {
+      useCentralEndpoint = value;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder("Resolution{");
+      sb.append("region=").append(region);
+      sb.append(", resolution=").append(resolution);
+      sb.append(", useFips=").append(useFips);
+      sb.append(", crossRegionAccessEnabled=").append(crossRegionAccessEnabled);
+      sb.append(", endpointUri=").append(endpointUri);
+      sb.append(", useCentralEndpoint=").append(useCentralEndpoint);
+      sb.append('}');
+      return sb.toString();
+    }
+  }
+
+  /**
+   * Given a endpoint string, create the endpoint URI.
+   *
+   * @param endpoint possibly null endpoint.
+   * @param secureConnections use secure HTTPS connection?
+   * @return an endpoint uri or null if the endpoint was passed in was null/empty
+   * @throws IllegalArgumentException failure to parse the endpoint.
+   */
+  public static URI buildEndpointUri(String endpoint, final boolean secureConnections) {
+
+    String protocol = secureConnections ? "https" : "http";
+
+    if (endpoint == null || endpoint.isEmpty()) {
+      // don't set an endpoint if none is configured, instead let the SDK figure it out.
+      return null;
+    }
+
+    if (!endpoint.contains("://")) {
+      endpoint = String.format("%s://%s", protocol, endpoint);
+    }
+
+    try {
+      return new URI(endpoint);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * Parses the endpoint to get the region.
+   * If endpoint is the central one, use US_EAST_2.
+   * @param endpoint the configure endpoint.
+   * @param endpointEndsWithCentral true if the endpoint is configured as central.
+   * @return the S3 region resolution if possible from parsing the endpoint
+   */
+  @VisibleForTesting
+  public static Optional<Resolution> getS3RegionFromEndpoint(
+      final String endpoint,
+      final boolean endpointEndsWithCentral) {
+
+    if (!endpointEndsWithCentral) {
+      // S3 VPC endpoint parsing
+      Matcher matcher = VPC_ENDPOINT_PATTERN.matcher(endpoint);
+      if (matcher.find()) {
+        LOG.debug("Mapping to VPCE");
+        LOG.debug("Endpoint {} is vpc endpoint; parsing region as {}", endpoint, matcher.group(1));
+        return Optional.of(new Resolution()
+            .withRegion(Region.of(matcher.group(1)),
+                RegionResolutionMechanism.ParseVpceEndpoint));
+      }
+
+      LOG.debug("Endpoint {} is not the default; parsing", endpoint);
+      return AwsHostNameUtils.parseSigningRegion(endpoint, S3_SERVICE_NAME)
+          .map(r ->
+              new Resolution().withRegion(r,
+                  RegionResolutionMechanism.CalculatedFromEndpoint));
+    }
+
+    // No resolution.
+    return Optional.empty();
+  }
+
+  /**
+   * Calculate the region and the final endpoint.
+   * @param parameters creation parameters
+   * @param conf configuration with other options.
+   * @return the resolved region and endpoint.
+   * @throws IllegalArgumentException failure to parse endpoint, or FIPS settings.
+   */
+  public static Resolution calculateRegion(
+      final S3ClientFactory.S3ClientCreationParameters parameters,
+      final Configuration conf) {
+
+    final Resolution resolution = new Resolution();
+
+    // endpoint; may be null
+    final String endpointStr = parameters.getEndpoint();
+    // will be null if endpointStr is null/empty
+    final URI endpoint = buildEndpointUri(endpointStr,
+        conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS));
+
+    final String configuredRegion = parameters.getRegion();
+
+    // If the region was configured, set it.
+    // this includes special handling of the sdk, ec2 and "" regions.
+    if (configuredRegion != null) {
+      switch (configuredRegion.toLowerCase(Locale.ROOT)) {
+      case EC2_REGION:
+      case SDK_REGION:
+      case EMPTY_REGION:
+        resolution.withRegion(null, RegionResolutionMechanism.Sdk);
+        break;
+
+      default:
+        resolution.withRegion(Region.of(configuredRegion),
+            RegionResolutionMechanism.Specified);
+      }
+    }
+
+
+    // cross region setting.
+    resolution.withCrossRegionAccessEnabled(
+        conf.getBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED,
+            AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT));
+
+    // central endpoint if no endpoint has been set, or it is explicitly
+    // requested
+    boolean endpointEndsWithCentral = endpointStr == null
+        || endpointStr.isEmpty()
+        || endpointStr.endsWith(CENTRAL_ENDPOINT);
+
+    // fips settings.
+    final boolean fipsEnabled = parameters.isFipsEnabled();
+    resolution.withUseFips(fipsEnabled);
+    if (fipsEnabled) {
+      // validate the FIPS settings
+      checkArgument(endpoint == null || endpointEndsWithCentral,
+          "%s : %s", ERROR_ENDPOINT_WITH_FIPS, endpoint);
+      checkArgument(!parameters.isPathStyleAccess(),
+          FIPS_PATH_ACCESS_INCOMPATIBLE);
+    }
+
+    if (!resolution.isRegionResolved()) {
+      // parse from the endpoint and set if calculated
+      LOG.debug("Falling back to parsing region endpoint {}; endpointEndsWithCentral={}",
+          endpointStr, endpointEndsWithCentral);
+      final Optional<Resolution> regionFromEndpoint =
+          getS3RegionFromEndpoint(endpointStr, endpointEndsWithCentral);
+      if (regionFromEndpoint.isPresent()) {
+        regionFromEndpoint
+            .map(r ->
+                resolution.withRegion(r.getRegion(), r.getResolution()));
+      }
+    }
+    if (!resolution.isRegionResolved()) {
+      // still failing to resolve the region
+      // fall back to central
+      resolution.withRegion(US_EAST_2, RegionResolutionMechanism.FallbackToCentral);
+    }
+
+    // No need to override endpoint with "s3.amazonaws.com".
+    // Let the client take care of endpoint resolution. Overriding
+    // the endpoint with "s3.amazonaws.com" causes 400 Bad Request
+    // errors for non-existent buckets and objects.
+    // ref: https://github.com/aws/aws-sdk-java-v2/issues/4846
+    if (!endpointEndsWithCentral) {
+      LOG.debug("Setting endpoint to {}", endpoint);
+      resolution.withEndpointStr(endpointStr)
+          .withEndpointUri(endpoint)
+          .withUseCentralEndpoint(false);
+    } else {
+      resolution.withUseCentralEndpoint(true);
+    }
+
+    final Region r = resolution.getRegion();
+    if (r != null && Region.regions().contains(r)) {
+      // note that the region isn't known.
+      // not an issue for third party stores, otherwise it may be a region newer than
+      // that expected by the SDK. Hence: only log at debug.
+      LOG.debug("Region {} is not recognized by this SDK", r);
+    }
+    return resolution;
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.regions.Region;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3ClientFactory;
 
 import static java.util.Objects.requireNonNull;
@@ -442,7 +441,6 @@ public class RegionResolution {
    * @throws IOException if the client failed to communicate with the IAM service.
    * @throws IllegalArgumentException failure to parse endpoint, or FIPS settings.
    */
-  @Retries.OnceTranslated
   public static Resolution calculateRegion(
       final S3ClientFactory.S3ClientCreationParameters parameters,
       final Configuration conf) throws IOException {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a.impl;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,11 +30,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3ClientFactory;
 
@@ -44,11 +41,11 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENAB
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT;
 import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
-import static org.apache.hadoop.fs.s3a.Constants.EC2_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.EMPTY_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.impl.NetworkBinding.isAwsEndpoint;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.ExternalEndpoint;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.FallbackToCentral;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
@@ -123,7 +120,6 @@ public class RegionResolution {
     ExternalEndpoint("External endpoint"),
     FallbackToCentral("Fallback to central endpoint"),
     ParseVpceEndpoint("Parse VPCE Endpoint"),
-    Ec2Metadata("EC2 Metadata"),
     Sdk("SDK resolution chain"),
     Specified("region specified");
 
@@ -353,7 +349,7 @@ public class RegionResolution {
    * @return the S3 region resolution if possible from parsing the endpoint
    */
   @VisibleForTesting
-  public static Optional<Resolution> getS3RegionFromEndpoint(
+  public static Optional<Resolution> determineS3RegionFromEndpoint(
       final String endpoint,
       final boolean endpointEndsWithCentral) {
 
@@ -369,7 +365,7 @@ public class RegionResolution {
             RegionResolutionMechanism.ParseVpceEndpoint));
       }
 
-      LOG.debug("Endpoint {} is not the default; parsing", endpoint);
+      LOG.debug("Endpoint {} is not the default; parsing signing region from name.", endpoint);
       return AwsHostNameUtils.parseSigningRegion(endpoint, S3_SERVICE_NAME)
           .map(r ->
               new Resolution(r, RegionResolutionMechanism.CalculatedFromEndpoint));
@@ -377,19 +373,6 @@ public class RegionResolution {
 
     // No resolution.
     return Optional.empty();
-  }
-
-  /**
-   * Is this an AWS endpoint, that is: has an endpoint been set which matches
-   * amazon.
-   * @param endpoint non-null endpoint URL
-   * @return true if this is amazonaws or amazonaws china
-   */
-  public static boolean isAwsEndpoint(final String endpoint) {
-    final String h = endpoint.toLowerCase(Locale.ROOT);
-    // Common AWS partitions: global (.amazonaws.com) and China (.amazonaws.com.cn).
-    return h.endsWith(".amazonaws.com")
-        || h.endsWith(".amazonaws.com.cn");
   }
 
 
@@ -401,16 +384,6 @@ public class RegionResolution {
   public static boolean isSdkRegion(String configuredRegion) {
     return SDK_REGION.equalsIgnoreCase(configuredRegion)
         || EMPTY_REGION.equalsIgnoreCase(configuredRegion);
-  }
-
-  /**
-   * Does the region name refer to {@code "ec2"} in which case special handling
-   * is required.
-   * @param configuredRegion region in the configuration
-   * @return true if this is considered to refer to an SDK region.
-   */
-  public static boolean isEc2Region(String configuredRegion) {
-    return EC2_REGION.equalsIgnoreCase(configuredRegion);
   }
 
   /**
@@ -431,9 +404,14 @@ public class RegionResolution {
     // endpoint; may be null
     final String endpointStr = parameters.getEndpoint();
     boolean endpointDeclared = endpointStr != null && !endpointStr.isEmpty();
-    // will be null if endpointStr is null/empty
-    final URI endpoint = buildEndpointUri(endpointStr,
-        conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS));
+    final URI endpoint;
+    if (endpointDeclared) {
+      endpoint = buildEndpointUri(endpointStr,
+          conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS));
+    } else {
+      // set to null if endpointStr is null/empty
+      endpoint = null;
+    }
 
     final String configuredRegion = parameters.getRegion();
 
@@ -444,10 +422,6 @@ public class RegionResolution {
           "null is region name");
       if (isSdkRegion(configuredRegion)) {
         resolution.withRegion(null, RegionResolutionMechanism.Sdk);
-      } else if (isEc2Region(configuredRegion)) {
-        // special EC2 handling
-        final Resolution r = getS3RegionFromEc2IAM();
-        resolution.withRegion(r.getRegion(), r.getMechanism());
       } else {
         resolution.withRegion(Region.of(configuredRegion),
             RegionResolutionMechanism.Specified);
@@ -461,15 +435,10 @@ public class RegionResolution {
 
     if (!resolution.isRegionResolved()) {
       // parse from the endpoint and set if calculated
-      LOG.debug("Falling back to parsing region endpoint {}; endpointEndsWithCentral={}",
+      LOG.debug("Attempting to determine region from endpoint {}; endpointEndsWithCentral={}",
           endpointStr, endpointEndsWithCentral);
-      final Optional<Resolution> regionFromEndpoint =
-          getS3RegionFromEndpoint(endpointStr, endpointEndsWithCentral);
-      if (regionFromEndpoint.isPresent()) {
-        regionFromEndpoint
-            .map(r ->
-                resolution.withRegion(r.getRegion(), r.getMechanism()));
-      }
+      determineS3RegionFromEndpoint(endpointStr, endpointEndsWithCentral).ifPresent(r ->
+          resolution.withRegion(r.getRegion(), r.getMechanism()));
     }
 
     // cross region setting.
@@ -487,7 +456,6 @@ public class RegionResolution {
       checkArgument(!parameters.isPathStyleAccess(),
           FIPS_PATH_ACCESS_INCOMPATIBLE);
     }
-
 
     if (!resolution.isRegionResolved()) {
       // still not resolved.
@@ -507,17 +475,17 @@ public class RegionResolution {
     // the endpoint with "s3.amazonaws.com" causes 400 Bad Request
     // errors for non-existent buckets and objects.
     // ref: https://github.com/aws/aws-sdk-java-v2/issues/4846
-    if (!endpointEndsWithCentral) {
+    if (endpointEndsWithCentral) {
+      resolution.withUseCentralEndpoint(true);
+    } else {
       LOG.debug("Setting endpoint to {}", endpoint);
       resolution.withEndpointStr(endpointStr)
           .withEndpointUri(endpoint)
           .withUseCentralEndpoint(false);
-    } else {
-      resolution.withUseCentralEndpoint(true);
     }
 
     final Region r = resolution.getRegion();
-    if (r != null && Region.regions().contains(r)) {
+    if (r != null && !Region.regions().contains(r)) {
       // note that the region isn't known.
       // not an issue for third party stores, otherwise it may be a region newer than
       // that expected by the SDK. Hence: only log at debug.
@@ -526,21 +494,4 @@ public class RegionResolution {
     return resolution;
   }
 
-  /**
-   * Probes EC2 Metadata for the region.
-   * This uses a class {@code InstanceProfileRegionProvider} which AWS
-   * declare as for internal use only.
-   * Linking/invocation should be caught and downgraded to returning an empty() option.
-   * @return the region from EC2 IAM.
-   * @throws IOException if the client failed to communicate with the IAM service.
-   */
-  @VisibleForTesting
-  @Retries.OnceTranslated
-  static Resolution getS3RegionFromEc2IAM() throws IOException {
-    return Invoker.once("Resolve EC2 Metadata", "/", () -> {
-      LOG.debug("Resolving region through EC2 Metadata");
-      final Region region = new InstanceProfileRegionProvider().getRegion();
-      return new Resolution(region, RegionResolutionMechanism.Ec2Metadata);
-    });
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -265,6 +265,7 @@ public class RegionResolution {
 
     /**
      * Endpoint URI.
+     * @return value if set.
      */
     public URI getEndpointUri() {
       return endpointUri;
@@ -282,6 +283,7 @@ public class RegionResolution {
 
     /**
      * Endpoint as string.
+     * @return value if set.
      */
     public String getEndpointStr() {
       return endpointStr;
@@ -289,6 +291,7 @@ public class RegionResolution {
 
     /**
      * Region: if null hand down to the SDK.
+     * @return value if set.
      */
     public Region getRegion() {
       return region;
@@ -296,6 +299,7 @@ public class RegionResolution {
 
     /**
      * Should FIPS be enabled?
+     * @return flag state.
      */
     public boolean isUseFips() {
       return useFips;
@@ -303,6 +307,7 @@ public class RegionResolution {
 
     /**
      * Should cross-region access be enabled?
+     * @return flag state.
      */
     public boolean isCrossRegionAccessEnabled() {
       return crossRegionAccessEnabled;
@@ -311,6 +316,7 @@ public class RegionResolution {
     /**
      * How was the region resolved?
      * Null means unresolved.
+     * @return value if set.
      */
     public RegionResolutionMechanism getMechanism() {
       return mechanism;
@@ -326,6 +332,7 @@ public class RegionResolution {
 
     /**
      * Use the central endpoint?
+     * @return flag state.
      */
     public boolean isUseCentralEndpoint() {
       return useCentralEndpoint;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -111,17 +111,31 @@ public class RegionResolution {
    */
   public static final Region EXTERNAL_REGION = Region.of(EXTERNAL);
 
+  private RegionResolution() {
+  }
+
   /**
    * How was the region resolved?
    */
   public enum RegionResolutionMechanism {
 
-    CalculatedFromEndpoint("Calculated from endpoint"),
+    /** Endpoint inference. */
+    CalculatedFromEndpoint("Calculated from endpoint."),
+
+    /** It's an external endpoint */
     ExternalEndpoint("External endpoint"),
+
+    /** No resolution: falling back to central endpoint. */
     FallbackToCentral("Fallback to central endpoint"),
+
+    /** Connection is a VPCE endpoint which was parsed for the region. */
     ParseVpceEndpoint("Parse VPCE Endpoint"),
+
+    /** SDK requested. */
     Sdk("SDK resolution chain"),
-    Specified("region specified");
+
+    /** Set in configuration. */
+    Specified("Region specified");
 
     /**
      * Text of the mechanism.
@@ -190,6 +204,7 @@ public class RegionResolution {
      */
     private boolean useCentralEndpoint;
 
+    /** Empty constructor. */
     public Resolution() {
     }
 
@@ -206,14 +221,14 @@ public class RegionResolution {
     /**
      * Set the region.
      * Declares the region as resolved even when the value is null (i.e. resolve to SDK).
-     * @param region region
+     * @param resolvedRegion region
      * @param resolutionMechanism resolution mechanism.
      * @return the builder
      */
     public Resolution withRegion(
-        @Nullable final Region region,
+        @Nullable final Region resolvedRegion,
         final RegionResolutionMechanism resolutionMechanism) {
-      this.region = region;
+      this.region = resolvedRegion;
       this.mechanism = requireNonNull(resolutionMechanism);
       return this;
     }
@@ -248,6 +263,9 @@ public class RegionResolution {
       return this;
     }
 
+    /**
+     * Endpoint URI.
+     */
     public URI getEndpointUri() {
       return endpointUri;
     }
@@ -262,30 +280,53 @@ public class RegionResolution {
       return this;
     }
 
-    public Region getRegion() {
-      return region;
-    }
-
-    public boolean isUseFips() {
-      return useFips;
-    }
-
-    public boolean isCrossRegionAccessEnabled() {
-      return crossRegionAccessEnabled;
-    }
-
-    public RegionResolutionMechanism getMechanism() {
-      return mechanism;
-    }
-
+    /**
+     * Endpoint as string.
+     */
     public String getEndpointStr() {
       return endpointStr;
     }
 
+    /**
+     * Region: if null hand down to the SDK.
+     */
+    public Region getRegion() {
+      return region;
+    }
+
+    /**
+     * Should FIPS be enabled?
+     */
+    public boolean isUseFips() {
+      return useFips;
+    }
+
+    /**
+     * Should cross-region access be enabled?
+     */
+    public boolean isCrossRegionAccessEnabled() {
+      return crossRegionAccessEnabled;
+    }
+
+    /**
+     * How was the region resolved?
+     * Null means unresolved.
+     */
+    public RegionResolutionMechanism getMechanism() {
+      return mechanism;
+    }
+
+    /**
+     * Is the region resolved.
+     * @return true if there's been a resolution.
+     */
     public boolean isRegionResolved() {
       return mechanism != null;
     }
 
+    /**
+     * Use the central endpoint?
+     */
     public boolean isUseCentralEndpoint() {
       return useCentralEndpoint;
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -21,10 +21,10 @@ package org.apache.hadoop.fs.s3a.impl;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
@@ -80,56 +80,67 @@ public class RegionResolution {
   private static final Pattern VPC_ENDPOINT_PATTERN =
       Pattern.compile("^(?:.+\\.)?([a-z0-9-]+)\\.vpce\\.amazonaws\\.(?:com|com\\.cn)$");
 
- /**
-  * Error message when an endpoint is set with FIPS enabled: {@value}.
-  */
- @VisibleForTesting
- public static final String ERROR_ENDPOINT_WITH_FIPS =
-     "Only S3 central endpoint cannot be set when " + FIPS_ENDPOINT + " is true";
+  /**
+   * Error message when an endpoint is set with FIPS enabled: {@value}.
+   */
+  @VisibleForTesting
+  public static final String ERROR_ENDPOINT_WITH_FIPS =
+      "Only S3 central endpoint cannot be set when " + FIPS_ENDPOINT + " is true";
 
   /**
    * Virtual hostnames MUST be used when using the FIPS endpoint.
    */
- public static final String FIPS_PATH_ACCESS_INCOMPATIBLE =
-     "Path style access must be disabled when "+ FIPS_ENDPOINT + " is true";
+  public static final String FIPS_PATH_ACCESS_INCOMPATIBLE =
+      "Path style access must be disabled when " + FIPS_ENDPOINT + " is true";
+
+  /**
+   * String value for external region: {@value}.
+   */
+  public static final String EXTERNAL = "external";
+
+  /**
+   * External region, used for third party endpoints.
+   */
+  public static final Region EXTERNAL_REGION = Region.of(EXTERNAL);
 
   /**
    * How was the region resolved?
    */
- public enum RegionResolutionMechanism {
+  public enum RegionResolutionMechanism {
 
-   CalculatedFromEndpoint("Calculated from endpoint"),
-   FallbackToCentral("Fallback to central endpoint"),
-   ParseVpceEndpoint("Parse VPCE Endpoint"),
-   Ec2Metadata("EC2 Metadata"),
-   Sdk("SDK resolution chain"),
-   Specified("region specified");
+    CalculatedFromEndpoint("Calculated from endpoint"),
+    ExternalEndpoint("External endpoint"),
+    FallbackToCentral("Fallback to central endpoint"),
+    ParseVpceEndpoint("Parse VPCE Endpoint"),
+    Ec2Metadata("EC2 Metadata"),
+    Sdk("SDK resolution chain"),
+    Specified("region specified");
 
-   /**
-    * Text of the mechanism.
-    */
-   private final String mechanism;
+    /**
+     * Text of the mechanism.
+     */
+    private final String mechanism;
 
-   RegionResolutionMechanism(String mechanism) {
-     this.mechanism = mechanism;
-   }
+    RegionResolutionMechanism(String mechanism) {
+      this.mechanism = mechanism;
+    }
 
     /**
      * String value of the resolution mechanism.
      * @return the resolution mechanism.
      */
-   public String getMechanism() {
-     return mechanism;
-   }
+    public String getMechanism() {
+      return mechanism;
+    }
 
-   @Override
-   public String toString() {
-     final StringBuilder sb = new StringBuilder("RegionResolutionMechanism{");
-     sb.append("mechanism='").append(mechanism).append('\'');
-     sb.append('}');
-     return sb.toString();
-   }
- }
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder("RegionResolutionMechanism{");
+      sb.append("mechanism='").append(mechanism).append('\'');
+      sb.append('}');
+      return sb.toString();
+    }
+  }
 
   /**
    * The resolution of a region and endpoint..
@@ -298,7 +309,6 @@ public class RegionResolution {
 
   /**
    * Given a endpoint string, create the endpoint URI.
-   *
    * @param endpoint possibly null endpoint.
    * @param secureConnections use secure HTTPS connection?
    * @return an endpoint uri or null if the endpoint was passed in was null/empty
@@ -341,7 +351,8 @@ public class RegionResolution {
       Matcher matcher = VPC_ENDPOINT_PATTERN.matcher(endpoint);
       if (matcher.find()) {
         LOG.debug("Mapping to VPCE");
-        LOG.debug("Endpoint {} is vpc endpoint; parsing region as {}", endpoint, matcher.group(1));
+        LOG.debug("Endpoint {} is VPC endpoint; parsing region as {}",
+            endpoint, matcher.group(1));
         return Optional.of(new Resolution(
             Region.of(matcher.group(1)),
             RegionResolutionMechanism.ParseVpceEndpoint));
@@ -356,6 +367,20 @@ public class RegionResolution {
     // No resolution.
     return Optional.empty();
   }
+
+  /**
+   * Is this an AWS endpoint, that is: has an endpoint been set which matches
+   * amazon.
+   * @param endpoint non-null endpoint URL
+   * @return true if this is amazonaws or amazonaws china
+   */
+  public static boolean isAwsEndpoint(final String endpoint) {
+    final String h = endpoint.toLowerCase(Locale.ROOT);
+    // Common AWS partitions: global (.amazonaws.com) and China (.amazonaws.com.cn).
+    return h.endsWith(".amazonaws.com")
+        || h.endsWith(".amazonaws.com.cn");
+  }
+
 
   /**
    * Does the region name refer to an SDK region?
@@ -394,6 +419,7 @@ public class RegionResolution {
 
     // endpoint; may be null
     final String endpointStr = parameters.getEndpoint();
+    boolean endpointDeclared = endpointStr != null && !endpointStr.isEmpty();
     // will be null if endpointStr is null/empty
     final URI endpoint = buildEndpointUri(endpointStr,
         conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS));
@@ -419,8 +445,7 @@ public class RegionResolution {
 
     // central endpoint if no endpoint has been set, or it is explicitly
     // requested
-    boolean endpointEndsWithCentral = endpointStr == null
-        || endpointStr.isEmpty()
+    boolean endpointEndsWithCentral = !endpointDeclared
         || endpointStr.endsWith(CENTRAL_ENDPOINT);
 
     if (!resolution.isRegionResolved()) {
@@ -452,10 +477,18 @@ public class RegionResolution {
           FIPS_PATH_ACCESS_INCOMPATIBLE);
     }
 
+
     if (!resolution.isRegionResolved()) {
-      // still failing to resolve the region
-      // fall back to central
-      resolution.withRegion(US_EAST_2, RegionResolutionMechanism.FallbackToCentral);
+      // still not resolved.
+      if (!endpointDeclared || isAwsEndpoint(endpointStr)) {
+        // still failing to resolve the region
+        // fall back to central
+        resolution.withRegion(US_EAST_2, RegionResolutionMechanism.FallbackToCentral);
+      } else {
+        // we are not resolved and not an aws region.
+        // set the region to being "external"
+        resolution.withRegion(EXTERNAL_REGION, RegionResolutionMechanism.ExternalEndpoint);
+      }
     }
 
     // No need to override endpoint with "s3.amazonaws.com".

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -49,8 +49,10 @@ import static org.apache.hadoop.fs.s3a.Constants.EMPTY_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.ExternalEndpoint;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.RegionResolutionMechanism.FallbackToCentral;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
-import static software.amazon.awssdk.regions.Region.US_EAST_2;
+import static software.amazon.awssdk.regions.Region.US_EAST_1;
 
 /**
  * Region resolution.
@@ -58,11 +60,20 @@ import static software.amazon.awssdk.regions.Region.US_EAST_2;
  * <p>The V1 SDK was happy to take an endpoint and
  * work details out from there, possibly probing us-central-1 and cacheing
  * the result.
- * <p>The V2 SDK like the signing region and endpoint to be declared.
+ * <p>The V2 SDK likes the signing region and endpoint to be declared.
  * The S3A connector has tried to mimic the V1 code, but lacks some features
  * (use of environment variables, probing of EC2 IAM details) for which
  * the SDK is better.
- *
+ * <ol>
+ * <li>If region is configured via fs.s3a.endpoint.region, use it.</li>
+ * <li>If endpoint is configured via via fs.s3a.endpoint, set it.
+ *     If no region is configured, try to parse region from endpoint. </li>
+ * <li> If no region is configured, and it could not be parsed from the endpoint,
+ *     set the default region as US_EAST_2</li>
+ * <li> If configured region is empty, fallback to SDK resolution chain. </li>
+ * <li> S3 cross region is enabled by default irrespective of region or endpoint
+ *      is set or not.</li>
+ * </ol>
  */
 public class RegionResolution {
 
@@ -336,7 +347,7 @@ public class RegionResolution {
 
   /**
    * Parses the endpoint to get the region.
-   * If endpoint is the central one, use US_EAST_2.
+   * If endpoint is the central one, use US_EAST_1.
    * @param endpoint the configure endpoint.
    * @param endpointEndsWithCentral true if the endpoint is configured as central.
    * @return the S3 region resolution if possible from parsing the endpoint
@@ -483,11 +494,11 @@ public class RegionResolution {
       if (!endpointDeclared || isAwsEndpoint(endpointStr)) {
         // still failing to resolve the region
         // fall back to central
-        resolution.withRegion(US_EAST_2, RegionResolutionMechanism.FallbackToCentral);
+        resolution.withRegion(US_EAST_1, FallbackToCentral);
       } else {
         // we are not resolved and not an aws region.
         // set the region to being "external"
-        resolution.withRegion(EXTERNAL_REGION, RegionResolutionMechanism.ExternalEndpoint);
+        resolution.withRegion(EXTERNAL_REGION, ExternalEndpoint);
       }
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RegionResolution.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,9 +31,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.Invoker;
+import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3ClientFactory;
 
 import static java.util.Objects.requireNonNull;
@@ -98,6 +101,7 @@ public class RegionResolution {
    CalculatedFromEndpoint("Calculated from endpoint"),
    FallbackToCentral("Fallback to central endpoint"),
    ParseVpceEndpoint("Parse VPCE Endpoint"),
+   Ec2Metadata("EC2 Metadata"),
    Sdk("SDK resolution chain"),
    Specified("region specified");
 
@@ -141,7 +145,7 @@ public class RegionResolution {
      * How was the region resolved?
      * Null means unresolved.
      */
-    private RegionResolutionMechanism resolution;
+    private RegionResolutionMechanism mechanism;
 
     /**
      * Should FIPS be enabled?
@@ -168,17 +172,31 @@ public class RegionResolution {
      */
     private boolean useCentralEndpoint;
 
+    public Resolution() {
+    }
+
+    /**
+     * Instantiate with a region and resolution mechanism.
+     * @param region region
+     * @param mechanism resolution mechanism.
+     */
+    public Resolution(final Region region, final RegionResolutionMechanism mechanism) {
+      this.region = region;
+      this.mechanism = mechanism;
+    }
+
     /**
      * Set the region.
      * Declares the region as resolved even when the value is null (i.e. resolve to SDK).
-     * @param region new value
+     * @param region region
+     * @param resolutionMechanism resolution mechanism.
      * @return the builder
      */
     public Resolution withRegion(
         @Nullable final Region region,
         final RegionResolutionMechanism resolutionMechanism) {
       this.region = region;
-      this.resolution = requireNonNull(resolutionMechanism);
+      this.mechanism = requireNonNull(resolutionMechanism);
       return this;
     }
 
@@ -238,8 +256,8 @@ public class RegionResolution {
       return crossRegionAccessEnabled;
     }
 
-    public RegionResolutionMechanism getResolution() {
-      return resolution;
+    public RegionResolutionMechanism getMechanism() {
+      return mechanism;
     }
 
     public String getEndpointStr() {
@@ -247,7 +265,7 @@ public class RegionResolution {
     }
 
     public boolean isRegionResolved() {
-      return resolution != null;
+      return mechanism != null;
     }
 
     public boolean isUseCentralEndpoint() {
@@ -268,7 +286,7 @@ public class RegionResolution {
     public String toString() {
       final StringBuilder sb = new StringBuilder("Resolution{");
       sb.append("region=").append(region);
-      sb.append(", resolution=").append(resolution);
+      sb.append(", resolution=").append(mechanism);
       sb.append(", useFips=").append(useFips);
       sb.append(", crossRegionAccessEnabled=").append(crossRegionAccessEnabled);
       sb.append(", endpointUri=").append(endpointUri);
@@ -324,16 +342,15 @@ public class RegionResolution {
       if (matcher.find()) {
         LOG.debug("Mapping to VPCE");
         LOG.debug("Endpoint {} is vpc endpoint; parsing region as {}", endpoint, matcher.group(1));
-        return Optional.of(new Resolution()
-            .withRegion(Region.of(matcher.group(1)),
-                RegionResolutionMechanism.ParseVpceEndpoint));
+        return Optional.of(new Resolution(
+            Region.of(matcher.group(1)),
+            RegionResolutionMechanism.ParseVpceEndpoint));
       }
 
       LOG.debug("Endpoint {} is not the default; parsing", endpoint);
       return AwsHostNameUtils.parseSigningRegion(endpoint, S3_SERVICE_NAME)
           .map(r ->
-              new Resolution().withRegion(r,
-                  RegionResolutionMechanism.CalculatedFromEndpoint));
+              new Resolution(r, RegionResolutionMechanism.CalculatedFromEndpoint));
     }
 
     // No resolution.
@@ -341,17 +358,39 @@ public class RegionResolution {
   }
 
   /**
+   * Does the region name refer to an SDK region?
+   * @param configuredRegion region in the configuration
+   * @return true if this is considered to refer to an SDK region.
+   */
+  public static boolean isSdkRegion(String configuredRegion) {
+    return SDK_REGION.equalsIgnoreCase(configuredRegion)
+        || EMPTY_REGION.equalsIgnoreCase(configuredRegion);
+  }
+
+  /**
+   * Does the region name refer to {@code "ec2"} in which case special handling
+   * is required.
+   * @param configuredRegion region in the configuration
+   * @return true if this is considered to refer to an SDK region.
+   */
+  public static boolean isEc2Region(String configuredRegion) {
+    return EC2_REGION.equalsIgnoreCase(configuredRegion);
+  }
+
+  /**
    * Calculate the region and the final endpoint.
    * @param parameters creation parameters
    * @param conf configuration with other options.
    * @return the resolved region and endpoint.
+   * @throws IOException if the client failed to communicate with the IAM service.
    * @throws IllegalArgumentException failure to parse endpoint, or FIPS settings.
    */
+  @Retries.OnceTranslated
   public static Resolution calculateRegion(
       final S3ClientFactory.S3ClientCreationParameters parameters,
-      final Configuration conf) {
+      final Configuration conf) throws IOException {
 
-    final Resolution resolution = new Resolution();
+    Resolution resolution = new Resolution();
 
     // endpoint; may be null
     final String endpointStr = parameters.getEndpoint();
@@ -364,30 +403,43 @@ public class RegionResolution {
     // If the region was configured, set it.
     // this includes special handling of the sdk, ec2 and "" regions.
     if (configuredRegion != null) {
-      switch (configuredRegion.toLowerCase(Locale.ROOT)) {
-      case EC2_REGION:
-      case SDK_REGION:
-      case EMPTY_REGION:
+      checkArgument(!"null".equals(configuredRegion),
+          "null is region name");
+      if (isSdkRegion(configuredRegion)) {
         resolution.withRegion(null, RegionResolutionMechanism.Sdk);
-        break;
-
-      default:
+      } else if (isEc2Region(configuredRegion)) {
+        // special EC2 handling
+        final Resolution r = getS3RegionFromEc2IAM();
+        resolution.withRegion(r.getRegion(), r.getMechanism());
+      } else {
         resolution.withRegion(Region.of(configuredRegion),
             RegionResolutionMechanism.Specified);
       }
     }
-
-
-    // cross region setting.
-    resolution.withCrossRegionAccessEnabled(
-        conf.getBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED,
-            AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT));
 
     // central endpoint if no endpoint has been set, or it is explicitly
     // requested
     boolean endpointEndsWithCentral = endpointStr == null
         || endpointStr.isEmpty()
         || endpointStr.endsWith(CENTRAL_ENDPOINT);
+
+    if (!resolution.isRegionResolved()) {
+      // parse from the endpoint and set if calculated
+      LOG.debug("Falling back to parsing region endpoint {}; endpointEndsWithCentral={}",
+          endpointStr, endpointEndsWithCentral);
+      final Optional<Resolution> regionFromEndpoint =
+          getS3RegionFromEndpoint(endpointStr, endpointEndsWithCentral);
+      if (regionFromEndpoint.isPresent()) {
+        regionFromEndpoint
+            .map(r ->
+                resolution.withRegion(r.getRegion(), r.getMechanism()));
+      }
+    }
+
+    // cross region setting.
+    resolution.withCrossRegionAccessEnabled(
+        conf.getBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED,
+            AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT));
 
     // fips settings.
     final boolean fipsEnabled = parameters.isFipsEnabled();
@@ -400,18 +452,6 @@ public class RegionResolution {
           FIPS_PATH_ACCESS_INCOMPATIBLE);
     }
 
-    if (!resolution.isRegionResolved()) {
-      // parse from the endpoint and set if calculated
-      LOG.debug("Falling back to parsing region endpoint {}; endpointEndsWithCentral={}",
-          endpointStr, endpointEndsWithCentral);
-      final Optional<Resolution> regionFromEndpoint =
-          getS3RegionFromEndpoint(endpointStr, endpointEndsWithCentral);
-      if (regionFromEndpoint.isPresent()) {
-        regionFromEndpoint
-            .map(r ->
-                resolution.withRegion(r.getRegion(), r.getResolution()));
-      }
-    }
     if (!resolution.isRegionResolved()) {
       // still failing to resolve the region
       // fall back to central
@@ -442,4 +482,21 @@ public class RegionResolution {
     return resolution;
   }
 
+  /**
+   * Probes EC2 Metadata for the region.
+   * This uses a class {@code InstanceProfileRegionProvider} which AWS
+   * declare as for internal use only.
+   * Linking/invocation should be caught and downgraded to returning an empty() option.
+   * @return the region from EC2 IAM.
+   * @throws IOException if the client failed to communicate with the IAM service.
+   */
+  @VisibleForTesting
+  @Retries.OnceTranslated
+  static Resolution getS3RegionFromEc2IAM() throws IOException {
+    return Invoker.once("Resolve EC2 Metadata", "/", () -> {
+      LOG.debug("Resolving region through EC2 Metadata");
+      final Region region = new InstanceProfileRegionProvider().getRegion();
+      return new Resolution(region, RegionResolutionMechanism.Ec2Metadata);
+    });
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
@@ -61,7 +61,7 @@ The S3A connector supports S3 cross region access via AWS SDK which is enabled b
 Not supported:
 * AWS [Snowball](https://aws.amazon.com/snowball/).
 
-As of December 2023, AWS S3 uses Transport Layer Security (TLS) [version 1.2](https://aws.amazon.com/blogs/security/tls-1-2-required-for-aws-endpoints/) to secure the communications channel; the S3A client is does this through
+As of December 2023, AWS S3 uses Transport Layer Security (TLS) [version 1.2](https://aws.amazon.com/blogs/security/tls-1-2-required-for-aws-endpoints/) to secure the communications channel; the S3A client does this through
 the Apache [HttpClient library](https://hc.apache.org/index.html).
 
 ### <a name="third-party"></a> Third party stores
@@ -74,81 +74,127 @@ _MUST_ be installed on the JVMs on hosts within the Hadoop cluster.
 See [Working with Third-party S3 Stores](third_party_stores.html) *after* reading this document.
 
 
-## <a name="settings"></a> Connection Settings
+## <a name="settings"></a> Endpoint and Region Settings
 
-There are three core settings to connect to an S3 store, endpoint, region and whether or not to use path style access.
+There are three core settings to connect to an S3 store, endpoint, region and whether to use path style access.
+
+The term "endpoint" means the URL or hostname of the remote s3 store.
+The default S3 endpoint is `s3.amazonaws.com`
+When a request is made to a bucket and path style access is false, the hostname to
+make HTTP requests from is prefixed to the endpoint. A bucket `example` would
+end up with a name `example.s3.amazonaws.com`.
+
+S3 Buckets are hosted in different AWS regions.
+
+Each region has its own S3 endpoint, documented [by Amazon](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+
+1. Applications running in EC2 infrastructure do not pay for IO to/from
+   *local S3 buckets*. They will be billed for access to remote buckets. Always
+   use local buckets and local copies of data, wherever possible.
+2. With the V4 signing protocol, AWS requires the explicit region endpoint
+   to be used —hence S3A must be configured to use the specific endpoint. This
+   is done by setting the region in the configuration option `fs.s3a.endpoint.region`,
+   or by explicitly setting `fs.s3a.endpoint` and `fs.s3a.endpoint.region`.
+3. All endpoints other than the default region only support interaction
+   with buckets local to that S3 instance.
+4. Standard S3 buckets support "cross-region" access where use of the original `us-east-1`
+   endpoint allows access to the data, but newer storage types, particularly S3 Express are
+   not supported.
+
+If the wrong endpoint is used, the request will fail. This may be reported as a 301/redirect error,
+or as a "400 Bad Request": take these as cues to check the endpoint setting of
+a bucket.
+
+The up-to-date list of regions is [Available online](https://docs.aws.amazon.com/general/latest/gr/s3.html).
+
+Knowing the region of a bucket is key to be able to communicate and authenticate with
+an S3 bucket.
 
 
 ```xml
-<property>
-  <name>fs.s3a.endpoint</name>
-  <description>AWS S3 endpoint to connect to. An up-to-date list is
-    provided in the AWS Documentation: regions and endpoints. Without this
-    property, the endpoint/hostname of the S3 Store is inferred from
-    the value of fs.s3a.endpoint.region, fs.s3a.endpoint.fips and more.
-  </description>
-</property>
 
 <property>
   <name>fs.s3a.endpoint.region</name>
   <value>REGION</value>
-  <description>AWS Region of the data</description>
+  <description>AWS Region of the bucket</description>
+</property>
+
+<property>
+  <name>fs.s3a.endpoint</name>
+  <description>AWS S3 endpoint to connect to.
+    Leave blank for the SDK to determine it from the region and/or other settings.
+  </description>
 </property>
 
 <property>
   <name>fs.s3a.path.style.access</name>
   <value>false</value>
   <description>Enable S3 path style access by disabling the default virtual hosting behaviour.
-    Needed for AWS PrivateLink, S3 AccessPoints, and, generally, third party stores.
+    Needed for AWS PrivateLink, S3 AccessPoints, and  third party stores.
     Default: false.
   </description>
+</property>
+```
+
+There are also some secondary options. The `fs.s3a.endpoint.fips` is covered in its own section;
+the option `fs.s3a.cross.region.access.enabled` is generally left alone -this SDK feature is
+often critical when configuring a cluster to work with data round the world.
+
+```xml
+<property>
+  <name>fs.s3a.cross.region.access.enabled</name>
+  <value>true</value>
+  <description>SDK to fall back to cross-region bucket access</description>
+</property>
+
+<property>
+  <name>fs.s3a.endpoint.fips</name>
+  <value>false</value>
+  <description>Use the FIPS endpoint</description>
 </property>
 ```
 
 Historically the S3A connector preferred the endpoint as defined by the option `fs.s3a.endpoint`.
 With the move to the AWS V2 SDK, there is more emphasis on the region, set by the `fs.s3a.endpoint.region` option.
 
-Normally, declaring the region in `fs.s3a.endpoint.region` should be sufficient to set up the network connection to correctly connect to an AWS-hosted S3 store.
+Normally, declaring the region in `fs.s3a.endpoint.region` should be sufficient to set up the network
+connection to correctly connect to an _AWS-hosted S3 store_.
+
+When connecting to third-party stores, the `fs.s3a.endpoint` option becomes critical;
+the value of `fs.s3a.endpoint.region` can still tune s3a client behavior.
 
 ### <a name="s3_endpoint_region_details"></a> S3 endpoint and region settings in detail
 
-* Configuration options `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are used to set values
-  for S3 endpoint and region respectively.
-* If `fs.s3a.endpoint.region` is configured with valid AWS region value, S3A will
-  configure the S3 client to use this value. If this is set to a region that does
-  not match your bucket, you will receive a 301 redirect response.
-* If `fs.s3a.endpoint.region` is not set and `fs.s3a.endpoint` is set with a valid
-  endpoint value, S3A will attempt to parse the region from the endpoint and
-  configure S3 client to use the region value.
-  This works for VPCE, amazonaws.com and amazonaws.cn endpoints.
-* If both `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are not set, S3A will
-  use `us-east-1` as default region and enable cross region access. In this case,
-  S3A does not attempt to override the endpoint while configuring the S3 client.
-* If `fs.s3a.endpoint` is not set and `fs.s3a.endpoint.region` is set to an empty
-  string, S3A will configure S3 client without any region or endpoint override.
-  This will allow fallback to S3 SDK region resolution chain. More details
-  [here](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
-* The same is true if the region is set to `sdk`.
-  This makes explicit what is required, is easier to enter into XML files, and to use as an override option.
-* If `fs.s3a.endpoint` is set to the central endpoint `s3.amazonaws.com` and
-  `fs.s3a.endpoint.region` is not set, S3A will use `us-east-1` as the default region
-  and enable cross region access. In this case, S3A does not attempt to explicitly set
-  the endpoint while configuring the S3 client in the AWS SDK.
-* If `fs.s3a.endpoint` is set to the central endpoint `s3.amazonaws.com` and
-  `fs.s3a.endpoint.region` is also set to some region, S3A will use that region
-  value and enable cross region access. In this case, S3A does not attempt to
-  override the endpoint while configuring the S3 client.
+1. Configuration options `fs.s3a.endpoint.region` and `fs.s3a.endpoint` are used to set values
+   for the S3 region and endpoint respectively.
+2. If `fs.s3a.endpoint.region` is configured with valid AWS region value, S3A will
+   configure the S3 client to use this value. If this is set to a region that does
+   not match your bucket, you will receive a 301 redirect response.
+3. If `fs.s3a.endpoint.region` is not set and `fs.s3a.endpoint` is set to an AWS regional endpoint 
+   S3A will determine the region by parsing the endpoint string.
+   This works for VPCE, `amazonaws.com` and `amazonaws.cn` endpoints.
+4. If `fs.s3a.endpoint.region` is set to `sdk` then region resolution is handled
+   by the SDK. It's process is documented
+   [here](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
+5. If both `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are unset, S3A will
+   use `us-east-1` as default region and expect cross-region access.
+6. If `fs.s3a.endpoint` is not set and `fs.s3a.endpoint.region` is set to ""
+   string, S3A will use the SDK Resolution, as when the region is set to `sdk`.
+   (this is different from the resolution point 5 as the string is empty, rather than null)
+7. If `fs.s3a.endpoint` is set to the central endpoint `s3.amazonaws.com` and
+   `fs.s3a.endpoint.region` is not set, S3A will use `us-east-1` as the default region
+   and expect cross-region access.
 
-When the cross-region access is enabled while configuring the S3 client, even if the
-region set is incorrect, S3 SDK determines the region. This is done by making the
-request, and if the SDK receives 301 redirect response, it determines the region at
-the cost of a HEAD request, and caches it.
+When the cross-region access is set, the AWS SDK determines the region if when unknown.
+This is done by making the request, and if the SDK receives 301 redirect response, issues
+a HEAD request to the bucket to determine its location.
+This is cached for the duration of the JVM.
 
-Cross-region resolution requires that the host performing the lookup has network access
-to the central region. If it is has been deployed in a EC2 VPC which lacks such network
+This cross-region resolution requires that the host performing the lookup has network access
+to the central region. If the host is in an AWS VPC which lacks such network
 access, cross region lookup will fail.
 
-Please note that some endpoint and region settings that require cross region access
+Please note that some endpoint and region settings that require cross-region access
 are complex and improving over time. Hence, they may be considered unstable.
 
 If you are working with third party stores, please check [third party stores in detail](./third_party_stores.html).
@@ -157,28 +203,37 @@ If this seems confusing: you are correct!
 
 Here is what to do
 
-#### Deploying on EC2 and working with buckets in the local region
+#### Deploying on EC2 and working with AWS S3 buckets mostly in the local region
 
 1. Leave `fs.s3a.endpoint` unset.
 2. Set `fs.s3a.endpoint.region` to `sdk`.
+3. Leave `fs.s3a.cross.region.access.enabled` as `true`.
 
 This hands off resolution to the SDK, which will use the IAM service to determine the local region.
 The SDK will use this to build the endpoint URL and sign all requests.
 
-#### On-prem access to S3 where the bucket region is known
+Remote buckets will be accessed via probes to `s3.amazonaws.com`, relying on
+cross-region access to resolve their location.
+
+
+#### On-prem access to AWS S3 where the bucket region is known
 
 1. Leave `fs.s3a.endpoint` unset.
 2. Set `fs.s3a.endpoint.region` to the region of the bucket.
 
+The AWS SDK will choose the correct endpoint for the bucket region and sign requests
+appropriately.
 
-#### On-prem access to S3 where the bucket region is not known
+#### On-prem access to AWS S3 where the bucket region is **not** known
 
 1. Leave `fs.s3a.endpoint` unset.
-2. Leave `fs.s3a.endpoint.region` unset/set to SDK
-3. Set `fs.s3a.cross.region.access.enabled` to `true` (this is the default).
+2. Set `fs.s3a.endpoint.region` to `sdk`
+3. Leave `fs.s3a.cross.region.access.enabled` as `true`.
 
+The AWS SDK will attempt to connect to the bucket via the central `s3.amazonaws.com` region;
+if it is elsewhere it will determine the correct location.
 
-#### On-prem access to S3 through VPCE
+#### On-prem access to AWS S3 through VPCE
 
 1. Set `fs.s3a.endpoint` to the VPCE endpoint
 2. Set `fs.s3a.endpoint.region` to the region of the bucket, *or leave unset*
@@ -194,10 +249,7 @@ The SDK will use this to build the endpoint URL and sign all requests.
     <name>fs.s3a.bucket.example.path.style.access</name>
     <value>true</value>
   </property>
-
 ```
-
-#### On-prem access where the region 
 
 #### Third party stores
 
@@ -206,7 +258,6 @@ See [Third Party Stores](./third_party_stores.html) for the full details and exa
 to the domain name to which virtual hosts are prefixed.
 * Set `fs.s3a.endpoint.region` to `external`.
 * If working with an HTTP endpoint, set `fs.s3a.bucket.connection.ssl.enabled` to false.
-
 
 
 ### <a name="timeouts"></a> Network timeouts
@@ -345,6 +396,12 @@ Core aspects of pool settings are:
 </property>
 ```
 
+Using OpenSSL is 5-10% faster than using the java 8 TLS implementation, that is: *SQL queries complete faster*.
+
+It is hard to set up and a bit brittle, but if possible, use it!
+
+
+
 ### <a name="proxies"></a> Proxy Settings
 
 Connections to S3A stores can be made through an HTTP or HTTPS proxy.
@@ -402,37 +459,6 @@ if long-lived connections have problems.
 
 
 ##  <a name="per_bucket_endpoints"></a>Using Per-Bucket Configuration to access data round the world
-
-S3 Buckets are hosted in different "regions", the default being "US-East-1".
-The S3A client talks to this region by default, issuing HTTP requests
-to the server `s3.amazonaws.com`.
-
-S3A can work with buckets from any region. Each region has its own
-S3 endpoint, documented [by Amazon](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
-
-1. Applications running in EC2 infrastructure do not pay for IO to/from
-*local S3 buckets*. They will be billed for access to remote buckets. Always
-use local buckets and local copies of data, wherever possible.
-2. With the V4 signing protocol, AWS requires the explicit region endpoint
-to be used —hence S3A must be configured to use the specific endpoint. This
-is done by setting the regon in the configuration option `fs.s3a.endpoint.region`,
-or by explicitly setting `fs.s3a.endpoint` and `fs.s3a.endpoint.region`.
-3. All endpoints other than the default region only support interaction
-with buckets local to that S3 instance.
-4. Standard S3 buckets support "cross-region" access where use of the original `us-east-1`
-   endpoint allows access to the data, but newer storage types, particularly S3 Express are
-   not supported.
-
-
-If the wrong endpoint is used, the request will fail. This may be reported as a 301/redirect error,
-or as a 400 Bad Request: take these as cues to check the endpoint setting of
-a bucket.
-
-The up to date list of regions is [Available online](https://docs.aws.amazon.com/general/latest/gr/s3.html).
-
-This list can be used to specify the endpoint of individual buckets, for example
-for buckets in the us-west-2 and EU/Ireland endpoints.
-
 
 ```xml
 <property>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
@@ -105,21 +105,22 @@ There are three core settings to connect to an S3 store, endpoint, region and wh
 </property>
 ```
 
-Historically the S3A connector has preferred the endpoint as defined by the option `fs.s3a.endpoint`.
+Historically the S3A connector preferred the endpoint as defined by the option `fs.s3a.endpoint`.
 With the move to the AWS V2 SDK, there is more emphasis on the region, set by the `fs.s3a.endpoint.region` option.
 
 Normally, declaring the region in `fs.s3a.endpoint.region` should be sufficient to set up the network connection to correctly connect to an AWS-hosted S3 store.
 
 ### <a name="s3_endpoint_region_details"></a> S3 endpoint and region settings in detail
 
-* Configs `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are used to set values
+* Configuration options `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are used to set values
   for S3 endpoint and region respectively.
 * If `fs.s3a.endpoint.region` is configured with valid AWS region value, S3A will
   configure the S3 client to use this value. If this is set to a region that does
   not match your bucket, you will receive a 301 redirect response.
-* If `fs.s3a.endpoint.region` is not set and `fs.s3a.endpoint` is set with valid
+* If `fs.s3a.endpoint.region` is not set and `fs.s3a.endpoint` is set with a valid
   endpoint value, S3A will attempt to parse the region from the endpoint and
   configure S3 client to use the region value.
+  This works for VPCE, amazonaws.com and amazonaws.cn endpoints.
 * If both `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are not set, S3A will
   use `us-east-1` as default region and enable cross region access. In this case,
   S3A does not attempt to override the endpoint while configuring the S3 client.
@@ -127,27 +128,86 @@ Normally, declaring the region in `fs.s3a.endpoint.region` should be sufficient 
   string, S3A will configure S3 client without any region or endpoint override.
   This will allow fallback to S3 SDK region resolution chain. More details
   [here](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
-* If `fs.s3a.endpoint` is set to central endpoint `s3.amazonaws.com` and
-  `fs.s3a.endpoint.region` is not set, S3A will use `us-east-1` as default region
-  and enable cross region access. In this case, S3A does not attempt to override
-  the endpoint while configuring the S3 client.
-* If `fs.s3a.endpoint` is set to central endpoint `s3.amazonaws.com` and
+* The same is true if the region is set to `sdk`.
+  This makes explicit what is required, is easier to enter into XML files, and to use as an override option.
+* If `fs.s3a.endpoint` is set to the central endpoint `s3.amazonaws.com` and
+  `fs.s3a.endpoint.region` is not set, S3A will use `us-east-1` as the default region
+  and enable cross region access. In this case, S3A does not attempt to explicitly set
+  the endpoint while configuring the S3 client in the AWS SDK.
+* If `fs.s3a.endpoint` is set to the central endpoint `s3.amazonaws.com` and
   `fs.s3a.endpoint.region` is also set to some region, S3A will use that region
   value and enable cross region access. In this case, S3A does not attempt to
   override the endpoint while configuring the S3 client.
 
-When the cross region access is enabled while configuring the S3 client, even if the
+When the cross-region access is enabled while configuring the S3 client, even if the
 region set is incorrect, S3 SDK determines the region. This is done by making the
 request, and if the SDK receives 301 redirect response, it determines the region at
 the cost of a HEAD request, and caches it.
 
+Cross-region resolution requires that the host performing the lookup has network access
+to the central region. If it is has been deployed in a EC2 VPC which lacks such network
+access, cross region lookup will fail.
+
 Please note that some endpoint and region settings that require cross region access
 are complex and improving over time. Hence, they may be considered unstable.
 
-*Important:* do not use `auto`, `ec2`, or `sdk` as these may be used
-in the future for specific region-binding algorithms.
-
 If you are working with third party stores, please check [third party stores in detail](./third_party_stores.html).
+
+If this seems confusing: you are correct!
+
+Here is what to do
+
+#### Deploying on EC2 and working with buckets in the local region
+
+1. Leave `fs.s3a.endpoint` unset.
+2. Set `fs.s3a.endpoint.region` to `sdk`.
+
+This hands off resolution to the SDK, which will use the IAM service to determine the local region.
+The SDK will use this to build the endpoint URL and sign all requests.
+
+#### On-prem access to S3 where the bucket region is known
+
+1. Leave `fs.s3a.endpoint` unset.
+2. Set `fs.s3a.endpoint.region` to the region of the bucket.
+
+
+#### On-prem access to S3 where the bucket region is not known
+
+1. Leave `fs.s3a.endpoint` unset.
+2. Leave `fs.s3a.endpoint.region` unset/set to SDK
+3. Set `fs.s3a.cross.region.access.enabled` to `true` (this is the default).
+
+
+#### On-prem access to S3 through VPCE
+
+1. Set `fs.s3a.endpoint` to the VPCE endpoint
+2. Set `fs.s3a.endpoint.region` to the region of the bucket, *or leave unset*
+3. Set `fs.s3a.path.style.access` to `true`.
+
+```xml
+  <property>
+    <name>fs.s3a.bucket.example.endpoint</name>
+    <value>https://bucket.vpce-05ba4f2400000-x92g7xzc.s3.us-west-2.vpce.amazonaws.com/</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.bucket.example.path.style.access</name>
+    <value>true</value>
+  </property>
+
+```
+
+#### On-prem access where the region 
+
+#### Third party stores
+
+See [Third Party Stores](./third_party_stores.html) for the full details and example settings.
+* Set `fs.s3a.endpoint` to the full URL of the service, or, if it supports virtual hostnames,
+to the domain name to which virtual hosts are prefixed.
+* Set `fs.s3a.endpoint.region` to `external`.
+* If working with an HTTP endpoint, set `fs.s3a.bucket.connection.ssl.enabled` to false.
+
+
 
 ### <a name="timeouts"></a> Network timeouts
 
@@ -362,7 +422,6 @@ with buckets local to that S3 instance.
 4. Standard S3 buckets support "cross-region" access where use of the original `us-east-1`
    endpoint allows access to the data, but newer storage types, particularly S3 Express are
    not supported.
-
 
 
 If the wrong endpoint is used, the request will fail. This may be reported as a 301/redirect error,

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
@@ -170,7 +170,7 @@ the value of `fs.s3a.endpoint.region` can still tune s3a client behavior.
 2. If `fs.s3a.endpoint.region` is configured with valid AWS region value, S3A will
    configure the S3 client to use this value. If this is set to a region that does
    not match your bucket, you will receive a 301 redirect response.
-3. If `fs.s3a.endpoint.region` is not set and `fs.s3a.endpoint` is set to an AWS regional endpoint 
+3. If `fs.s3a.endpoint.region` is not set and `fs.s3a.endpoint` is set to an AWS regional endpoint
    S3A will determine the region by parsing the endpoint string.
    This works for VPCE, `amazonaws.com` and `amazonaws.cn` endpoints.
 4. If `fs.s3a.endpoint.region` is set to `sdk` then region resolution is handled

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/connecting.md
@@ -121,14 +121,14 @@ Normally, declaring the region in `fs.s3a.endpoint.region` should be sufficient 
   endpoint value, S3A will attempt to parse the region from the endpoint and
   configure S3 client to use the region value.
 * If both `fs.s3a.endpoint` and `fs.s3a.endpoint.region` are not set, S3A will
-  use `us-east-2` as default region and enable cross region access. In this case,
+  use `us-east-1` as default region and enable cross region access. In this case,
   S3A does not attempt to override the endpoint while configuring the S3 client.
 * If `fs.s3a.endpoint` is not set and `fs.s3a.endpoint.region` is set to an empty
   string, S3A will configure S3 client without any region or endpoint override.
   This will allow fallback to S3 SDK region resolution chain. More details
   [here](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 * If `fs.s3a.endpoint` is set to central endpoint `s3.amazonaws.com` and
-  `fs.s3a.endpoint.region` is not set, S3A will use `us-east-2` as default region
+  `fs.s3a.endpoint.region` is not set, S3A will use `us-east-1` as default region
   and enable cross region access. In this case, S3A does not attempt to override
   the endpoint while configuring the S3 client.
 * If `fs.s3a.endpoint` is set to central endpoint `s3.amazonaws.com` and
@@ -147,7 +147,7 @@ are complex and improving over time. Hence, they may be considered unstable.
 *Important:* do not use `auto`, `ec2`, or `sdk` as these may be used
 in the future for specific region-binding algorithms.
 
-If you are working with third party stores, please check [third party stores in detail](third_party_stores.html).
+If you are working with third party stores, please check [third party stores in detail](./third_party_stores.html).
 
 ### <a name="timeouts"></a> Network timeouts
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
@@ -663,7 +663,7 @@ Use at your own risk. Running the `hadoop-aws` test suite against your store wou
 versions have changed their behavior.
 
 Example settings for a local rust bucket. Note that `fs.s3a.bucket.rustybucket.connection.ssl.enabled` has been set to false
-as the SDK doesn't look at the http/https prefix of the endpoint to determine which protocol to use. 
+as the SDK doesn't look at the http/https prefix of the endpoint to determine which protocol to use.
 
 ```xml
   <property>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
@@ -102,7 +102,7 @@ AWS SDK requires the name of a region is supplied for signing, and that region m
 Third-party stores don't normally care about the name of a region, *only that a region is supplied*.
 
 You should set `fs.s3a.endpoint.region` to anything except the following reserved names: `sdk`, `ec2` and `auto`.
-We have plans for those.
+Recommended: `external`
 
 ## Other issues
 
@@ -445,7 +445,6 @@ The S3A client's creation of an endpoint URL generates an unknown host.
   </property>
 ```
 
-
 ```
 ls: software.amazon.awssdk.core.exception.SdkClientException:
     Received an UnknownHostException when attempting to interact with a service.
@@ -491,7 +490,7 @@ at [ECS Test Drive](https://portal.ecstestdrive.com/) were
 ```xml
 <property>
   <name>fs.s3a.endpoint.region</name>
-  <value>dell</value>
+  <value>external</value>
   <description>arbitrary name other than sdk, ec2, auto or null</description>
 </property>
 
@@ -564,7 +563,7 @@ this makes renaming and deleting significantly slower.
   <!-- any value except sdk, auto and ec2 is allowed here, using "gcs" is more informative -->
   <property>
     <name>fs.s3a.endpoint.region</name>
-    <value>gcs</value>
+    <value>external</value>
   </property>
 
   <property>
@@ -640,3 +639,67 @@ It is also a way to regression test foundational S3A third-party store compatibi
 _Note_ If anyone is set up to test this regularly, please let the hadoop developer team know if regressions do surface,
 as it is not a common test configuration.
 We do use it to help test compatibility during SDK updates.
+
+## RustFS localhost with no https
+
+RustFS is an easy to deploy S3 store.
+
+In tests of the S3A connector in December 2025 we observed:
+1. Eventual consistency in path deletion (LIST responses included recently deleted objects; HEAD correctly returned 404)
+2. Eventual consistency in lists of multipart object uploads (`s3guard uploads` command, *and* s3a committer cleanup)
+3. Case inconsistency when running on a MacOS system; not tested elsewhere.
+4. Other minor issues in niche API calls (`getBucketMetadata()`) which don't affect normal use.
+
+Listing inconsistency after directory deletion is the key issue which may break applications as it means that
+* Newly deleted directories may still return objects.
+* Newly renamed objects may still be listable at the source paths.
+* The logic which determines whether an empty directory marker should be reinserted after a child path deletion may not behave correctly.
+
+It may be safe for use with tables which are designed to work on inconsistent object stores (Apache Iceberg and rivals), but
+it does not, as of December 2025 appear safe for use with classic Hive directory structured tables, through Hive, Spark or other applications.
+Nor are the S3A committers guaranteed to work safely.
+
+Use at your own risk. Running the `hadoop-aws` test suite against your store would be the ideal way to see if later
+versions have changed their behavior.
+
+Example settings for a local rust bucket. Note that `fs.s3a.bucket.rustybucket.connection.ssl.enabled` has been set to false
+as the SDK doesn't look at the http/https prefix of the endpoint to determine which protocol to use. 
+
+```xml
+  <property>
+    <name>fs.s3a.bucket.rustybucket.access.key</name>
+    <value>rustfsadmin</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.bucket.rustybucket.secret.key</name>
+    <value>rustfsadmin</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.bucket.rustybucket.endpoint</name>
+    <value>http://localhost:9000</value>
+  </property>
+
+  <!-- this is critical to stop the SDK using TLS encryption even though the endpoint is declared as HTTP -->
+  <property>
+    <name>fs.s3a.bucket.rustybucket.connection.ssl.enabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.bucket.rustybucket.endpoint.region</name>
+    <value>external</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.bucket.rustybucket.path.style.access</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.bucket.rustybucket.create.conditional.enabled</name>
+    <value>false</value>
+  </property>
+```
+

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import java.net.URI;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 /**
  * Abstract base class for S3A unit tests using a mock S3 client.
  */
-public abstract class AbstractS3AMockTest {
+public abstract class AbstractS3AMockTest extends AbstractHadoopTestBase {
 
   protected static final String BUCKET = "mock-bucket";
   protected static final AwsServiceException NOT_FOUND =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -29,8 +29,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -54,11 +56,12 @@ import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.PATH_STYLE_ACCESS;
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_ALGORITHM;
-import static org.apache.hadoop.fs.s3a.DefaultS3ClientFactory.ERROR_ENDPOINT_WITH_FIPS;
+import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assume;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeNotS3ExpressFileSystem;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeStoreAwsHosted;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.ERROR_ENDPOINT_WITH_FIPS;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.DEFAULT_REQUESTER_PAYS_BUCKET_NAME;
 import static org.apache.hadoop.io.IOUtils.closeStream;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -113,6 +116,9 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
    * Text to include in assertions.
    */
   private static final AtomicReference<String> EXPECTED_MESSAGE = new AtomicReference<>();
+
+  public static final String INCORRECT_REGION_SET = "Incorrect region set";
+
   /**
    * New FS instance which will be closed in teardown.
    */
@@ -221,6 +227,32 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     S3Client client = createS3Client(conf, null, EU_WEST_2, EU_WEST_2, false);
 
     expectInterceptorException(client);
+  }
+
+  /**
+   * This hands off resolution to the SDK which may fail if nothing can be found
+   * (non-EC2; no AWS_REGION env var or through {@code ~/.aws/config}.
+   * There's separate handling for the different failure modes so this
+   * test will work in all deployments.
+   */
+  @Test
+  public void testWithSDKRegionConfig() throws Throwable {
+    describe("Create a client with an SDK region");
+    Configuration conf = getConfiguration();
+
+    try {
+      S3Client client = createS3Client(conf, CENTRAL_ENDPOINT, SDK_REGION, null, false);
+
+      expectInterceptorException(client);
+    } catch (SdkClientException e) {
+      Assertions.assertThat(e)
+          .describedAs("Exception raised due to unable to resolve region")
+          .hasMessageContaining("region");
+    } catch (AssertionFailedError e) {
+      Assertions.assertThat(e)
+          .describedAs("Exception raised region resolution working on local system")
+          .hasMessageContaining(INCORRECT_REGION_SET);
+    }
   }
 
   @Test
@@ -646,7 +678,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
       }
 
       Assertions.assertThat(reg)
-          .describedAs("Incorrect region set in %s. Client Config=%s",
+          .describedAs(INCORRECT_REGION_SET + " in %s. Client Config=%s",
               state, EXPECTED_MESSAGE.get())
           .isEqualTo(region);
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
@@ -33,21 +33,21 @@ public class TestS3AEndpointParsing extends AbstractS3AMockTest {
     private static final String US_WEST_2 = "us-west-2";
     private static final String EU_WEST_1 = "eu-west-1";
 
-    @Test
-    public void testVPCEndpoint() {
-        Optional<RegionResolution.Resolution>
-            region = RegionResolution.determineS3RegionFromEndpoint(VPC_ENDPOINT, false);
-        Assertions.assertThat(region).get()
-            .extracting(RegionResolution.Resolution::getRegion)
-            .isEqualTo(Region.of(US_WEST_2));
-    }
+  @Test
+  public void testVPCEndpoint() {
+    Optional<RegionResolution.Resolution>
+        region = RegionResolution.determineS3RegionFromEndpoint(VPC_ENDPOINT, false);
+    Assertions.assertThat(region).get()
+        .extracting(RegionResolution.Resolution::getRegion)
+        .isEqualTo(Region.of(US_WEST_2));
+  }
 
-    @Test
-    public void testNonVPCEndpoint() {
-      Optional<RegionResolution.Resolution>
-                  region = RegionResolution.determineS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
-        Assertions.assertThat(region).get()
-            .extracting(RegionResolution.Resolution::getRegion)
-            .isEqualTo(Region.of(EU_WEST_1));
-    }
+  @Test
+  public void testNonVPCEndpoint() {
+    Optional<RegionResolution.Resolution>
+        region = RegionResolution.determineS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
+    Assertions.assertThat(region).get()
+        .extracting(RegionResolution.Resolution::getRegion)
+        .isEqualTo(Region.of(EU_WEST_1));
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
@@ -18,9 +18,13 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import java.util.Optional;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
+
+import org.apache.hadoop.fs.s3a.impl.RegionResolution;
 
 public class TestS3AEndpointParsing extends AbstractS3AMockTest {
 
@@ -31,13 +35,19 @@ public class TestS3AEndpointParsing extends AbstractS3AMockTest {
 
     @Test
     public void testVPCEndpoint() {
-        Region region = DefaultS3ClientFactory.getS3RegionFromEndpoint(VPC_ENDPOINT, false);
-        Assertions.assertThat(region).isEqualTo(Region.of(US_WEST_2));
+        Optional<RegionResolution.Resolution>
+            region = RegionResolution.getS3RegionFromEndpoint(VPC_ENDPOINT, false);
+        Assertions.assertThat(region).get()
+            .extracting(RegionResolution.Resolution::getRegion)
+            .isEqualTo(Region.of(US_WEST_2));
     }
 
     @Test
     public void testNonVPCEndpoint() {
-        Region region = DefaultS3ClientFactory.getS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
-        Assertions.assertThat(region).isEqualTo(Region.of(EU_WEST_1));
+      Optional<RegionResolution.Resolution>
+                  region = RegionResolution.getS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
+        Assertions.assertThat(region).get()
+            .extracting(RegionResolution.Resolution::getRegion)
+            .isEqualTo(Region.of(EU_WEST_1));
     }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
@@ -36,7 +36,7 @@ public class TestS3AEndpointParsing extends AbstractS3AMockTest {
     @Test
     public void testVPCEndpoint() {
         Optional<RegionResolution.Resolution>
-            region = RegionResolution.getS3RegionFromEndpoint(VPC_ENDPOINT, false);
+            region = RegionResolution.determineS3RegionFromEndpoint(VPC_ENDPOINT, false);
         Assertions.assertThat(region).get()
             .extracting(RegionResolution.Resolution::getRegion)
             .isEqualTo(Region.of(US_WEST_2));
@@ -45,7 +45,7 @@ public class TestS3AEndpointParsing extends AbstractS3AMockTest {
     @Test
     public void testNonVPCEndpoint() {
       Optional<RegionResolution.Resolution>
-                  region = RegionResolution.getS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
+                  region = RegionResolution.determineS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
         Assertions.assertThat(region).get()
             .extracting(RegionResolution.Resolution::getRegion)
             .isEqualTo(Region.of(EU_WEST_1));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import java.io.IOException;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -38,8 +40,6 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 /**
  * Test region resolution logic in {@link RegionResolution}.
  * These are based on {@code ITestS3AEndpointRegion}.
- * <p>
- * This does not look at SDK internal logic, "what really happens".
  */
 public class TestRegionResolution extends AbstractHadoopTestBase {
 
@@ -51,8 +51,6 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   private static final String US_EAST_2 = "us-east-2";
 
   private static final String US_WEST_2 = "us-west-2";
-
-  private static final String SA_EAST_1 = "sa-east-1";
 
   private static final String EU_WEST_2 = "eu-west-2";
 
@@ -90,7 +88,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
       String configuredRegion,
       boolean isFips,
       String expectedRegion,
-      final RegionResolution.RegionResolutionMechanism expectedMechanism) {
+      final RegionResolution.RegionResolutionMechanism expectedMechanism) throws IOException {
     S3ClientFactory.S3ClientCreationParameters parameters =
         new S3ClientFactory.S3ClientCreationParameters()
             .withEndpoint(endpoint)
@@ -112,21 +110,32 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
 
     // supplied resolution
     if (expectedMechanism != null) {
-      Assertions.assertThat(resolved.getResolution())
-          .describedAs("Resolution mechanism of %s", resolved)
-          .isEqualTo(expectedMechanism);
+      assertMechanism(expectedMechanism, resolved);
     }
     return resolved;
   }
 
+  /**
+   * Assert that a resolution used a specific mechanism.
+   * @param expectedMechanism expected mechanism.
+   * @param resolved resolved region
+   */
+  private static void assertMechanism(
+      final RegionResolution.RegionResolutionMechanism expectedMechanism,
+      final RegionResolution.Resolution resolved) {
+    Assertions.assertThat(resolved.getMechanism())
+        .describedAs("Resolution mechanism of %s", resolved)
+        .isEqualTo(expectedMechanism);
+  }
+
   @Test
-  public void testWithVPCE() {
+  public void testWithVPCE() throws IOException {
     resolve(getConfiguration(), VPC_ENDPOINT, null, false, US_WEST_2,
         RegionResolution.RegionResolutionMechanism.ParseVpceEndpoint);
   }
 
   @Test
-  public void testWithChinaVPCE() {
+  public void testWithChinaVPCE() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), CN_VPC_ENDPOINT, null, false,
             CN_NORTHWEST_1, RegionResolution.RegionResolutionMechanism.ParseVpceEndpoint);
@@ -135,7 +144,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testCentralEndpointNoRegion() {
+  public void testCentralEndpointNoRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), CENTRAL_ENDPOINT, null, false,
             US_EAST_2,
@@ -145,7 +154,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testCentralEndpointWithRegion() {
+  public void testCentralEndpointWithRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), CENTRAL_ENDPOINT, US_WEST_2, false,
             US_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
@@ -154,7 +163,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testConfiguredRegion() {
+  public void testConfiguredRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), null, EU_WEST_2, false,
             EU_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
@@ -164,7 +173,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testSDKRegion() {
+  public void testSDKRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), null, SDK_REGION, false,
             null, RegionResolution.RegionResolutionMechanism.Sdk);
@@ -174,17 +183,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testEC2Region() {
-    final RegionResolution.Resolution r =
-        resolve(getConfiguration(), null, EC2_REGION, false,
-            null, RegionResolution.RegionResolutionMechanism.Sdk);
-    // SDK handles endpoint logic.
-    assertEndpoint(r, null);
-    assertUseCentral(r, true);
-  }
-
-  @Test
-  public void testEC2UpperCaseRegion() {
+  public void testEC2UpperCaseRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), null, "EC2", false,
             null, RegionResolution.RegionResolutionMechanism.Sdk);
@@ -194,7 +193,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testSDKUpperCaseRegion() {
+  public void testSDKUpperCaseRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), null, "SDK", false,
             null, RegionResolution.RegionResolutionMechanism.Sdk);
@@ -204,7 +203,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testEmptyStringRegion() {
+  public void testEmptyStringRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), null, "", false,
             null, RegionResolution.RegionResolutionMechanism.Sdk);
@@ -214,7 +213,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testWithFipsNoEndpoint() {
+  public void testWithFipsNoEndpoint() throws IOException {
     describe("Create a client with fips enabled");
 
     resolve(getConfiguration(),
@@ -235,7 +234,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testWithRegionConfig() {
+  public void testWithRegionConfig() throws IOException {
     describe("Create a client with a configured region");
 
     resolve(getConfiguration(), null, EU_WEST_2, false,
@@ -243,7 +242,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testEUWest2Endpoint() {
+  public void testEUWest2Endpoint() throws IOException {
     describe("specifying an eu-west-2 endpoint selects that region");
 
     resolve(getConfiguration(), EU_WEST_2_ENDPOINT, null, false,
@@ -251,7 +250,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testWithRegionAndEndpointConfig() {
+  public void testWithRegionAndEndpointConfig() throws IOException {
     describe("Test that when both region and endpoint are configured, region takes precedence");
 
     resolve(getConfiguration(), EU_WEST_2_ENDPOINT, US_WEST_2, false,
@@ -259,7 +258,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testWithChinaEndpoint() {
+  public void testWithChinaEndpoint() throws IOException {
     describe("Test with a china endpoint");
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), CN_ENDPOINT, null, false,
@@ -270,7 +269,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testWithGovCloudEndpoint() {
+  public void testWithGovCloudEndpoint() throws IOException {
     describe("Test with a gov cloud endpoint");
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), GOV_ENDPOINT, null, false,
@@ -278,6 +277,40 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             RegionResolution.RegionResolutionMechanism.CalculatedFromEndpoint);
     assertEndpoint(r, GOV_ENDPOINT);
     assertUseCentral(r, false);
+  }
+
+  @Test
+  public void testNullIsForbidden() throws Throwable {
+    describe("The region null is forbidden as a red flag of configuration problems");
+    intercept(IllegalArgumentException.class, () ->
+        resolve(getConfiguration(), null, "null", false,
+            null, null));
+  }
+
+
+  /**
+   * This does attempt to talk to EC2 IAM but it doesn't need cloud credentials
+   * and will succeed whether the information came back or not.
+   * <p>What it does do is validate the codepath.
+   */
+  @Test
+  public void testEC2Region() {
+    describe("Attempt to resolve region through EC2");
+
+    final Configuration conf = new Configuration(false);
+    S3ClientFactory.S3ClientCreationParameters parameters =
+        new S3ClientFactory.S3ClientCreationParameters()
+            .withRegion(EC2_REGION);
+    try {
+      final RegionResolution.Resolution resolved = calculateRegion(parameters, conf);
+      // here the process is under EC2 and a region was returned.
+      LOG.info("EC2 IAM resolved metadata: {}", resolved);
+      assertMechanism(RegionResolution.RegionResolutionMechanism.Ec2Metadata, resolved);
+    } catch (IOException e) {
+      // expected on anything except EC2
+      LOG.info("Expected failure when EC2 IAM is not present", e);
+    }
+
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
@@ -31,11 +31,9 @@ import org.apache.hadoop.fs.s3a.S3ClientFactory;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
-import static org.apache.hadoop.fs.s3a.Constants.EC2_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.ERROR_ENDPOINT_WITH_FIPS;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
-import static org.apache.hadoop.fs.s3a.impl.RegionResolution.isEc2Region;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -148,7 +146,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
   public void testCentralEndpointNoRegion() throws IOException {
     final RegionResolution.Resolution r =
         resolve(getConfiguration(), CENTRAL_ENDPOINT, null, false,
-            US_EAST_2,
+            US_EAST_1,
             RegionResolution.RegionResolutionMechanism.FallbackToCentral);
     assertEndpoint(r, null);
     assertUseCentralValue(r, true);
@@ -276,39 +274,6 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
     intercept(IllegalArgumentException.class, () ->
         resolve(getConfiguration(), null, "null", false,
             null, null));
-  }
-
-
-  /**
-   * This does attempt to talk to EC2 IAM but it doesn't need cloud credentials
-   * and will succeed whether the information came back or not.
-   * <p>What it does do is validate the codepath.
-   */
-  @Test
-  public void testEC2Region() {
-    describe("Attempt to resolve region through EC2");
-
-    final Configuration conf = new Configuration(false);
-    S3ClientFactory.S3ClientCreationParameters parameters =
-        new S3ClientFactory.S3ClientCreationParameters()
-            .withRegion(EC2_REGION);
-    try {
-      final RegionResolution.Resolution resolved = calculateRegion(parameters, conf);
-      // here the process is under EC2 and a region was returned.
-      LOG.info("EC2 IAM resolved metadata: {}", resolved);
-      assertMechanism(RegionResolution.RegionResolutionMechanism.Ec2Metadata, resolved);
-    } catch (IOException e) {
-      // expected on anything except EC2
-      LOG.info("Expected failure when EC2 IAM is not present", e);
-    }
-  }
-
-  @Test
-  public void testEc2RegionCaseLogic() throws Throwable {
-    Assertions.assertThat(isEc2Region("ec2"))
-        .describedAs("lower case ec2").isTrue();
-    Assertions.assertThat(isEc2Region("EC2"))
-        .describedAs("upper case ec2").isTrue();
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
@@ -35,6 +35,7 @@ import static org.apache.hadoop.fs.s3a.Constants.EC2_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.ERROR_ENDPOINT_WITH_FIPS;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.isEc2Region;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -140,7 +141,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
         resolve(getConfiguration(), CN_VPC_ENDPOINT, null, false,
             CN_NORTHWEST_1, RegionResolution.RegionResolutionMechanism.ParseVpceEndpoint);
     assertEndpoint(r, CN_VPC_ENDPOINT);
-    assertUseCentral(r, false);
+    assertUseCentralValue(r, false);
   }
 
   @Test
@@ -150,7 +151,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             US_EAST_2,
             RegionResolution.RegionResolutionMechanism.FallbackToCentral);
     assertEndpoint(r, null);
-    assertUseCentral(r, true);
+    assertUseCentralValue(r, true);
   }
 
   @Test
@@ -159,7 +160,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
         resolve(getConfiguration(), CENTRAL_ENDPOINT, US_WEST_2, false,
             US_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
     assertEndpoint(r, null);
-    assertUseCentral(r, true);
+    assertUseCentralValue(r, true);
   }
 
   @Test
@@ -169,7 +170,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             EU_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
     // this still uses the central endpoint.
     assertEndpoint(r, null);
-    assertUseCentral(r, true);
+    assertUseCentralValue(r, true);
   }
 
   @Test
@@ -179,17 +180,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             null, RegionResolution.RegionResolutionMechanism.Sdk);
     // SDK handles endpoint logic.
     assertEndpoint(r, null);
-    assertUseCentral(r, true);
-  }
-
-  @Test
-  public void testEC2UpperCaseRegion() throws IOException {
-    final RegionResolution.Resolution r =
-        resolve(getConfiguration(), null, "EC2", false,
-            null, RegionResolution.RegionResolutionMechanism.Sdk);
-    // SDK handles endpoint logic.
-    assertEndpoint(r, null);
-    assertUseCentral(r, true);
+    assertUseCentralValue(r, true);
   }
 
   @Test
@@ -199,7 +190,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             null, RegionResolution.RegionResolutionMechanism.Sdk);
     // SDK handles endpoint logic.
     assertEndpoint(r, null);
-    assertUseCentral(r, true);
+    assertUseCentralValue(r, true);
   }
 
   @Test
@@ -209,7 +200,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             null, RegionResolution.RegionResolutionMechanism.Sdk);
     // SDK handles endpoint logic.
     assertEndpoint(r, null);
-    assertUseCentral(r, true);
+    assertUseCentralValue(r, true);
   }
 
   @Test
@@ -265,7 +256,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             CN_NORTHWEST_1,
             RegionResolution.RegionResolutionMechanism.CalculatedFromEndpoint);
     assertEndpoint(r, CN_ENDPOINT);
-    assertUseCentral(r, false);
+    assertUseCentralValue(r, false);
   }
 
   @Test
@@ -276,7 +267,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
             US_GOV_EAST_1,
             RegionResolution.RegionResolutionMechanism.CalculatedFromEndpoint);
     assertEndpoint(r, GOV_ENDPOINT);
-    assertUseCentral(r, false);
+    assertUseCentralValue(r, false);
   }
 
   @Test
@@ -310,7 +301,28 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
       // expected on anything except EC2
       LOG.info("Expected failure when EC2 IAM is not present", e);
     }
+  }
 
+  @Test
+  public void testEc2RegionCaseLogic() throws Throwable {
+    Assertions.assertThat(isEc2Region("ec2"))
+        .describedAs("lower case ec2").isTrue();
+    Assertions.assertThat(isEc2Region("EC2"))
+        .describedAs("upper case ec2").isTrue();
+  }
+
+  @Test
+  public void testGcsRegion() throws Throwable {
+    resolve(getConfiguration(), "https://storage.googleapis.com", null, false,
+        RegionResolution.EXTERNAL,
+        RegionResolution.RegionResolutionMechanism.ExternalEndpoint);
+  }
+
+  @Test
+  public void testLocalhostRegion() throws Throwable {
+    resolve(getConfiguration(), "127.0.0.1", null, false,
+        RegionResolution.EXTERNAL,
+        RegionResolution.RegionResolutionMechanism.ExternalEndpoint);
   }
 
   /**
@@ -331,7 +343,7 @@ public class TestRegionResolution extends AbstractHadoopTestBase {
    * @param r resolution
    * @param expected expected value.
    */
-  private static void assertUseCentral(final RegionResolution.Resolution r,
+  private static void assertUseCentralValue(final RegionResolution.Resolution r,
       final boolean expected) {
     Assertions.assertThat(r.isUseCentralEndpoint())
         .describedAs("Endpoint of %s", r)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRegionResolution.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.EC2_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.SDK_REGION;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.ERROR_ENDPOINT_WITH_FIPS;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.calculateRegion;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Test region resolution logic in {@link RegionResolution}.
+ * These are based on {@code ITestS3AEndpointRegion}.
+ * <p>
+ * This does not look at SDK internal logic, "what really happens".
+ */
+public class TestRegionResolution extends AbstractHadoopTestBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestRegionResolution.class);
+
+  private static final String US_EAST_1 = "us-east-1";
+
+  private static final String US_EAST_2 = "us-east-2";
+
+  private static final String US_WEST_2 = "us-west-2";
+
+  private static final String SA_EAST_1 = "sa-east-1";
+
+  private static final String EU_WEST_2 = "eu-west-2";
+
+  private static final String CN_NORTHWEST_1 = "cn-northwest-1";
+
+  private static final String US_GOV_EAST_1 = "us-gov-east-1";
+
+  private static final String EU_WEST_2_ENDPOINT = "s3.eu-west-2.amazonaws.com";
+
+  private static final String CN_ENDPOINT = "s3.cn-northwest-1.amazonaws.com.cn";
+
+  private static final String GOV_ENDPOINT = "s3-fips.us-gov-east-1.amazonaws.com";
+
+  private static final String VPC_ENDPOINT = "vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com";
+
+  private static final String CN_VPC_ENDPOINT =
+      "vpce-1a2b3c4d-5e6f.s3.cn-northwest-1.vpce.amazonaws.com.cn";
+
+
+  private Configuration getConfiguration() {
+    return new Configuration(false);
+  }
+
+  /**
+   * Describe a test. This is a replacement for javadocs
+   * where the tests role is printed in the log output
+   * @param text description
+   */
+  protected void describe(String text) {
+    LOG.info(text);
+  }
+
+  private RegionResolution.Resolution resolve(Configuration conf,
+      String endpoint,
+      String configuredRegion,
+      boolean isFips,
+      String expectedRegion,
+      final RegionResolution.RegionResolutionMechanism expectedMechanism) {
+    S3ClientFactory.S3ClientCreationParameters parameters =
+        new S3ClientFactory.S3ClientCreationParameters()
+            .withEndpoint(endpoint)
+            .withRegion(configuredRegion)
+            .withFipsEnabled(isFips);
+    final RegionResolution.Resolution resolved = calculateRegion(parameters, conf);
+
+    // check the region
+    if (expectedRegion != null) {
+      Assertions.assertThat(resolved.getRegion())
+          .describedAs("Resolved region %s", resolved)
+          .isNotNull()
+          .isEqualTo(Region.of(expectedRegion));
+    } else {
+      Assertions.assertThat(resolved.getRegion())
+          .describedAs("Resolved region %s", resolved)
+          .isNull();
+    }
+
+    // supplied resolution
+    if (expectedMechanism != null) {
+      Assertions.assertThat(resolved.getResolution())
+          .describedAs("Resolution mechanism of %s", resolved)
+          .isEqualTo(expectedMechanism);
+    }
+    return resolved;
+  }
+
+  @Test
+  public void testWithVPCE() {
+    resolve(getConfiguration(), VPC_ENDPOINT, null, false, US_WEST_2,
+        RegionResolution.RegionResolutionMechanism.ParseVpceEndpoint);
+  }
+
+  @Test
+  public void testWithChinaVPCE() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), CN_VPC_ENDPOINT, null, false,
+            CN_NORTHWEST_1, RegionResolution.RegionResolutionMechanism.ParseVpceEndpoint);
+    assertEndpoint(r, CN_VPC_ENDPOINT);
+    assertUseCentral(r, false);
+  }
+
+  @Test
+  public void testCentralEndpointNoRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), CENTRAL_ENDPOINT, null, false,
+            US_EAST_2,
+            RegionResolution.RegionResolutionMechanism.FallbackToCentral);
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testCentralEndpointWithRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), CENTRAL_ENDPOINT, US_WEST_2, false,
+            US_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testConfiguredRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), null, EU_WEST_2, false,
+            EU_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
+    // this still uses the central endpoint.
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testSDKRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), null, SDK_REGION, false,
+            null, RegionResolution.RegionResolutionMechanism.Sdk);
+    // SDK handles endpoint logic.
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testEC2Region() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), null, EC2_REGION, false,
+            null, RegionResolution.RegionResolutionMechanism.Sdk);
+    // SDK handles endpoint logic.
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testEC2UpperCaseRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), null, "EC2", false,
+            null, RegionResolution.RegionResolutionMechanism.Sdk);
+    // SDK handles endpoint logic.
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testSDKUpperCaseRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), null, "SDK", false,
+            null, RegionResolution.RegionResolutionMechanism.Sdk);
+    // SDK handles endpoint logic.
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testEmptyStringRegion() {
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), null, "", false,
+            null, RegionResolution.RegionResolutionMechanism.Sdk);
+    // SDK handles endpoint logic.
+    assertEndpoint(r, null);
+    assertUseCentral(r, true);
+  }
+
+  @Test
+  public void testWithFipsNoEndpoint() {
+    describe("Create a client with fips enabled");
+
+    resolve(getConfiguration(),
+        null, EU_WEST_2, true,
+        EU_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
+  }
+
+  /**
+   * Attempting to create a client with fips enabled and an endpoint specified
+   * fails during client construction.
+   */
+  @Test
+  public void testWithFipsAndEndpoint() throws Exception {
+    describe("Create a client with fips and an endpoint");
+
+    intercept(IllegalArgumentException.class, ERROR_ENDPOINT_WITH_FIPS, () ->
+        resolve(getConfiguration(), US_WEST_2, null, true, US_EAST_1, null));
+  }
+
+  @Test
+  public void testWithRegionConfig() {
+    describe("Create a client with a configured region");
+
+    resolve(getConfiguration(), null, EU_WEST_2, false,
+        EU_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
+  }
+
+  @Test
+  public void testEUWest2Endpoint() {
+    describe("specifying an eu-west-2 endpoint selects that region");
+
+    resolve(getConfiguration(), EU_WEST_2_ENDPOINT, null, false,
+        EU_WEST_2, RegionResolution.RegionResolutionMechanism.CalculatedFromEndpoint);
+  }
+
+  @Test
+  public void testWithRegionAndEndpointConfig() {
+    describe("Test that when both region and endpoint are configured, region takes precedence");
+
+    resolve(getConfiguration(), EU_WEST_2_ENDPOINT, US_WEST_2, false,
+        US_WEST_2, RegionResolution.RegionResolutionMechanism.Specified);
+  }
+
+  @Test
+  public void testWithChinaEndpoint() {
+    describe("Test with a china endpoint");
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), CN_ENDPOINT, null, false,
+            CN_NORTHWEST_1,
+            RegionResolution.RegionResolutionMechanism.CalculatedFromEndpoint);
+    assertEndpoint(r, CN_ENDPOINT);
+    assertUseCentral(r, false);
+  }
+
+  @Test
+  public void testWithGovCloudEndpoint() {
+    describe("Test with a gov cloud endpoint");
+    final RegionResolution.Resolution r =
+        resolve(getConfiguration(), GOV_ENDPOINT, null, false,
+            US_GOV_EAST_1,
+            RegionResolution.RegionResolutionMechanism.CalculatedFromEndpoint);
+    assertEndpoint(r, GOV_ENDPOINT);
+    assertUseCentral(r, false);
+  }
+
+  /**
+   * Assert that an endpoint matches the expected value.
+   * @param r resolution
+   * @param expected expected value.
+   */
+  private static void assertEndpoint(final RegionResolution.Resolution r,
+      final String expected) {
+    Assertions.assertThat(r.getEndpointStr())
+        .describedAs("Endpoint of %s", r)
+        .isEqualTo(expected);
+  }
+
+  /**
+   * assert that the resolution {@code isUseCentralEndpoint()} value
+   * matches that expected.
+   * @param r resolution
+   * @param expected expected value.
+   */
+  private static void assertUseCentral(final RegionResolution.Resolution r,
+      final boolean expected) {
+    Assertions.assertThat(r.isUseCentralEndpoint())
+        .describedAs("Endpoint of %s", r)
+        .isEqualTo(expected);
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/ITestBucketTool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/ITestBucketTool.java
@@ -35,10 +35,13 @@ import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.util.ExitUtil;
 
 import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.assume;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeNotS3ExpressFileSystem;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeS3ExpressFileSystem;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeStoreAwsHosted;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.expectErrorCode;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.isEc2Region;
+import static org.apache.hadoop.fs.s3a.impl.RegionResolution.isSdkRegion;
 import static org.apache.hadoop.fs.s3a.impl.S3ExpressStorage.STORE_CAPABILITY_S3_EXPRESS_STORAGE;
 import static org.apache.hadoop.fs.s3a.tools.BucketTool.CREATE;
 import static org.apache.hadoop.fs.s3a.tools.BucketTool.NO_ZONE_SUPPLIED;
@@ -142,6 +145,9 @@ public class ITestBucketTool extends AbstractS3ATestBase {
   public void testRecreateTestBucketNonS3Express() throws Throwable {
     assumeNotS3ExpressFileSystem(fs);
     assumeStoreAwsHosted(fs);
+    // fix a region if resolution is handed down to sdk
+    assume("Skipping as SDK region logic active",
+        !isSdkRegion(region) && !isEc2Region(region));
     intercept(AWSBadRequestException.class, OWNED,
         () -> bucketTool.exec("bucket", d(CREATE),
             d(OPT_REGION), region,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/ITestBucketTool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/ITestBucketTool.java
@@ -40,7 +40,6 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeNotS3ExpressFileSystem
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeS3ExpressFileSystem;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeStoreAwsHosted;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.expectErrorCode;
-import static org.apache.hadoop.fs.s3a.impl.RegionResolution.isEc2Region;
 import static org.apache.hadoop.fs.s3a.impl.RegionResolution.isSdkRegion;
 import static org.apache.hadoop.fs.s3a.impl.S3ExpressStorage.STORE_CAPABILITY_S3_EXPRESS_STORAGE;
 import static org.apache.hadoop.fs.s3a.tools.BucketTool.CREATE;
@@ -147,7 +146,7 @@ public class ITestBucketTool extends AbstractS3ATestBase {
     assumeStoreAwsHosted(fs);
     // fix a region if resolution is handed down to sdk
     assume("Skipping as SDK region logic active",
-        !isSdkRegion(region) && !isEc2Region(region));
+        !isSdkRegion(region));
     intercept(AWSBadRequestException.class, OWNED,
         () -> bucketTool.exec("bucket", d(CREATE),
             d(OPT_REGION), region,


### PR DESCRIPTION

* Pull out region resolution to new class RegionResolution for isolation and testing through TestRegionResolution.
* Add new "sdk" region hand down to SDK
* region resolution is passed as info for testing and logging.
* Test in ITestS3AEndpointRegion to verify that either the SDK fails to resolve with an SDK message or it does resolve to *something* and the test assert fails instead.

### How was this patch tested?


New tests.

* running regression test with configured endpoint.
* planning to run a test with a bucket set to "sdk" to see that the sdk handles it through my .aws/config setting.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

