### PR TITLE
HADOOP-19611. Fix native profile build of hadoop-pipes on SLES 15.

### DIFF
--- a/hadoop-tools/hadoop-pipes/src/CMakeLists.txt
+++ b/hadoop-tools/hadoop-pipes/src/CMakeLists.txt
@@ -25,9 +25,7 @@ find_package(OpenSSL REQUIRED)
 find_package(PkgConfig QUIET)
 pkg_check_modules(LIBTIRPC libtirpc)
 
-find_path(RPC_INCLUDE_DIRS NAMES rpc/rpc.h)
-
-if (NOT RPC_INCLUDE_DIRS)
+if (LIBTIRPC_FOUND)
     find_path(TIRPC_INCLUDE_DIRS
         NAMES netconfig.h
         PATH_SUFFIXES tirpc
@@ -70,7 +68,7 @@ add_library(hadooputils STATIC
     main/native/utils/impl/StringUtils.cc
     main/native/utils/impl/SerialUtils.cc
 )
-if (NOT RPC_INCLUDE_DIRS AND LIBTIRPC_FOUND)
+if (LIBTIRPC_FOUND)
     target_link_libraries(hadooputils tirpc)
 endif()
 


### PR DESCRIPTION
### Description of PR

On SLES 15, failing to add tirpc results in failures linking pthreads. tirpc is present and appears to be the newer RPC library option (with support for IPv6), and provides an rpc.h that Hadoop falsely thinks comes from SunRPC. Use tirpc when available.

### How was this patch tested?

Tested builds on RedHat 8 and 9; SLES 15; and Ubuntu 20.04, 22.04, and 24.04.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

