### PR TITLE
HDFS-17861. The mis-behavior of commitBlockSynchronization may cause standby namenode and observer namenode crash.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4107,6 +4107,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         boolean remove = iFile.removeLastBlock(blockToDel) != null;
         if (remove) {
           blockManager.removeBlock(storedBlock);
+          FSDirWriteFileOp.persistBlocks(dir, src, iFile, false);
         }
       } else {
         // update last block

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBlockRecoveryCauseStandbyNameNodeCrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBlockRecoveryCauseStandbyNameNodeCrash.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.Whitebox;
+import org.apache.hadoop.util.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestBlockRecoveryCauseStandbyNameNodeCrash {
+  public static final Logger LOG = LoggerFactory
+      .getLogger(TestBlockRecoveryCauseStandbyNameNodeCrash.class);
+  private final ErasureCodingPolicy ecPolicy =
+      StripedFileTestUtil.getDefaultECPolicy();
+  private final int dataBlocks = ecPolicy.getNumDataUnits();
+  private final int parityBlocks = ecPolicy.getNumParityUnits();
+  private final int cellSize = ecPolicy.getCellSize();
+  private final int stripeSize = dataBlocks * cellSize;
+  private final int stripesPerBlock = 4;
+  private final int blockSize = cellSize * stripesPerBlock;
+
+  private final String fakeUsername = "fakeUser1";
+  private final String fakeGroup = "supergroup";
+
+  private MiniDFSCluster cluster;
+  private DistributedFileSystem dfs;
+  private Configuration conf;
+  private Configuration newConf;
+  private final Path dir = new Path("/" + this.getClass().getSimpleName());
+  private Path p = new Path(dir, "testfile");
+
+  @BeforeEach
+  public void setup() throws IOException {
+    conf = new HdfsConfiguration();
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
+    conf.setLong(HdfsClientConfigKeys.DFS_CLIENT_SOCKET_TIMEOUT_KEY, 60000L);
+    conf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1);
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY, 0);
+    conf.setInt(DFSConfigKeys.DFS_HA_LOGROLL_PERIOD_KEY, 1);
+    conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
+    final int numDNs = dataBlocks + parityBlocks;
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(numDNs)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology(2, 50070))
+        .build();
+    cluster.waitActive();
+    cluster.transitionToActive(0);
+    newConf = cluster.getConfiguration(0);
+    dfs = cluster.getFileSystem(0);
+    dfs.enableErasureCodingPolicy(ecPolicy.getName());
+    dfs.mkdirs(dir);
+    dfs.setErasureCodingPolicy(dir, ecPolicy.getName());
+  }
+
+
+  @AfterEach
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * 1. PauseIBR on some datanodes and write 25MB data (two block groups).
+   * 2. Mock client quiet exceptionally.
+   * 3. Trigger lease recovery.
+   * 4. Standby NameNode crashed.
+   */
+  @Test
+  public void testCommitBlockSynchronizationWithDeleteECBlockgroupCommitted() {
+    int curCellSize = (int) 1024 * 1024;
+    try {
+      for (int i = 0; i < parityBlocks + 1; i++) {
+        DataNodeTestUtils.pauseIBR(cluster.getDataNodes().get(i));
+      }
+      final FSDataOutputStream out = dfs.create(p);
+      final DFSStripedOutputStream stripedOut = (DFSStripedOutputStream) out
+          .getWrappedStream();
+      // 
+      for (int pos = 0; pos < (stripesPerBlock * dataBlocks + 1) * curCellSize; pos++) {
+        out.write(StripedFileTestUtil.getByte(pos));
+      }
+      for (int i = 0; i < dataBlocks + parityBlocks; i++) {
+        StripedDataStreamer s = stripedOut.getStripedDataStreamer(i);
+        waitStreamerAllAcked(s);
+        stopBlockStream(s);
+      }
+      recoverLease();
+      LOG.info("Trigger recover lease manually successfully.");
+    } catch (Throwable e) {
+      String msg = "failed testCase" + StringUtils.stringifyException(e);
+      fail(msg);
+    } finally {
+      for (int i = 0; i < parityBlocks + 1; i++) {
+        DataNodeTestUtils.resumeIBR(cluster.getDataNodes().get(i));
+      }
+    }
+  }
+
+  /**
+   * Stop the block stream without immediately inducing a hard failure.
+   * Packets can continue to be queued until the streamer hits a socket timeout.
+   *
+   * @param s
+   * @throws Exception
+   */
+  private void stopBlockStream(StripedDataStreamer s) throws Exception {
+    IOUtils.NullOutputStream nullOutputStream = new IOUtils.NullOutputStream();
+    Whitebox.setInternalState(s, "blockStream",
+        new DataOutputStream(nullOutputStream));
+  }
+
+  private void recoverLease() throws Exception {
+    final DistributedFileSystem dfs2 =
+        (DistributedFileSystem) getFSAsAnotherUser(newConf);
+    try {
+      GenericTestUtils.waitFor(new Supplier<Boolean>() {
+        @Override
+        public Boolean get() {
+          try {
+            return dfs2.recoverLease(p);
+          } catch (IOException e) {
+            LOG.info("BZL#Test. recoverLease() failed: " + e.getMessage());
+            return false;
+          }
+        }
+      }, 5000, 24000);
+    } catch (TimeoutException e) {
+      throw new IOException("Timeout waiting for recoverLease()");
+    }
+  }
+
+  private FileSystem getFSAsAnotherUser(final Configuration c)
+      throws IOException, InterruptedException {
+    return FileSystem.get(FileSystem.getDefaultUri(c), c,
+        UserGroupInformation
+            .createUserForTesting(fakeUsername, new String[]{fakeGroup})
+            .getUserName());
+  }
+
+  public static void waitStreamerAllAcked(DataStreamer s) throws IOException {
+    long toWaitFor = s.getLastQueuedSeqno();
+    s.waitForAckedSeqno(toWaitFor);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBlockRecoveryCauseStandbyNameNodeCrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBlockRecoveryCauseStandbyNameNodeCrash.java
@@ -50,7 +50,6 @@ public class TestBlockRecoveryCauseStandbyNameNodeCrash {
   private final int dataBlocks = ecPolicy.getNumDataUnits();
   private final int parityBlocks = ecPolicy.getNumParityUnits();
   private final int cellSize = ecPolicy.getCellSize();
-  private final int stripeSize = dataBlocks * cellSize;
   private final int stripesPerBlock = 4;
   private final int blockSize = cellSize * stripesPerBlock;
 
@@ -111,7 +110,6 @@ public class TestBlockRecoveryCauseStandbyNameNodeCrash {
       final FSDataOutputStream out = dfs.create(p);
       final DFSStripedOutputStream stripedOut = (DFSStripedOutputStream) out
           .getWrappedStream();
-      // 
       for (int pos = 0; pos < (stripesPerBlock * dataBlocks + 1) * curCellSize; pos++) {
         out.write(StripedFileTestUtil.getByte(pos));
       }
@@ -136,7 +134,7 @@ public class TestBlockRecoveryCauseStandbyNameNodeCrash {
    * Stop the block stream without immediately inducing a hard failure.
    * Packets can continue to be queued until the streamer hits a socket timeout.
    *
-   * @param s
+   * @param s the streamer to stop.
    * @throws Exception
    */
   private void stopBlockStream(StripedDataStreamer s) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBlockRecoveryCauseStandbyNameNodeCrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBlockRecoveryCauseStandbyNameNodeCrash.java
@@ -86,7 +86,6 @@ public class TestBlockRecoveryCauseStandbyNameNodeCrash {
     dfs.setErasureCodingPolicy(dir, ecPolicy.getName());
   }
 
-
   @AfterEach
   public void tearDown() {
     if (cluster != null) {


### PR DESCRIPTION
### Description of PR
Recently, our standby namenode and observer namenode crash suddenly.  The error stack is as below :

```java
2025-11-18 17:47:51,092 ERROR org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader: Encountered exception on operation CloseOp [length=0, inodeId=0, path=/user/luca/data-pre/dc/Bee-Training-Data-Stage1/dir=data/.20251118161754_13.tgz.downloading, replication=1, mtime=1763459209763, atime=1763453874541, blockSize=33554432, blocks=[blk_-9223372036154510304_120502284, blk_-9223372036154398096_120522931], permissions=luca:luca:rw-r--r--, aclEntries=null, clientName=, clientMachine=, overwrite=false, storagePolicyId=0, erasureCodingPolicyId=0, opCode=OP_CLOSE, txid=564395272]
java.io.IOException: Mismatched block IDs or generation stamps, attempting to replace block blk_-9223372036154398096_120505068 with blk_-9223372036154398096_120522931 as block # 1/2 of /user/luca/data-pre/dc/Bee-Training-Data-Stage1/dir=data/.20251118161754_13.tgz.downloading
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.updateBlocks(FSEditLogLoader.java:1145)
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.applyEditLogOp(FSEditLogLoader.java:498)
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.loadEditRecords(FSEditLogLoader.java:288)
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.loadFSEdits(FSEditLogLoader.java:183)
        at org.apache.hadoop.hdfs.server.namenode.FSImage.loadEdits(FSImage.java:915)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer.doTailEdits(EditLogTailer.java:364)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread.doWork(EditLogTailer.java:505)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread.access$400(EditLogTailer.java:451)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread$1.run(EditLogTailer.java:468)
        at org.apache.hadoop.security.SecurityUtil.doAsLoginUserOrFatal(SecurityUtil.java:503)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread.run(EditLogTailer.java:464)

2025-11-18 17:47:51,094 ERROR org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer: Unknown error encountered while tailing edits. Shutting down standby NN.
java.io.IOException: Mismatched block IDs or generation stamps, attempting to replace block blk_-9223372036154398096_120505068 with blk_-9223372036154398096_120522931 as block # 1/2 of /user/luca/data-pre/dc/Bee-Training-Data-Stage1/dir=data/.20251118161754_13.tgz.downloading
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.updateBlocks(FSEditLogLoader.java:1145)
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.applyEditLogOp(FSEditLogLoader.java:498)
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.loadEditRecords(FSEditLogLoader.java:288)
        at org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader.loadFSEdits(FSEditLogLoader.java:183)
        at org.apache.hadoop.hdfs.server.namenode.FSImage.loadEdits(FSImage.java:915)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer.doTailEdits(EditLogTailer.java:364)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread.doWork(EditLogTailer.java:505)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread.access$400(EditLogTailer.java:451)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread$1.run(EditLogTailer.java:468)
        at org.apache.hadoop.security.SecurityUtil.doAsLoginUserOrFatal(SecurityUtil.java:503)
        at org.apache.hadoop.hdfs.server.namenode.ha.EditLogTailer$EditLogTailerThread.run(EditLogTailer.java:464)
2025-11-18 17:47:51,096 INFO org.apache.hadoop.util.ExitUtil: Exiting with status 1: java.io.IOException: Mismatched block IDs or generation stamps, attempting to replace block blk_-9223372036154398096_120505068 with blk_-9223372036154398096_120522931 as block # 1/2 of /user/luca/data-pre/dc/Bee-Training-Data-Stage1/dir=data/.20251118161754_13.tgz.downloading
```

There are also some other logs:

```java
2025-11-18 17:26:49,228 INFO org.apache.hadoop.hdfs.server.namenode.FSNamesystem: commitBlockSynchronization(oldBlock=BP-1615086879-nn-1719219336538:blk_-9223372036154287024_120510825, newgenerationstamp=120517330, newlength=0, newtargets=[null:0, null:0, null:0, null:0, dn1:50010, dn2:50010], closeFile=true, deleteBlock=true)

2025-11-18 17:26:49,229 WARN org.apache.hadoop.ipc.Server: IPC Server handler 433 on default port 8022, call Call#27747 Retry#0 org.apache.hadoop.hdfs.server.protocol.DatanodeProtocol.commitBlockSynchronization from 10.104.16.99:40332
java.lang.IllegalStateException: Unexpected block state: blk_-9223372036154398096_120505068 is COMMITTED but not COMPLETE, file=.20251118161754_13.tgz.downloading (INodeFile), blocks=[blk_-9223372036154510304_120502284, blk_-9223372036154398096_120505068] (i=1)
        at org.apache.hadoop.hdfs.server.namenode.INodeFile.assertAllBlocksComplete(INodeFile.java:356)
        at org.apache.hadoop.hdfs.server.namenode.INodeFile.toCompleteFile(INodeFile.java:344)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.finalizeINodeFileUnderConstruction(FSNamesystem.java:3986)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.closeFileCommitBlocks(FSNamesystem.java:4227)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.commitBlockSynchronization(FSNamesystem.java:4189)
        at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.commitBlockSynchronization(NameNodeRpcServer.java:1033)
        at org.apache.hadoop.hdfs.protocolPB.DatanodeProtocolServerSideTranslatorPB.commitBlockSynchronization(DatanodeProtocolServerSideTranslatorPB.java:302)
        at org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos$DatanodeProtocolService$2.callBlockingMethod(DatanodeProtocolProtos.java:33863)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:643)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:609)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:593)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1140)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1133)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1052)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:688)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:423)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1973)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:3200)


2025-11-18 17:46:49,763 INFO org.apache.hadoop.hdfs.server.namenode.FSNamesystem: commitBlockSynchronization(oldBlock=BP-1615086879-nn-1719219336538:blk_-9223372036154398096_120505068, newgenerationstamp=120522931, newlength=125829120, newtargets=[dn:50010, null:0, null:0, dn:50010, dn:50010, dn:50010], closeFile=true, deleteBlock=false)

2025-11-18 17:46:49,763 INFO org.apache.hadoop.hdfs.server.namenode.FSNamesystem: commitBlockSynchronization(oldBlock=BP-1615086879-10.104.16.4-1719219336538:blk_-9223372036154398096_120505068, file=/user/luca/data-pre/dc/Bee-Training-Data-Stage1/dir=data/.20251118161754_13.tgz.downloading, newgenerationstamp=120522931, newlength=125829120, newtargets=[dn:50010, null:0, null:0, dn:50010, dn:50010, dn:50010]) successful
```

After diving into FSNamesystem#commitBlockSynchronizationsource method, we find the root cause of this critical problem is as below:
1、`deleteblock == true`, So we remove a block of INodeFile successfully.
2、`closeFile == true`，we try to closeFileCommitBlocks.
3、 In method closeFileCommitBlocks,  we met an `IllegalStateException Exception`, this cause edit log write failed.
At this moment,  the blocks metadatas in active namenode are different from standby(or observer) namenode.
4、In the next block recovery progress, all operations are success. we write an OP_CLOSE edit log.
5、Standby namenode apply that OP_CLOSE edit log and found metadata not match， then crashed.

Below are the key codes snippets:

```java
      if (deleteblock) {
        Block blockToDel = ExtendedBlock.getLocalBlock(oldBlock);
        boolean remove = iFile.removeLastBlock(blockToDel) != null;
        if (remove) {
          blockManager.removeBlock(storedBlock);
        }
      }
      
     xxxxx
       
      if (closeFile) {
        if(copyTruncate) {
          closeFileCommitBlocks(src, iFile, truncatedBlock);
          if(!iFile.isBlockInLatestSnapshot(storedBlock)) {
            blockManager.removeBlock(storedBlock);
          }
        } else {
           // We met exceptions here, so edit log was not synced to standby successfully.
          closeFileCommitBlocks(src, iFile, storedBlock);
        }
      } else {
        // If this commit does not want to close the file, persist blocks
        FSDirWriteFileOp.persistBlocks(dir, src, iFile, false);
      }
```


# How to test ?
Add an unit test. The result is as below:

Before applying this patch:

<img width="1900" height="666" alt="image" src="https://github.com/user-attachments/assets/22b95402-b9fa-42d6-a2a1-779f5b381863" />

