### PR TITLE
YARN-11902.Fix build failure caused by mktemp@2.0.2

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/package.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/package.json
@@ -61,6 +61,7 @@
   },
   "resolutions": {
     "graceful-fs": "^4.2.4",
-    "node-gyp": "5.1.1"
+    "node-gyp": "5.1.1",
+    "mktemp": "0.4.0"
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: YARN-11902. Fix Hadoop Yarn UI build failure caused by mktemp@2.0.2.

A build failure occurs in the Yarn UI module during dependency installation due to an incompatible version of mktemp@2.0.2, which enforces a Node.js engine requirement of 20 || 22 || 24.
The current Hadoop build environment uses Node.js 12.22.1, resulting in the following error:

`error mktemp@2.0.2: The engine "node" is incompatible with this module. 
Expected version "20 || 22 || 24". Got "12.22.1"
error Found incompatible module.`

- Root Cause
The mktemp package was pulled in as a transitive dependency.
Version 2.x introduced a strict Node.js engine requirement (≥20), which is incompatible with the current Node 12 environment.

- Fix
Pinned the mktemp dependency to a compatible version (0.4.0) using Yarn's resolutions block in package.json:
`"resolutions": {
  "mktemp": "0.4.0"
}`
This resolves the build failure without requiring a Node.js upgrade.

### How was this patch tested?
ci

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?