### PR TITLE
HADOOP-19091: Add support for Tez to MagicS3GuardCommitter

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/PathOutputCommitterFactory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/PathOutputCommitterFactory.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.util.ReflectionUtils;
 
@@ -118,6 +119,19 @@ public class PathOutputCommitterFactory extends Configured {
   }
 
   /**
+   * Create an output committer for a job.
+   * @param outputPath output path. This may be null.
+   * @param context context
+   * @return a new committer
+   * @throws IOException problems instantiating the committer
+   */
+  public PathOutputCommitter createOutputCommitter(
+      Path outputPath,
+      JobContext context) throws IOException {
+    return createFileOutputCommitter(outputPath, context);
+  }
+
+  /**
    * Create an instance of the default committer, a {@link FileOutputCommitter}
    * for a task.
    * @param outputPath the task's output path, or or null if no output path
@@ -129,6 +143,14 @@ public class PathOutputCommitterFactory extends Configured {
   protected final PathOutputCommitter createFileOutputCommitter(
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    LOG.debug("Creating FileOutputCommitter for path {} and context {}",
+        outputPath, context);
+    return new FileOutputCommitter(outputPath, context);
+  }
+
+  protected final PathOutputCommitter createFileOutputCommitter(
+      Path outputPath,
+      JobContext context) throws IOException {
     LOG.debug("Creating FileOutputCommitter for path {} and context {}",
         outputPath, context);
     return new FileOutputCommitter(outputPath, context);
@@ -183,6 +205,13 @@ public class PathOutputCommitterFactory extends Configured {
           factory, key);
     }
     return ReflectionUtils.newInstance(factory, conf);
+  }
+
+  public static PathOutputCommitter createCommitter(Path outputPath,
+      JobContext context) throws IOException {
+    return getCommitterFactory(outputPath,
+        context.getConfiguration())
+        .createOutputCommitter(outputPath, context);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/dev-support/findbugs-exclude.xml
+++ b/hadoop-tools/hadoop-aws/dev-support/findbugs-exclude.xml
@@ -86,4 +86,19 @@
     <Method name="submit"/>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
   </Match>
+
+  <Match>
+    <Class name="org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitter"/>
+    <Bug pattern = "CT_CONSTRUCTOR_THROW"/>
+  </Match>
+
+  <Match>
+    <Class name="org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter"/>
+    <Bug pattern = "CT_CONSTRUCTOR_THROW"/>
+  </Match>
+
+  <Match>
+    <Class name="org.apache.hadoop.fs.s3a.commit.staging.StagingCommitter"/>
+    <Bug pattern = "CT_CONSTRUCTOR_THROW"/>
+  </Match>
 </FindBugsFilter>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -414,6 +414,7 @@
                     <exclusion>org.apache.hadoop.fs.s3a.commit.S3ACommitterFactory</exclusion>
                     <exclusion>org.apache.hadoop.fs.s3a.commit.impl.*</exclusion>
                     <exclusion>org.apache.hadoop.fs.s3a.commit.magic.*</exclusion>
+                    <exclusion>org.apache.hadoop.fs.s3a.commit.magic.mapred.*</exclusion>
                     <exclusion>org.apache.hadoop.fs.s3a.commit.staging.*</exclusion>
                   </exclusions>
                   <bannedImports>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitter.java
@@ -252,8 +252,8 @@ public abstract class AbstractS3ACommitter extends PathOutputCommitter
    * @throws IOException on a failure
    */
   protected AbstractS3ACommitter(
-          Path outputPath,
-          JobContext context) throws IOException {
+      Path outputPath,
+      JobContext context) throws IOException {
     super(outputPath, context);
     setOutputPath(outputPath);
     this.jobContext = requireNonNull(context, "null job context");

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitterFactory.java
@@ -58,6 +58,7 @@ public abstract class AbstractS3ACommitterFactory
     return outputCommitter;
   }
 
+  @Override
   public PathOutputCommitter createOutputCommitter(Path outputPath,
                                                    JobContext context) throws IOException {
     FileSystem fs = getDestinationFileSystem(outputPath, context);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/InternalCommitterConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/InternalCommitterConstants.java
@@ -117,6 +117,12 @@ public final class InternalCommitterConstants {
   public static final String SPARK_WRITE_UUID =
       "spark.sql.sources.writeJobUUID";
 
+  /*
+  * The UUID for jobs set by Tez
+  */
+  public static final String JOB_TEZ_UUID =
+      "job.committer.uuid";
+
   /**
    * Java temp dir: {@value}.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/S3ACommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/S3ACommitterFactory.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitterFactory;
 import org.apache.hadoop.fs.s3a.commit.staging.DirectoryStagingCommitterFactory;
 import org.apache.hadoop.fs.s3a.commit.staging.PartitionedStagingCommitterFactory;
 import org.apache.hadoop.fs.s3a.commit.staging.StagingCommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -79,6 +80,29 @@ public class S3ACommitterFactory extends AbstractS3ACommitterFactory {
         context.getConfiguration());
     if (factory != null) {
       PathOutputCommitter committer = factory.createTaskCommitter(
+          fileSystem, outputPath, context);
+      LOG.info("Using committer {} to output data to {}",
+          (committer instanceof AbstractS3ACommitter
+              ? ((AbstractS3ACommitter) committer).getName()
+              : committer.toString()),
+          outputPath);
+      return committer;
+    } else {
+      LOG.warn("Using standard FileOutputCommitter to commit work."
+          + " This is slow and potentially unsafe.");
+      return createFileOutputCommitter(outputPath, context);
+    }
+  }
+
+  @Override
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+      Path outputPath,
+      JobContext context) throws IOException {
+    AbstractS3ACommitterFactory factory = chooseCommitterFactory(fileSystem,
+        outputPath,
+        context.getConfiguration());
+    if (factory != null) {
+      PathOutputCommitter committer = factory.createJobCommitter(
           fileSystem, outputPath, context);
       LOG.info("Using committer {} to output data to {}",
           (committer instanceof AbstractS3ACommitter

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
@@ -85,6 +85,22 @@ public class MagicS3GuardCommitter extends AbstractS3ACommitter {
         getWorkPath());
   }
 
+  /**
+   * Create a job committer.
+   * @param outputPath the job's output path
+   * @param context the job's context
+   * @throws IOException on a failure
+   */
+  public MagicS3GuardCommitter(Path outputPath,
+                               JobContext context) throws IOException {
+    super(outputPath, context);
+    setWorkPath(getJobAttemptPath(context));
+    verifyIsMagicCommitPath(getDestS3AFS(), getWorkPath());
+    LOG.debug("Job attempt {} has work path {}",
+        context.getJobID(),
+        getWorkPath());
+  }
+
   @Override
   public String getName() {
     return NAME;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
@@ -92,7 +92,7 @@ public class MagicS3GuardCommitter extends AbstractS3ACommitter {
    * @throws IOException on a failure
    */
   public MagicS3GuardCommitter(Path outputPath,
-                               JobContext context) throws IOException {
+      JobContext context) throws IOException {
     super(outputPath, context);
     setWorkPath(getJobAttemptPath(context));
     verifyIsMagicCommitPath(getDestS3AFS(), getWorkPath());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -41,6 +42,13 @@ public class MagicS3GuardCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new MagicS3GuardCommitter(outputPath, context);
+  }
+
+  @Override
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+      Path outputPath,
+      JobContext context) throws IOException {
     return new MagicS3GuardCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.fs.s3a.commit.magic.mapred;
 
 import org.apache.hadoop.fs.Path;
@@ -28,18 +29,26 @@ import java.io.IOException;
 
 public class MagicS3GuardCommitter extends OutputCommitter {
 
-  org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter committer = null;
+  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter committer = null;
 
-  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(JobContext context) throws IOException {
+  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(
+          JobContext context) throws IOException {
     if (committer == null) {
-      committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter) PathOutputCommitterFactory.createCommitter(new Path(context.getConfiguration().get("mapred.output.dir")), context);
+      committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter)
+        PathOutputCommitterFactory.createCommitter(
+          new Path(context.getConfiguration().get("mapred.output.dir")),
+          context);
     }
     return committer;
   }
 
-  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(TaskAttemptContext context) throws IOException {
+  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(
+          TaskAttemptContext context) throws IOException {
     if (committer == null) {
-      committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter) MagicS3GuardCommitterFactory.createCommitter(new Path(context.getConfiguration().get("mapred.output.dir")), context);
+      committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter)
+          MagicS3GuardCommitterFactory.createCommitter(
+          new Path(context.getConfiguration().get("mapred.output.dir")),
+          context);
     }
     return committer;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
@@ -27,6 +27,9 @@ import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory;
 
 import java.io.IOException;
 
+/**
+ * This is a mapred wrapper for the MagicS3GuardCommitter.
+ */
 public class MagicS3GuardCommitter extends OutputCommitter {
 
   private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter committer = null;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.s3a.commit.magic.mapred;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitterFactory;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.OutputCommitter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory;
+
+import java.io.IOException;
+
+public class MagicS3GuardCommitter extends OutputCommitter {
+
+  org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter committer = null;
+
+  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(JobContext context) throws IOException {
+    if (committer == null) {
+      committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter) PathOutputCommitterFactory.createCommitter(new Path(context.getConfiguration().get("mapred.output.dir")), context);
+    }
+    return committer;
+  }
+
+  private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(TaskAttemptContext context) throws IOException {
+    if (committer == null) {
+      committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter) MagicS3GuardCommitterFactory.createCommitter(new Path(context.getConfiguration().get("mapred.output.dir")), context);
+    }
+    return committer;
+  }
+
+  @Override
+  public void setupJob(JobContext context) throws IOException {
+    getWrapped(context).setupJob(context);
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext context) throws IOException {
+    getWrapped(context).setupTask(context);
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext context) throws IOException {
+    return getWrapped(context).needsTaskCommit(context);
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext context) throws IOException {
+    getWrapped(context).commitTask(context);
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext context) throws IOException {
+    getWrapped(context).abortTask(context);
+  }
+
+  @Override
+  public void cleanupJob(JobContext context) throws IOException {
+    getWrapped(context).cleanupJob(context);
+  }
+
+  @Override
+  public void commitJob(JobContext context) throws IOException {
+    getWrapped(context).commitJob(context);
+  }
+
+  public final Path getWorkPath() {
+    return committer.getWorkPath();
+  }
+
+  public final Path getOutputPath() {
+    return committer.getOutputPath();
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/package-info.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is the "Magic" committer's mapred wrapper.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.s3a.commit.magic.mapred;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitter.java
@@ -58,6 +58,11 @@ public class DirectoryStagingCommitter extends StagingCommitter {
     super(outputPath, context);
   }
 
+  public DirectoryStagingCommitter(Path outputPath, JobContext context)
+      throws IOException {
+    super(outputPath, context);
+  }
+
   @Override
   public String getName() {
     return NAME;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -42,6 +43,12 @@ public class DirectoryStagingCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new DirectoryStagingCommitter(outputPath, context);
+  }
+
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+                                                 Path outputPath,
+                                                 JobContext context) throws IOException {
     return new DirectoryStagingCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitter.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.s3a.commit.files.PendingSet;
 import org.apache.hadoop.fs.s3a.commit.files.PersistentCommitData;
 import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
 import org.apache.hadoop.fs.s3a.commit.impl.CommitContext;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.util.DurationInfo;
 import org.apache.hadoop.util.functional.TaskPool;
@@ -70,6 +71,12 @@ public class PartitionedStagingCommitter extends StagingCommitter {
 
   public PartitionedStagingCommitter(Path outputPath,
       TaskAttemptContext context)
+      throws IOException {
+    super(outputPath, context);
+  }
+
+  public PartitionedStagingCommitter(Path outputPath,
+      JobContext context)
       throws IOException {
     super(outputPath, context);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -42,6 +43,12 @@ public class PartitionedStagingCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new PartitionedStagingCommitter(outputPath, context);
+  }
+
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+      Path outputPath,
+      JobContext context) throws IOException {
     return new PartitionedStagingCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitter.java
@@ -156,7 +156,7 @@ public class StagingCommitter extends AbstractS3ACommitter {
     Path finalOutputPath = requireNonNull(getOutputPath(),
         "Output path cannot be null");
     S3AFileSystem fs = getS3AFileSystem(finalOutputPath,
-       context.getConfiguration(), false);
+        context.getConfiguration(), false);
     s3KeyPrefix = fs.pathToKey(finalOutputPath);
     LOG.debug("{}: final output path is {}", getRole(), finalOutputPath);
     // forces evaluation and caching of the resolution mode.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitter.java
@@ -134,6 +134,37 @@ public class StagingCommitter extends AbstractS3ACommitter {
     LOG.debug("Conflict resolution mode: {}", mode);
   }
 
+  /**
+   * Committer for a single task attempt.
+   * @param outputPath final output path
+   * @param context job context
+   * @throws IOException on a failure
+   */
+  public StagingCommitter(Path outputPath,
+      JobContext context) throws IOException {
+    super(outputPath, context);
+    this.constructorOutputPath = requireNonNull(getOutputPath(), "output path");
+    Configuration conf = getConf();
+    this.uploadPartSize = conf.getLongBytes(
+        MULTIPART_SIZE, DEFAULT_MULTIPART_SIZE);
+    this.uniqueFilenames = conf.getBoolean(
+        FS_S3A_COMMITTER_STAGING_UNIQUE_FILENAMES,
+        DEFAULT_STAGING_COMMITTER_UNIQUE_FILENAMES);
+    setWorkPath(buildWorkPath(context, getUUID()));
+    this.wrappedCommitter = createWrappedCommitter(context, conf);
+    setOutputPath(constructorOutputPath);
+    Path finalOutputPath = requireNonNull(getOutputPath(),
+        "Output path cannot be null");
+    S3AFileSystem fs = getS3AFileSystem(finalOutputPath,
+       context.getConfiguration(), false);
+    s3KeyPrefix = fs.pathToKey(finalOutputPath);
+    LOG.debug("{}: final output path is {}", getRole(), finalOutputPath);
+    // forces evaluation and caching of the resolution mode.
+    ConflictResolution mode = getConflictResolutionMode(getJobContext(),
+        fs.getConf());
+    LOG.debug("Conflict resolution mode: {}", mode);
+  }
+
   @Override
   public String getName() {
     return NAME;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -43,6 +44,12 @@ public class StagingCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new StagingCommitter(outputPath, context);
+  }
+
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+       Path outputPath,
+       JobContext context) throws IOException {
     return new StagingCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
@@ -82,6 +82,7 @@ import static org.apache.hadoop.fs.s3a.commit.CommitConstants.*;
 import static org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants.E_NO_SPARK_UUID;
 import static org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants.FS_S3A_COMMITTER_UUID;
 import static org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants.FS_S3A_COMMITTER_UUID_SOURCE;
+import static org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants.JOB_TEZ_UUID;
 import static org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants.SPARK_WRITE_UUID;
 import static org.apache.hadoop.fs.s3a.Statistic.COMMITTER_TASKS_SUCCEEDED;
 import static org.apache.hadoop.fs.s3a.commit.magic.MagicCommitTrackerUtils.isTrackMagicCommitsInMemoryEnabled;
@@ -1775,6 +1776,37 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
   }
 
   /**
+   * Verify Tez-generated UUID logic.
+   */
+  @Test
+  public void testTezGeneratedUUID() throws Throwable {
+    describe("Create committer with Tez-generated UUID and see if it accepts it");
+    Configuration conf = getConfiguration();
+
+    unsetUUIDOptions(conf);
+    // job must pull Tez-generated UUID
+    conf.set(InternalCommitterConstants.JOB_TEZ_UUID, "dag-application654444302_10");
+
+    // create the job. don't write anything
+    JobData jobData = startJob(false);
+    AbstractS3ACommitter committer = jobData.committer;
+    String uuid = committer.getUUID();
+    Assertions.assertThat(committer.getUUIDSource())
+            .describedAs("UUID source of %s", committer)
+            .isEqualTo(AbstractS3ACommitter.JobUUIDSource.TezJobUUID);
+
+    // examine the job configuration and verify that it has been updated
+    Configuration jobConf = jobData.conf;
+    Assertions.assertThat(jobConf.get(FS_S3A_COMMITTER_UUID, null))
+            .describedAs("Config option " + FS_S3A_COMMITTER_UUID)
+            .isEqualTo(uuid);
+    Assertions.assertThat(jobConf.get(FS_S3A_COMMITTER_UUID_SOURCE, null))
+            .describedAs("Config option " + FS_S3A_COMMITTER_UUID_SOURCE)
+            .isEqualTo(AbstractS3ACommitter.JobUUIDSource.TezJobUUID
+                    .getText());
+  }
+
+  /**
    * Verify the option to require a UUID applies and
    * when a committer is instantiated without those options,
    * it fails early.
@@ -1799,6 +1831,7 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
    * @return the patched config
    */
   protected Configuration unsetUUIDOptions(final Configuration conf) {
+    conf.unset(JOB_TEZ_UUID);
     conf.unset(SPARK_WRITE_UUID);
     conf.unset(FS_S3A_COMMITTER_UUID);
     conf.unset(FS_S3A_COMMITTER_GENERATE_UUID);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
@@ -225,7 +225,8 @@ public class ITestMagicCommitProtocol extends AbstractITCommitProtocol {
     TaskAttemptContext tContext = new TaskAttemptContextImpl(
             getConfiguration(),
             getTaskAttempt0());
-    JobContext jobContext = new JobContextImpl(new JobConf(getConfiguration()), tContext.getJobID());
+    JobContext jobContext = new JobContextImpl(
+        new JobConf(getConfiguration()), tContext.getJobID());
     MagicS3GuardCommitter committer1 = createCommitter(getOutDir(), tContext);
     MagicS3GuardCommitter committer2 = new MagicS3GuardCommitter(getOutDir(), jobContext);
     //Task specific segment of working path is 3 levels deep beyond the job specific segment

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
@@ -25,6 +25,10 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContextImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
@@ -214,6 +218,19 @@ public class ITestMagicCommitProtocol extends AbstractITCommitProtocol {
         .doesNotContain("/" + MAGIC_PATH_PREFIX + committer.getUUID() + "/")
         .doesNotContain(BASE)
         .contains(ta0);
+  }
+
+  @Test
+  public void testCommitterJobContextPath() throws Throwable {
+    TaskAttemptContext tContext = new TaskAttemptContextImpl(
+            getConfiguration(),
+            getTaskAttempt0());
+    JobContext jobContext = new JobContextImpl(new JobConf(getConfiguration()), tContext.getJobID());
+    MagicS3GuardCommitter committer1 = createCommitter(getOutDir(), tContext);
+    MagicS3GuardCommitter committer2 = new MagicS3GuardCommitter(getOutDir(), jobContext);
+    //Task specific segment of working path is 3 levels deep beyond the job specific segment
+    Assertions.assertThat(committer2.getJobAttemptPath(jobContext))
+        .isEqualTo(committer1.getTaskAttemptPath(tContext).getParent().getParent().getParent());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobContextImpl;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
 
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;


### PR DESCRIPTION
This commit adds a MRv1 wrapper for the MagicS3GuardCommitter so applications like Hive can use it.

How was this patch tested?
The ITest suite was run with the changes in the us-east1 region. Two tests were added to test the code to handle Tez-generated UUIDs, and to check that the output path generated by the JobContext codepath matches the prefix of the one generated by the TaskAttemptContext codepath.

Exactly one test failed, with a timeout error. I've seen this error before, and I don't think it has anything to do with my change.

[ERROR] org.apache.hadoop.fs.s3a.impl.ITestConnectionTimeouts.testObjectUploadTimeouts -- Time elapsed: 18.71 s <<< FAILURE!
java.lang.AssertionError:
[Duration of write]
Expecting:
<PT16.212S>
to be less than:

at org.apache.hadoop.fs.s3a.impl.ITestConnectionTimeouts.testObjectUploadTimeouts(ITestConnectionTimeouts.java:247)
at java.lang.reflect.Method.invoke(Method.java:498)
at java.util.ArrayList.forEach(ArrayList.java:1259)
at java.util.ArrayList.forEach(ArrayList.java:1259)