### PR TITLE
HADOOP-19753 Support HADOOP_LOG_DAEMON_MODE environment variable

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -2733,7 +2733,7 @@ function hadoop_generic_java_subcmd_handler
 
   # are we actually in daemon mode?
   # if yes, use the daemon logger and the appropriate log file.
-  if [[ "${HADOOP_DAEMON_MODE}" != "default" ]]; then
+  if [[ "${HADOOP_DAEMON_MODE}" != "default" ]] || [[ "${HADOOP_LOG_DAEMON_MODE}" = true ]]; then
     HADOOP_ROOT_LOGGER="${HADOOP_DAEMON_ROOT_LOGGER}"
     if [[ "${HADOOP_SUBCMD_SECURESERVICE}" = true ]]; then
       HADOOP_LOGFILE="hadoop-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.log"


### PR DESCRIPTION
### Description of PR
Support a new environment variable HADOOP_LOG_DAEMON_MODE to allow dynamically setting HADOOP_ROOT_LOGGER and HADOOP_LOGFILE to same values as if using --daemon option to run hadoop services

hadoop systemd services run the daemon process in the forground without using --daemon option. However, HADOOP_ROOT_LOGGER and HADOOP_LOGFILE values will only be set dynamically when using --daemon flag. For systemd services, we want to have same default settings for HADOOP_ROOT_LOGGER and HADOOP_LOGFILE as the background daemon case.

### How was this patch tested?
This feature has been tested on workday real production environment.

