### PR TITLE
YARN-11894. Fix test root directory conflict about TestLogInfo.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLogInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLogInfo.java
@@ -77,6 +77,7 @@ public class TestLogInfo {
 
   @BeforeEach
   public void setup() throws Exception {
+    prepareCleanTestRootDir();
     config.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR.toString());
     HdfsConfiguration hdfsConfig = new HdfsConfiguration();
     hdfsCluster = new MiniDFSCluster.Builder(hdfsConfig).numDataNodes(1).build();
@@ -106,7 +107,24 @@ public class TestLogInfo {
     jsonGenerator.close();
     outStream.close();
     outStreamDomain.close();
+
+    FileSystem hdfsFs = hdfsCluster.getFileSystem();
+    if (hdfsFs.exists(TEST_ROOT_DIR)) {
+      hdfsFs.delete(TEST_ROOT_DIR, true);
+    }
     hdfsCluster.shutdown();
+
+    FileSystem localFs = FileSystem.getLocal(config);
+    if (localFs.exists(TEST_ROOT_DIR)) {
+        localFs.delete(TEST_ROOT_DIR, true);
+    }
+  }
+  /**
+   * Creates a fresh test root directory after cleanup.
+   */
+  private void prepareCleanTestRootDir() throws IOException {
+      FileSystem localFs = FileSystem.getLocal(config);
+      localFs.mkdirs(TEST_ROOT_DIR);
   }
 
   @Test


### PR DESCRIPTION
…s order dependency if other tests are run in between test class.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

In package org.apache.hadoop.yarn.server.timeline, TestLogInfo test, it is sometimes order dependent if interleaved with other tests from other classes. This perhaps suggests some state pollution. In particular, this affects tests

org.apache.hadoop.yarn.server.timeline.TestLogInfo.testMatchesGroupId
org.apache.hadoop.yarn.server.timeline.TestLogInfo.testParseBrokenEntity
org.apache.hadoop.yarn.server.timeline.TestLogInfo.testParseDomain
org.apache.hadoop.yarn.server.timeline.TestLogInfo.testParseEntity

This was addressed by cleaning the file system created in the test directory 

### How was this patch tested?

`mvn test` was run and all previous tests continue to pass.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

