### PR TITLE
YARN-11893. Extend REST API error messages with exception classes

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
@@ -328,7 +328,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   public void testTaskAttemptIdBogus() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("bogusid",
-        "TaskAttemptId string : bogusid is not properly formed");
+        "java.lang.Exception: TaskAttemptId string : bogusid is not properly formed");
   }
 
   @Test
@@ -336,14 +336,14 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
 
     testTaskAttemptIdErrorGeneric(
         "attempt_0_12345_m_000000_0",
-        "Error getting info on task attempt id attempt_0_12345_m_000000_0");
+        "java.lang.Exception: Error getting info on task attempt id attempt_0_12345_m_000000_0");
   }
 
   @Test
   public void testTaskAttemptIdInvalid() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_d_000000_0",
-        "Bad TaskType identifier. " +
+        "java.lang.Exception: Bad TaskType identifier. " +
         "TaskAttemptId string : attempt_0_12345_d_000000_0 is not properly formed.");
   }
 
@@ -351,14 +351,14 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   public void testTaskAttemptIdInvalid2() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_12345_m_000000_0",
-        "TaskAttemptId string : attempt_12345_m_000000_0 is not properly formed");
+        "java.lang.Exception: TaskAttemptId string : attempt_12345_m_000000_0 is not properly formed");
   }
 
   @Test
   public void testTaskAttemptIdInvalid3() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_m_000000",
-        "TaskAttemptId string : attempt_0_12345_m_000000 is not properly formed");
+        "java.lang.Exception: TaskAttemptId string : attempt_0_12345_m_000000 is not properly formed");
   }
 
   private void testTaskAttemptIdErrorGeneric(String attid, String error)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -269,7 +269,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "job, job_0_1234, is not found", message);
+          "java.lang.Exception: job, job_0_1234, is not found", message);
       WebServicesTestUtils.checkStringMatch("exception type",
           "NotFoundException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
@@ -356,7 +356,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   private void verifyJobIdInvalid(String message, String type, String classname) {
     WebServicesTestUtils.checkStringMatch("exception message",
-        "JobId string : job_foo is not properly formed",
+        "java.lang.Exception: JobId string : job_foo is not properly formed",
         message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "NotFoundException", type);
@@ -385,7 +385,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch(
           "exception message",
-          "JobId string : bogusfoo is not properly formed",
+          "java.lang.Exception: JobId string : bogusfoo is not properly formed",
           message);
       WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
@@ -266,7 +266,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringMatch("exception message",
-            "tasktype must be either m or r", message);
+            "java.lang.Exception: tasktype must be either m or r", message);
         WebServicesTestUtils.checkStringMatch("exception type",
             "BadRequestException", type);
         WebServicesTestUtils.checkStringMatch("exception classname",
@@ -365,7 +365,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : " +
+            "java.lang.Exception: TaskId string : " +
             "bogustaskid is not properly formed"
             + "\nReason: java.util.regex.Matcher[pattern=" +
             TaskID.TASK_ID_REGEX + " region=0,11 lastmatch=]", message);
@@ -401,7 +401,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringMatch("exception message",
-            "task not found with id task_0_0000_m_000000", message);
+            "java.lang.Exception: task not found with id task_0_0000_m_000000", message);
         WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
         WebServicesTestUtils.checkStringMatch("exception classname",
             "org.apache.hadoop.yarn.webapp.NotFoundException", classname);
@@ -432,7 +432,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : "
+            "java.lang.Exception: TaskId string : "
             + "task_0_0000_d_000000 is not properly formed"
             + "\nReason: java.util.regex.Matcher[pattern=" +
             TaskID.TASK_ID_REGEX + " region=0,20 lastmatch=]", message);
@@ -467,7 +467,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : "
+            "java.lang.Exception: TaskId string : "
              + "task_0_m_000000 is not properly formed"
              + "\nReason: java.util.regex.Matcher[pattern=" +
              TaskID.TASK_ID_REGEX + " region=0,15 lastmatch=]", message);
@@ -501,7 +501,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : "
+            "java.lang.Exception: TaskId string : "
              + "task_0_0000_m is not properly formed"
              + "\nReason: java.util.regex.Matcher[pattern=" +
              TaskID.TASK_ID_REGEX + " region=0,13 lastmatch=]", message);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesAttempts.java
@@ -339,33 +339,33 @@ public class TestHsWebServicesAttempts extends JerseyTestBase {
   public void testTaskAttemptIdBogus() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("bogusid",
-        "TaskAttemptId string : bogusid is not properly formed");
+        "java.lang.Exception: TaskAttemptId string : bogusid is not properly formed");
   }
 
   @Test
   public void testTaskAttemptIdNonExist() throws JSONException, Exception {
     testTaskAttemptIdErrorGeneric("attempt_0_1234_m_000000_0",
-        "Error getting info on task attempt id attempt_0_1234_m_000000_0");
+        "java.lang.Exception: Error getting info on task attempt id attempt_0_1234_m_000000_0");
   }
 
   @Test
   public void testTaskAttemptIdInvalid() throws JSONException, Exception {
     testTaskAttemptIdErrorGeneric("attempt_0_1234_d_000000_0",
-        "Bad TaskType identifier. TaskAttemptId string : "
+        "java.lang.Exception: Bad TaskType identifier. TaskAttemptId string : "
          + "attempt_0_1234_d_000000_0 is not properly formed.");
   }
 
   @Test
   public void testTaskAttemptIdInvalid2() throws JSONException, Exception {
     testTaskAttemptIdErrorGeneric("attempt_1234_m_000000_0",
-        "TaskAttemptId string : attempt_1234_m_000000_0 is not properly formed");
+        "java.lang.Exception: TaskAttemptId string : attempt_1234_m_000000_0 is not properly formed");
   }
 
   @Test
   public void testTaskAttemptIdInvalid3() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_1234_m_000000",
-        "TaskAttemptId string : attempt_0_1234_m_000000 is not properly formed");
+        "java.lang.Exception: TaskAttemptId string : attempt_0_1234_m_000000 is not properly formed");
   }
 
   private void testTaskAttemptIdErrorGeneric(String attid, String error)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java
@@ -427,7 +427,7 @@ public class TestHsWebServicesJobs extends JerseyTestBase {
 
   private void verifyJobIdInvalid(String message, String type, String classname) {
     WebServicesTestUtils.checkStringMatch("exception message",
-        "JobId string : job_foo is not properly formed", message);
+        "java.lang.Exception: JobId string : job_foo is not properly formed", message);
     WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
     WebServicesTestUtils.checkStringMatch("exception classname",
         "org.apache.hadoop.yarn.webapp.NotFoundException", classname);
@@ -455,7 +455,7 @@ public class TestHsWebServicesJobs extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "JobId string : bogusfoo is not properly formed", message);
+          "java.lang.Exception: JobId string : bogusfoo is not properly formed", message);
       WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.NotFoundException", classname);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobsQuery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobsQuery.java
@@ -251,7 +251,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
     WebServicesTestUtils.checkStringMatch("exception message",
-        "limit value must be greater then 0", message);
+        "java.lang.Exception: limit value must be greater then 0", message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
     WebServicesTestUtils.checkStringMatch("exception classname",
@@ -371,7 +371,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     WebServicesTestUtils
         .checkStringMatch(
             "exception message",
-            "startedTimeEnd must be greater than startTimeBegin",
+            "java.lang.Exception: startedTimeEnd must be greater than startTimeBegin",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
@@ -397,7 +397,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     WebServicesTestUtils
         .checkStringMatch(
             "exception message",
-            "Invalid number format: For input string: \"efsd\"",
+            "java.lang.Exception: Invalid number format: For input string: \"efsd\"",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
@@ -424,7 +424,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     WebServicesTestUtils
         .checkStringMatch(
             "exception message",
-            "Invalid number format: For input string: \"efsd\"",
+            "java.lang.Exception: Invalid number format: For input string: \"efsd\"",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
@@ -450,7 +450,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     String classname = exception.getString("javaClassName");
     WebServicesTestUtils
         .checkStringMatch("exception message",
-            "startedTimeBegin must be greater than 0",
+            "java.lang.Exception: startedTimeBegin must be greater than 0",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
@@ -476,7 +476,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
     WebServicesTestUtils.checkStringMatch("exception message",
-        "startedTimeEnd must be greater than 0", message);
+        "java.lang.Exception: startedTimeEnd must be greater than 0", message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
     WebServicesTestUtils.checkStringMatch("exception classname",
@@ -501,7 +501,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
     WebServicesTestUtils.checkStringMatch("exception message",
-        "finishedTimeEnd must be greater than 0", message);
+        "java.lang.Exception: finishedTimeEnd must be greater than 0", message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
     WebServicesTestUtils.checkStringMatch("exception classname",
@@ -526,7 +526,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
     WebServicesTestUtils.checkStringMatch("exception message",
-        "finishedTimeBegin must be greater than 0", message);
+        "java.lang.Exception: finishedTimeBegin must be greater than 0", message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
     WebServicesTestUtils.checkStringMatch("exception classname",
@@ -555,7 +555,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     WebServicesTestUtils
         .checkStringMatch(
             "exception message",
-            "finishedTimeEnd must be greater than finishedTimeBegin",
+            "java.lang.Exception: finishedTimeEnd must be greater than finishedTimeBegin",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
@@ -582,7 +582,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     WebServicesTestUtils
         .checkStringMatch(
             "exception message",
-            "Invalid number format: For input string: \"efsd\"",
+            "java.lang.Exception: Invalid number format: For input string: \"efsd\"",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);
@@ -609,7 +609,7 @@ public class TestHsWebServicesJobsQuery extends JerseyTestBase {
     WebServicesTestUtils
         .checkStringMatch(
             "exception message",
-            "Invalid number format: For input string: \"efsd\"",
+            "java.lang.Exception: Invalid number format: For input string: \"efsd\"",
             message);
     WebServicesTestUtils.checkStringMatch("exception type",
         "BadRequestException", type);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesTasks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesTasks.java
@@ -277,7 +277,7 @@ public class TestHsWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringMatch("exception message",
-            "tasktype must be either m or r", message);
+            "java.lang.Exception: tasktype must be either m or r", message);
         WebServicesTestUtils.checkStringMatch("exception type",
             "BadRequestException", type);
         WebServicesTestUtils.checkStringMatch("exception classname",
@@ -377,7 +377,7 @@ public class TestHsWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : " +
+            "java.lang.Exception: TaskId string : " +
             "bogustaskid is not properly formed" +
             "\nReason: java.util.regex.Matcher[pattern=" +
             TaskID.TASK_ID_REGEX + " region=0,11 lastmatch=]", message);
@@ -411,7 +411,7 @@ public class TestHsWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringMatch("exception message",
-            "task not found with id task_0_0000_m_000000", message);
+            "java.lang.Exception: task not found with id task_0_0000_m_000000", message);
         WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
         WebServicesTestUtils.checkStringMatch("exception classname",
             "org.apache.hadoop.yarn.webapp.NotFoundException", classname);
@@ -442,7 +442,7 @@ public class TestHsWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : " +
+            "java.lang.Exception: TaskId string : " +
             "task_0_0000_d_000000 is not properly formed" +
             "\nReason: java.util.regex.Matcher[pattern=" +
             TaskID.TASK_ID_REGEX + " region=0,20 lastmatch=]", message);
@@ -476,7 +476,7 @@ public class TestHsWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : " +
+            "java.lang.Exception: TaskId string : " +
             "task_0000_m_000000 is not properly formed" +
             "\nReason: java.util.regex.Matcher[pattern=" +
             TaskID.TASK_ID_REGEX + " region=0,18 lastmatch=]", message);
@@ -510,7 +510,7 @@ public class TestHsWebServicesTasks extends JerseyTestBase {
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
         WebServicesTestUtils.checkStringEqual("exception message",
-            "TaskId string : " +
+            "java.lang.Exception: TaskId string : " +
             "task_0_0000_m is not properly formed" +
             "\nReason: java.util.regex.Matcher[pattern=" +
             TaskID.TASK_ID_REGEX + " region=0,13 lastmatch=]", message);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/GenericExceptionHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/GenericExceptionHandler.java
@@ -100,10 +100,10 @@ public class GenericExceptionHandler implements ExceptionMapper<Exception> {
     }
 
     // let jaxb handle marshalling data out in the same format requested
-    String errorMessage = e.getMessage();
+    String errorMessage = e.toString();
     Throwable cause = e.getCause();
     if (cause != null) {
-      errorMessage = cause.getMessage();
+      errorMessage = cause.toString();
     }
     RemoteExceptionData exception = new RemoteExceptionData(e.getClass().getSimpleName(),
         errorMessage, e.getClass().getName());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
@@ -336,7 +336,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception cause",
-          "Error: You must specify a non-empty string for the user", message);
+          "java.lang.Exception: Error: You must specify a non-empty string for the user", message);
       WebServicesTestUtils.checkStringMatch("exception type", "BadRequestException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.BadRequestException", classname);
@@ -576,7 +576,8 @@ public class TestNMWebServicesApps extends JerseyTestBase {
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
-      WebServicesTestUtils.checkStringMatch("exception message", "Invalid ApplicationId prefix: " +
+      WebServicesTestUtils.checkStringMatch("exception message", 
+          "java.lang.IllegalArgumentException: Invalid ApplicationId prefix: " +
           "app_foo_0000. The valid ApplicationId should start with prefix application", message);
       WebServicesTestUtils.checkStringMatch("exception type", "BadRequestException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
@@ -610,7 +611,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "app with id application_1234_0009 not found", message);
+          "java.lang.Exception: app with id application_1234_0009 not found", message);
       WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.NotFoundException", classname);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
@@ -292,7 +292,7 @@ public class TestNMWebServicesAuxServices extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "Auxiliary services manifest is not enabled", message);
+          "java.lang.Exception: Auxiliary services manifest is not enabled", message);
       WebServicesTestUtils.checkStringMatch("exception type", "BadRequestException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.BadRequestException", classname);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
@@ -349,7 +349,7 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception cause",
-          "invalid container id, container_foo_1234", message);
+          "java.lang.Exception: invalid container id, container_foo_1234", message);
       WebServicesTestUtils.checkStringMatch("exception type", "BadRequestException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.BadRequestException", classname);
@@ -381,7 +381,7 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception cause",
-          "invalid container id, container_1234_0001", message);
+          "java.lang.Exception: invalid container id, container_1234_0001", message);
       WebServicesTestUtils.checkStringMatch("exception type", "BadRequestException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.BadRequestException", classname);
@@ -414,7 +414,7 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "container with id, container_1234_0001_01_000005, not found",
+          "java.lang.Exception: container with id, container_1234_0001_01_000005, not found",
           message);
       WebServicesTestUtils.checkStringMatch("exception type", "NotFoundException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppAttempts.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppAttempts.java
@@ -255,7 +255,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       checkStringMatch("exception message",
-          "Invalid ApplicationId: application_invalid_12", message);
+          "java.lang.IllegalArgumentException: Invalid ApplicationId: application_invalid_12", message);
       checkStringMatch("exception type", "BadRequestException", type);
       checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.BadRequestException", classname);
@@ -292,7 +292,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       checkStringMatch("exception message",
-          "Invalid AppAttemptId: appattempt_invalid_12_000001", message);
+          "java.lang.IllegalArgumentException: Invalid AppAttemptId: appattempt_invalid_12_000001", message);
       checkStringMatch("exception type", "BadRequestException", type);
       checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.BadRequestException", classname);
@@ -333,7 +333,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       checkStringMatch("exception message",
-          "app with id: application_00000_0099 not found", message);
+          "java.lang.Exception: app with id: application_00000_0099 not found", message);
       checkStringMatch("exception type", "NotFoundException", type);
       checkStringMatch("exception classname",
           "org.apache.hadoop.yarn.webapp.NotFoundException", classname);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
@@ -1223,7 +1223,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringContains("exception message",
-          "Invalid deSelects string"
+          "java.lang.Exception: Invalid deSelects string"
               + " INVALIED_deSelectsParam " + "specified. It should be one of",
           message);
       WebServicesTestUtils.checkStringEqual("exception type",
@@ -1623,7 +1623,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "Invalid ApplicationId: application_invalid_12", message);
+          "java.lang.IllegalArgumentException: Invalid ApplicationId: application_invalid_12", message);
       WebServicesTestUtils.checkStringMatch("exception type",
           "BadRequestException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",
@@ -1665,7 +1665,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
       WebServicesTestUtils.checkStringMatch("exception message",
-          "app with id: application_00000_0099 not found", message);
+          "java.lang.Exception: app with id: application_00000_0099 not found", message);
       WebServicesTestUtils.checkStringMatch("exception type",
           "NotFoundException", type);
       WebServicesTestUtils.checkStringMatch("exception classname",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesHttpStaticUserPermissions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesHttpStaticUserPermissions.java
@@ -192,7 +192,7 @@ public class TestRMWebServicesHttpStaticUserPermissions {
         JSONObject remoteException = errResponse
             .getJSONObject("RemoteException");
         assertEquals(
-            "The default static user cannot carry out "
+            "java.lang.Exception: The default static user cannot carry out "
             + "this operation.",
             remoteException.getString("message"));
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodeLabels.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodeLabels.java
@@ -599,7 +599,7 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
     Response response = addNodeLabels(Lists.newArrayList(Pair.of("a&",
         DEFAULT_NL_EXCLUSIVITY)));
     String expectedMessage =
-        "label name should only contains"
+        "java.io.IOException: label name should only contains"
             + " {0-9, a-z, A-Z, -, _} and should not started with"
             + " {-,_}, now it is= a&";
     validateJsonExceptionContent(response, expectedMessage);
@@ -614,7 +614,7 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
     // new info and change exclusivity
     response = addNodeLabels(Lists.newArrayList(Pair.of("newLabel", false)));
     String expectedMessage =
-        "Exclusivity cannot be modified for an existing"
+        "java.io.IOException: Exclusivity cannot be modified for an existing"
             + " label with : <newLabel:exclusivity=false>";
     validateJsonExceptionContent(response, expectedMessage);
   }
@@ -656,7 +656,7 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
     Response response;
     response = removeNodeLabel("ireallydontexist");
     String expectedMessage =
-        "Node label=ireallydontexist to be"
+        "java.io.IOException: Node label=ireallydontexist to be"
             + " removed doesn't existed in cluster node labels"
             + " collection.";
     validateJsonExceptionContent(response, expectedMessage);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodes.java
@@ -584,7 +584,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
   }
 
   private void verifyNonexistNodeException(String message, String type, String classname) {
-    assertTrue("nodeId, node_invalid:99, is not found".matches(message),
+    assertTrue("java.lang.Exception: nodeId, node_invalid:99, is not found".matches(message),
         "exception message incorrect: " + message);
     assertTrue("NotFoundException".matches(type), "exception type incorrect");
     assertTrue("org.apache.hadoop.yarn.webapp.NotFoundException".matches(classname),


### PR DESCRIPTION
Change-Id: I7c08bd438fe17dfed8641f6883d8dbc9566fc771

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In GenericExceptionHandler's toResponse method we put only the exception message into the RemoteExceptionData object.

It would be a bit more informative if we would use throwable.toString() instead of throwable.getMessage() as the former extends the error message with the exception class as well, similarly to previous versions.

### How was this patch tested?
Tested on a Hadoop cluster

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

