### PR TITLE
HADOOP-19752. Upgrade to caffeine 3.2.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -232,7 +232,7 @@ com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.18.5
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.18.5
 com.fasterxml.uuid:java-uuid-generator:3.1.4
 com.fasterxml.woodstox:woodstox-core:5.4.0
-com.github.ben-manes.caffeine:caffeine:2.9.3
+com.github.ben-manes.caffeine:caffeine:3.2.3
 com.github.davidmoten:rxjava-extras:0.8.0.17
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.api:api-common:2.47.2

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -137,7 +137,7 @@
     <kerby.version>2.0.3</kerby.version>
     <ehcache.version>3.8.2</ehcache.version>
     <cache.api.version>1.1.1</cache.api.version>
-    <caffeine.version>2.9.3</caffeine.version>
+    <caffeine.version>3.2.3</caffeine.version>
     <hikari.version>4.0.3</hikari.version>
     <derby.version>10.14.2.0</derby.version>
     <mssql.version>6.2.1.jre7</mssql.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19752 - Caffeine 3.x needs Java 11 min

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

