### PR TITLE
HADOOP-19743. S3A: ITestS3ACommitterMRJob MR process OOM on java17

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/integration/ITestS3ACommitterMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/integration/ITestS3ACommitterMRJob.java
@@ -278,7 +278,7 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
       Path log4jPath = new Path(log4j.toURI());
       LOG.debug("Using log4j path {}", log4jPath);
       mrJob.addFileToClassPath(log4jPath);
-      String sysprops = String.format("-Xmx128m -Dlog4j.configuration=%s",
+      String sysprops = String.format("-Xmx256m -Dlog4j.configuration=%s",
           log4j);
       jobConf.set(JobConf.MAPRED_MAP_TASK_JAVA_OPTS, sysprops);
       jobConf.set(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS, sysprops);


### PR DESCRIPTION

Contributed by Steve Loughran




### How was this patch tested?

running ITestS3ACommitterMRJob from IDE and CLI.

Saw a new error message coming from #8061 ; reported it on the JIRA.
```
[INFO] Running org.apache.hadoop.fs.s3a.commit.integration.ITestS3ACommitterMRJob
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.apache.hadoop.security.authentication.util.SubjectUtil (file:/Users/stevel/.m2/repository/org/apache/hadoop/hadoop-auth/3.5.0-SNAPSHOT/hadoop-auth-3.5.0-SNAPSHOT.jar)
WARNING: Please consider reporting this to the maintainers of org.apache.hadoop.security.authentication.util.SubjectUtil
WARNING: System::setSecurityManager will be removed in a future release
```


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

