### PR TITLE
YARN-10423: adding a working YARN UI2 for application diagnostic

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -283,6 +283,9 @@
                         <goals>
                             <goal>yarn</goal>
                         </goals>
+                        <configuration>
+                            <arguments>install --ignore-engines</arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/adapters/common-issue.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/adapters/common-issue.js
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import RESTAbstractAdapter from './restabstract';
+
+export default RESTAbstractAdapter.extend({
+    address: "rmWebAddress",
+    restNameSpace: "cluster",
+    serverName: "RM",
+
+    // Call, store.findAll('common-issue')
+    urlForFindAll(){
+        var url = this._buildURL();
+        url = url + '/common-issues/list';
+        console.log('diagnostics url list: ', url);
+        return url;
+
+    },
+
+    urlForQuery(query){
+        let url = this._buildURL();
+
+        if(query.issueId && query.appId){
+            let finalUrl = `${url}/common-issues/collect?issueId=${query.issueId}&args=${query.appId}`;
+            console.log('diagnostics url problems: ', finalUrl);
+            delete query.issueId;
+            delete query.appId;
+
+            return finalUrl;
+        }
+
+        return `${url}/common-issues`;
+
+    }
+
+})

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/controllers/yarn-app/info.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/controllers/yarn-app/info.js
@@ -23,8 +23,45 @@ export default Ember.Controller.extend({
   service: undefined,
   isLoading: false,
   actionResponse: null,
+  diagnosticResult: null,
 
   actions: {
+
+    runDiagnostic(issueId){
+      this.set('isLoading', true);
+      this.set('diagnosticResult', null);
+      this.set('diagnosticIssueId', issueId);
+
+      const appId = this.get('model.appId');
+      const adapter = this.store.adapterFor('common-issue');
+      const url = adapter.urlForQuery({ issueId, appId});
+
+      fetch(url)
+          .then(function (response){
+            if(!response.ok){
+              throw new Error("Network response was not ok");
+            }
+            return response.json();
+          })
+          .then((data) => {
+            this.set('diagnosticResult', data.file || []);
+          })
+          .catch(() => {
+            this.set('actionResponse', { msg: 'Diagnostic Failed!', type: 'error'});
+          })
+          .finally(() => {
+            this.set('isLoading', false);
+          });
+    },
+
+    downloadFile(file) {
+      const blob = new Blob([file.content], {type: file.contentType || 'text/plain'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = file.filename || "diagnostic.txt";
+      a.click();
+    },
+
     showStopServiceConfirm() {
       this.set('actionResponse', null);
       Ember.$("#stopServiceConfirmDialog").modal('show');

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/common-issue.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/common-issue.js
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+    issueData: DS.attr('string', {defaultValue: ''}),
+    file: DS.attr('string', {defaultValue: ''}),
+    filename: DS.attr('string', {defaultValue: ''}),
+    content: DS.attr('string', {defaultValue: ''}),
+    contentType: DS.attr('string', {defaultValue: ''})
+});

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/router.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/router.js
@@ -64,6 +64,7 @@ Router.map(function() {
     this.route('configs');
     this.route('logs');
     this.route('threaddump');
+    this.route('diagnostic');
   });
   this.route('yarn-component-instances', function() {
     this.route('info', {path: '/:component_name/info'});

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/routes/yarn-app/diagnostic.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/routes/yarn-app/diagnostic.js
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Ember from 'ember';
+import AbstractRoute from '../abstract';
+import AppAttemptMixin from 'yarn-ui/mixins/app-attempt';
+
+export default AbstractRoute.extend(AppAttemptMixin, {
+    model(param, transition) {
+        const { app_id } = this.paramsFor('yarn-app');
+        const { service } = param;
+        transition.send('updateBreadcrumbs', app_id, service);
+
+        return Ember.RSVP.hash({
+            appId: app_id,
+            serviceName: service,
+
+            issues: this.store.findAll('common-issue'),
+
+            diagnostic:this.store.query('common-issue', {
+                issueId: 'application_failed',
+                appId: app_id
+            })
+        });
+    },
+
+    refresh() {
+        window.location.reload();
+    },
+
+    unloadAll() {
+        this.store.unloadAll('yarn-app');
+        this.store.unloadAll('yarn-app-timeline');
+        this.store.unloadAll('yarn-service-info');
+    }
+});

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-app/diagnostic.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-app/diagnostic.hbs
@@ -1,0 +1,30 @@
+{{!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+}}
+
+
+<h2>Diagnostics</h2>
+
+<h3>Available Issues</h3>
+<ul>
+  {{#each model.issues as |issue|}}
+    <li>{{issue.fileName}} - {{issue.contentType}}</li>
+  {{/each}}
+</ul>
+
+<h3>Diagnostics for {{model.appId}}</h3>
+<pre>{{model.diagnostic.firstObject.content}}</pre>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-app/info.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-app/info.hbs
@@ -137,6 +137,55 @@
   </div>
 </div>
 
+<div class="col-md-12">
+  <div class="panel panel-default">
+    <button class="panel-heading" {{action "runDiagnostic" "application_failed"}}>
+        Application Failed
+    </button>
+  </div>
+</div>
+
+<div class="col-md-12">
+  <div class="panel panel-default">
+    <button class="panel-heading" {{action "runDiagnostic" "application_hanging"}}>
+        Application Hanging
+    </button>
+  </div>
+</div>
+
+<div class="col-md-12">
+  <div class="panel panel-default">
+    <button class="panel-heading" {{action "runDiagnostic" "application_hanging"}}>
+        Application Diagnostic
+    </button>
+  </div>
+</div>
+
+{{#if diagnosticResult}}
+<div class="col-md-12 margin-top-20">
+    <div class="panel panel-info text-center">
+      <div class="panel-heading">
+          Diagnostic Result: <strong>{{diagnosticIssueId}}</strong>
+      </div>
+      <div class="panel-body">
+        <ul class="list-group">
+           {{#each diagnosticResult as |file|}}
+              <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <span>{{file.filename}}</span>
+                  <button class="btn btn-sm btn-primary" {{action "downloadFile" file}}>
+                        Download
+                  </button>
+              </li>
+           {{/each}}
+        </ul>
+      </div>
+    </div>
+</div>
+
+{{/if}}
+
+
+
 {{confirm-dialog
   dialogId="stopServiceConfirmDialog"
   message=(concat 'Are you sure you want to stop service "' model.serviceName '" for user "' model.app.user '" ?')


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
A working YARN UI2 for application diagnostic. With automatic download after clicking it. 
See screenshot below.


<img width="1543" height="598" alt="Screenshot 2025-12-10 at 1 32 17" src="https://github.com/user-attachments/assets/4d770518-1436-4e69-9217-25fca93df269" />

Will remove unnecessary code.
### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

