### PR TITLE
YARN-11895. Migrate Yarn Native Service to Jersey2.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1418,9 +1418,7 @@ public class ResourceManager extends CompositeService
         false)) {
       String apiPackages = "org.apache.hadoop.yarn.service.webapp;" +
           "org.apache.hadoop.yarn.webapp";
-      params.put("com.sun.jersey.config.property.resourceConfigClass",
-          "com.sun.jersey.api.core.PackagesResourceConfig");
-      params.put("com.sun.jersey.config.property.packages", apiPackages);
+      params.put("jersey.config.server.provider.packages", apiPackages);
     }
 
     Builder<ResourceManager> builder =


### PR DESCRIPTION
### Description of PR

YARN-11895. Migrate Yarn Native Service to Jersey2.

Currently the YARN Service API can not be accessed from the Resource manager. The issue caused by a missing migration to Jersey2.

### How was this patch tested?

Manually i enabled the `yarn.webapp.api-service.enable` and then i could access the `app/v1/services/version` api

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

