### PR TITLE
HADOOP-19744. Do not use SecurityManager in SubjectUtil.checkThreadInheritsSubject

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -90,20 +90,17 @@ public final class SubjectUtil {
    */
   private static boolean checkThreadInheritsSubject() {
 
-    boolean securityManagerEnabled = true;
-    try {
-      // TODO this needs SecurityManager to compile, use reflection to look it up instead
-      SecurityManager sm = System.getSecurityManager();
-      System.setSecurityManager(sm);
-    } catch (UnsupportedOperationException e) {
-      // JDK24+ unconditionally throws this, so we don't need to check for JDK24+
-      // explicitly
-      securityManagerEnabled = false;
-    } catch (Throwable t) {
-      // don't care
+    if (JAVA_SPEC_VER <= 21) {
+      return true;
+    } else {
+      // 24+ never inherits the Subject.
+      // For 22 and 23 the behavior actually depends on whether the SecurityManager
+      // is enabled, but this check is only used to enable a minor performance
+      // optimization of bypassing a doAs/callAs call in SubjectInheritingThread.
+      // We accept that possible minor performance cost to avoid extra complexity
+      // and prevent the HVM from logging SecurityManager warnings to console.
+      return false;
     }
-
-    return JAVA_SPEC_VER < 22 || securityManagerEnabled;
   }
 
   /**

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -95,10 +95,11 @@ public final class SubjectUtil {
     } else {
       // 24+ never inherits the Subject.
       // For 22 and 23 the behavior actually depends on whether the SecurityManager
-      // is enabled, but this check is only used to enable a minor performance
-      // optimization of bypassing a doAs/callAs call in SubjectInheritingThread.
-      // We accept that possible minor performance cost to avoid extra complexity
-      // and prevent the HVM from logging SecurityManager warnings to console.
+      // is enabled, but this check is only used to determine whether a doAs/callAs
+      // call can be optimized out in SubjectInheritingThread and Daemon.
+      // We accept that possible minor performance cost for those EOL non-LTS versions
+      // to avoid the extra complexity and to prevent the JVM from logging
+      // SecurityManager warnings to the console.
       return false;
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/concurrent/TestSubjectPropagation.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/concurrent/TestSubjectPropagation.java
@@ -151,7 +151,7 @@ public class TestSubjectPropagation {
       assertEquals(parentSubject, childSubject);
     } else {
       // This is the behaviour that breaks Hadoop authorization
-      // This would break for Java 22-23 if the SecurityManager would be enabled,
+      // This would fail for Java 22-23 if the SecurityManager would be enabled,
       // but we don't run tests with the SecurityManager enabled.
       assertNull(childSubject);
     }
@@ -182,7 +182,7 @@ public class TestSubjectPropagation {
       assertEquals(parentSubject, childSubject);
     } else {
       // This is the behaviour that breaks Hadoop authorization
-      // This would break for Java 22-23 if the SecurityManager would be enabled,
+      // This would fail for Java 22-23 if the SecurityManager would be enabled,
       // but we don't run tests with the SecurityManager enabled.
       assertNull(childSubject);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/concurrent/TestSubjectPropagation.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/concurrent/TestSubjectPropagation.java
@@ -147,9 +147,12 @@ public class TestSubjectPropagation {
     });
 
     if (SubjectUtil.THREAD_INHERITS_SUBJECT) {
+
       assertEquals(parentSubject, childSubject);
     } else {
       // This is the behaviour that breaks Hadoop authorization
+      // This would break for Java 22-23 if the SecurityManager would be enabled,
+      // but we don't run tests with the SecurityManager enabled.
       assertNull(childSubject);
     }
   }
@@ -179,6 +182,8 @@ public class TestSubjectPropagation {
       assertEquals(parentSubject, childSubject);
     } else {
       // This is the behaviour that breaks Hadoop authorization
+      // This would break for Java 22-23 if the SecurityManager would be enabled,
+      // but we don't run tests with the SecurityManager enabled.
       assertNull(childSubject);
     }
   }


### PR DESCRIPTION
### Description of PR

Remove SecurityManager dependent logic for determining if we can optimize out the doAs()/callAs() methods in
SubjectInheritingThread and Daemon on JDK 22 and 23, and assume that we cannot optimize them out.

### How was this patch tested?

Ran TestSubjectPropagation with Java 17,21,23,24,25.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

