### PR TITLE
HADOOP-19719. Wildfly Followup: TestDelegatingSSLSocketFactory

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -19,13 +19,14 @@
 package org.apache.hadoop.security.ssl;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.util.NativeCodeLoader;
 
-import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -47,7 +48,10 @@ public class TestDelegatingSSLSocketFactory {
               .getProviderName()).contains("openssl");
     } catch (IOException e) {
       // if this is caused by a wildfly version error, downgrade to an assume
-      assertExceptionContains("GLIBC_2.34", e);
+      final Throwable cause = e.getCause();
+      Assertions.assertThat(cause)
+              .describedAs("Cause of %s: %s", e, cause)
+              .isInstanceOf(NoSuchAlgorithmException.class);
       assumeTrue("wildfly library not compatible with this OS version", false);
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import org.apache.hadoop.util.NativeCodeLoader;
 
+import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -34,15 +35,21 @@ import static org.junit.Assume.assumeTrue;
 public class TestDelegatingSSLSocketFactory {
 
   @Test
-  public void testOpenSSL() throws IOException {
+  public void testOpenSSL() {
     assumeTrue("Unable to load native libraries",
             NativeCodeLoader.isNativeCodeLoaded());
     assumeTrue("Build was not compiled with support for OpenSSL",
             NativeCodeLoader.buildSupportsOpenssl());
-    DelegatingSSLSocketFactory.initializeDefaultFactory(
-            DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
-    assertThat(DelegatingSSLSocketFactory.getDefaultFactory()
-            .getProviderName()).contains("openssl");
+    try {
+      DelegatingSSLSocketFactory.initializeDefaultFactory(
+              DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
+      assertThat(DelegatingSSLSocketFactory.getDefaultFactory()
+              .getProviderName()).contains("openssl");
+    } catch (IOException e) {
+      // if this is caused by a wildfly version error, downgrade to an assume
+      assertExceptionContains("GLIBC_2.34", e);
+      assumeTrue("wildfly library not compatible with this OS version", false);
+    }
   }
 
   @Test


### PR DESCRIPTION

Downgrade to a skipped tests if the OS doesn't have GLIBC_2.34.

The branch-3.4 version of the patch doesn't delete testJSEENoGCMJava8() and uses classic junit assumeTrue() calls.


### How was this patch tested?

Yetus needs to do this

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

