### PR TITLE
HADOOP-19719. Wildfly Followup: TestDelegatingSSLSocketFactory

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -19,12 +19,13 @@
 package org.apache.hadoop.security.ssl;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.util.NativeCodeLoader;
 
-import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class TestDelegatingSSLSocketFactory {
 
   @Test
-  public void testOpenSSL() throws IOException {
+  public void testOpenSSL() {
     assumeTrue(NativeCodeLoader.isNativeCodeLoaded(),
         "Unable to load native libraries");
     assumeTrue(NativeCodeLoader.buildSupportsOpenssl(),
@@ -46,7 +47,14 @@ public class TestDelegatingSSLSocketFactory {
               .getProviderName()).contains("openssl");
     } catch (IOException e) {
       // if this is caused by a wildfly version error, downgrade to an assume
-      assertExceptionContains("GLIBC_2.34", e);
+      final Throwable cause = e.getCause();
+      Assertions.assertThat(cause)
+              .describedAs("Cause of %s: %s", e, cause)
+              .isInstanceOf(NoSuchAlgorithmException.class);
+      final Throwable innermost = cause.getCause();
+      Assertions.assertThat(innermost)
+              .describedAs("Innermost Cause of %s: %s", e, innermost)
+              .isInstanceOf(UnsatisfiedLinkError.class);
       assumeTrue(false, "wildfly library not compatible with this OS version");
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -19,12 +19,12 @@
 package org.apache.hadoop.security.ssl;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.util.NativeCodeLoader;
 
+import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -39,19 +39,16 @@ public class TestDelegatingSSLSocketFactory {
         "Unable to load native libraries");
     assumeTrue(NativeCodeLoader.buildSupportsOpenssl(),
         "Build was not compiled with support for OpenSSL");
-    DelegatingSSLSocketFactory.initializeDefaultFactory(
-            DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
-    assertThat(DelegatingSSLSocketFactory.getDefaultFactory()
-            .getProviderName()).contains("openssl");
+    try {
+      DelegatingSSLSocketFactory.initializeDefaultFactory(
+              DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
+      assertThat(DelegatingSSLSocketFactory.getDefaultFactory()
+              .getProviderName()).contains("openssl");
+    } catch (IOException e) {
+      // if this is caused by a wildfly version error, downgrade to an assume
+      assertExceptionContains("GLIBC_2.34", e);
+      assumeTrue(false, "wildfly library not compatible with this OS version");
+    }
   }
 
-  @Test
-  public void testJSEENoGCMJava8() throws IOException {
-    assumeTrue(System.getProperty("java.version").startsWith("1.8"),
-        "Not running on Java 8");
-    DelegatingSSLSocketFactory.initializeDefaultFactory(
-            DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE);
-    assertThat(Arrays.stream(DelegatingSSLSocketFactory.getDefaultFactory()
-            .getSupportedCipherSuites())).noneMatch("GCM"::contains);
-  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -51,10 +51,6 @@ public class TestDelegatingSSLSocketFactory {
       Assertions.assertThat(cause)
               .describedAs("Cause of %s: %s", e, cause)
               .isInstanceOf(NoSuchAlgorithmException.class);
-      final Throwable innermost = cause.getCause();
-      Assertions.assertThat(innermost)
-              .describedAs("Innermost Cause of %s: %s", e, innermost)
-              .isInstanceOf(UnsatisfiedLinkError.class);
       assumeTrue(false, "wildfly library not compatible with this OS version");
     }
   }


### PR DESCRIPTION

Downgrade to a skipped tests if the OS doesn't have GLIBC_2.34.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

