### PR TITLE
HADOOP-19559. [Backport] Fixes failing unit tests.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -227,6 +227,7 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
 
   @Override
   protected void abortInFinalizer() {
+    getS3AStreamStatistics().streamLeaked();
     try {
       close();
     } catch (IOException ignored) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AInputStreamLeakage.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AInputStreamLeakage.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assume;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_LEAKS;
 import static org.apache.hadoop.test.GenericTestUtils.LogCapturer.captureLogs;
@@ -88,10 +87,6 @@ public class ITestS3AInputStreamLeakage extends AbstractS3ATestBase {
   @Test
   public void testFinalizer() throws Throwable {
     Path path = methodPath();
-    // Analytics accelerator currently does not support stream leak detection. This work is tracked
-    // in https://issues.apache.org/jira/browse/HADOOP-19451
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support leak detection");
 
     final S3AFileSystem fs = getFileSystem();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -619,7 +619,7 @@ public final class S3ATestUtils {
 
   public static boolean isAnalyticsAcceleratorEnabled(final Configuration conf) {
     return conf.get(INPUT_STREAM_TYPE,
-        INPUT_STREAM_TYPE_CLASSIC).equals(INPUT_STREAM_TYPE_ANALYTICS);
+        INPUT_STREAM_TYPE_ANALYTICS).equals(INPUT_STREAM_TYPE_ANALYTICS);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/streams/TestStreamFactories.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/streams/TestStreamFactories.java
@@ -55,14 +55,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestStreamFactories extends AbstractHadoopTestBase {
 
   /**
-   * The empty string and "default" both map to the classic stream.
+   * The empty string and "default" both map to the analytics stream.
    */
   @Test
   public void testDefaultFactoryCreation() throws Throwable {
     load("", DEFAULT_STREAM_TYPE,
-        ClassicObjectInputStreamFactory.class);
+        AnalyticsStreamFactory.class);
     load(INPUT_STREAM_TYPE_DEFAULT, DEFAULT_STREAM_TYPE,
-        ClassicObjectInputStreamFactory.class);
+        AnalyticsStreamFactory.class);
   }
 
   /**
@@ -71,7 +71,7 @@ public class TestStreamFactories extends AbstractHadoopTestBase {
   @Test
   public void testClassicFactoryCreation() throws Throwable {
     final ClassicObjectInputStreamFactory f =
-        load(INPUT_STREAM_TYPE_CLASSIC, DEFAULT_STREAM_TYPE,
+        load(INPUT_STREAM_TYPE_CLASSIC, InputStreamType.Classic,
             ClassicObjectInputStreamFactory.class);
     final StreamFactoryRequirements requirements = f.factoryRequirements();
     Assertions.assertThat(requirements.requiresFuturePool())


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Backport of https://github.com/apache/hadoop/pull/8109

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

