### PR TITLE
HDFS-17864. Improve fsimage load time by making LightWeightGSet and NameCache thread-safe

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GSet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GSet.java
@@ -101,4 +101,16 @@ public interface GSet<K, E extends K> extends Iterable<E> {
    * @return the collection of values.
    */
   Collection<E> values();
+
+  /**
+   * Create a new concurrency controller for this GSet.
+   * By default, a {@link SynchronizedGSetController} is returned.
+   * Subclasses may override this method to return a different type of controller.
+   *
+   * @return a new concurrency controller.
+   */
+  default GSetConcurrencyController<K> newConcurrencyController() {
+    return SynchronizedGSetController.of();
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GSetConcurrencyController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GSetConcurrencyController.java
@@ -54,7 +54,7 @@ public interface GSetConcurrencyController<K> {
   /**
    * In some scenarios, we already know the final size of the GSet. We can use this method
    * to correct the size directly without calling {@link #addSize(int)} repeatedly.
-   * 
+   *
    * <p>NOTE: Caller is responsible for ensuring the correctness of the given size.</p>
    *
    * @param size the corrected size.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GSetConcurrencyController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GSetConcurrencyController.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+/**
+ * A concurrency controller for {@link GSet}.
+ * This interface provides thread-safety mechanisms for GSet operations,
+ * including lock management and size correction for concurrent modifications.
+ *
+ * @param <K> The type of the key.
+ */
+public interface GSetConcurrencyController<K> {
+
+  /**
+   * Get the lock object for the given key.
+   *
+   * @param key the key.
+   * @return a lock object to synchronize on, or null if no synchronization is needed.
+   */
+  Object getLock(K key);
+
+  /**
+   * Some implementations may allow modifying GSet concurrently, but leave the GSet size inaccurate.
+   * GSetConcurrencyController provides an independent size counter(initial value is the size of
+   * the GSet when constructed), which needs caller to keep track of the size change and call
+   * this method to correct the size.
+   * The size change will not be applied to the underlying GSet util {@link #correctSize()}
+   * is called.
+   *
+   * @param deltaSize deltaSize, a negative value means size decrease.
+   */
+  void addSize(int deltaSize);
+
+  /**
+   * Apply the size correction to the underlying GSet.
+   */
+  void correctSize();
+
+  /**
+   * In some scenarios, we already know the final size of the GSet. We can use this method
+   * to correct the size directly without calling {@link #addSize(int)} repeatedly.
+   * 
+   * <p>NOTE: Caller is responsible for ensuring the correctness of the given size.</p>
+   *
+   * @param size the corrected size.
+   */
+  void correctSize(int size);
+
+  /**
+   * A convenience method to execute a runnable under the lock of the given key.
+   *
+   * @param key      the key.
+   * @param runnable the runnable to be executed.
+   */
+  default void doUnderLock(K key, Runnable runnable) {
+    Object lock = getLock(key);
+    if (lock != null) {
+      synchronized (lock) {
+        runnable.run();
+      }
+    } else {
+      runnable.run();
+    }
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightCache.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightCache.java
@@ -254,4 +254,10 @@ public class LightWeightCache<K, E extends K> extends LightWeightGSet<K, E> {
       }
     };
   }
+
+  @Override
+  public GSetConcurrencyController<K> newConcurrencyController() {
+    return SynchronizedGSetController.of();
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightGSet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightGSet.java
@@ -421,4 +421,10 @@ public class LightWeightGSet<K, E extends K> implements GSet<K, E> {
     Arrays.fill(entries, null);
     size = 0;
   }
+
+  @Override
+  public GSetConcurrencyController<K> newConcurrencyController() {
+    return new LightWeightGSetConcurrencyController<>(this);
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightGSetConcurrencyController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightGSetConcurrencyController.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * A concurrency controller implementation for {@link LightWeightGSet}.
+ *
+ * <p>This class provides fine-grained locking mechanism for concurrent access to
+ * {@link LightWeightGSet} by using a fixed array of locks. Each key is mapped to
+ * a specific lock based on its hash value, allowing multiple threads to operate
+ * on different parts of the set simultaneously while maintaining thread safety.
+ * 
+ * <p>The controller uses a lock striping approach with a fixed number of locks
+ * (4096 by default) to balance between memory usage and concurrency level. Keys are
+ * distributed across these locks using modulo operation on the key's index.
+ * 
+ * <p><strong>Thread Safety Scope:</strong>
+ * <ul>
+ *   <li><strong>Safe:</strong> Single-key operations like {@code get()}, {@code put()}, 
+ *       {@code remove()}, {@code contains()} when properly synchronized using the lock
+ *       returned by {@link #getLock(Object)}</li>
+ *   <li><strong>NOT Safe:</strong> Bulk operations like {@code values()}, {@code iterator()}, 
+ *       or any operations that traverse the entire set. These operations 
+ *       require additional synchronization mechanisms beyond this controller.
+ *       The {@code size()} will also be inconsistent if multiple threads are modifying the
+ *       set concurrently, call {@code correctSize(int)} to correct it. </li>
+ * </ul>
+ *
+ * @param <K> Key type for looking up the elements
+ * @param <E> Element type, which must be
+ *       (1) a subclass of K, and
+ *       (2) implementing {@link LightWeightGSet.LinkedElement} interface.
+ * 
+ * @see LightWeightGSet
+ * @see GSetConcurrencyController
+ */
+public class LightWeightGSetConcurrencyController<K, E extends K>
+    implements GSetConcurrencyController<K> {
+
+  private static final int CONCURRENCY = 16 * 16 * 16;
+
+  /**
+   * Array of lock objects used for synchronization.
+   * Each lock protects a subset of keys based on their hash values.
+   */
+  private final Object[] locks;
+  
+  /**
+   * Reference to the underlying LightWeightGSet that this controller manages.
+   */
+  private final LightWeightGSet<K, E> lightWeightGSet;
+
+  /**
+   * 
+   */
+  private final LongAdder size = new LongAdder();
+
+  /**
+   * Constructs a new concurrency controller for the given LightWeightGSet.
+   * 
+   * @param lightWeightGSet the LightWeightGSet instance to control concurrent access for
+   */
+  public LightWeightGSetConcurrencyController(LightWeightGSet<K, E> lightWeightGSet) {
+    this.locks = new Object[CONCURRENCY];
+    this.lightWeightGSet = lightWeightGSet;
+    this.size.add(lightWeightGSet.size());
+    initLocks();
+  }
+
+  private void initLocks() {
+    for (int i = 0; i < this.locks.length; i++) {
+      locks[i] = new Object();
+    }
+  }
+
+  /**
+   * Corrects the size of the underlying LightWeightGSet.
+   *
+   * <p>This method is used when concurrent modifications may have left
+   * the size of the LightWeightGSet in an inconsistent state. It directly updates the
+   * size field of the underlying set to the correct value.
+   *
+   * @param size the correct size to set
+   */
+  @Override
+  public void correctSize(int size) {
+    lightWeightGSet.size = size;
+  }
+
+  @Override
+  public void addSize(int deltaSize) {
+    size.add(deltaSize);
+  }
+
+  @Override
+  public void correctSize() {
+    correctSize(size.intValue());
+  }
+
+  /**
+   * Returns the lock object associated with the given key.
+   * 
+   * <p>The lock is determined by:
+   * <ol>
+   *   <li>Computing the key's index using the underlying set's getIndex method</li>
+   *   <li>Mapping the index to a lock using modulo operation</li>
+   * </ol>
+   * 
+   * <p>This ensures that the same key always maps to the same lock, while
+   * distributing different keys across multiple locks for better concurrency.
+   * 
+   * @param key the key for which to get the associated lock
+   * @return the lock object that should be used for synchronizing operations on this key
+   * @throws NullPointerException if key is null (depending on the underlying set's behavior)
+   */
+  public Object getLock(K key) {
+    int index = lightWeightGSet.getIndex(key);
+    return locks[index % locks.length];
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightGSetConcurrencyController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightGSetConcurrencyController.java
@@ -26,18 +26,18 @@ import java.util.concurrent.atomic.LongAdder;
  * {@link LightWeightGSet} by using a fixed array of locks. Each key is mapped to
  * a specific lock based on its hash value, allowing multiple threads to operate
  * on different parts of the set simultaneously while maintaining thread safety.
- * 
+ *
  * <p>The controller uses a lock striping approach with a fixed number of locks
  * (4096 by default) to balance between memory usage and concurrency level. Keys are
  * distributed across these locks using modulo operation on the key's index.
- * 
+ *
  * <p><strong>Thread Safety Scope:</strong>
  * <ul>
- *   <li><strong>Safe:</strong> Single-key operations like {@code get()}, {@code put()}, 
+ *   <li><strong>Safe:</strong> Single-key operations like {@code get()}, {@code put()},
  *       {@code remove()}, {@code contains()} when properly synchronized using the lock
  *       returned by {@link #getLock(Object)}</li>
- *   <li><strong>NOT Safe:</strong> Bulk operations like {@code values()}, {@code iterator()}, 
- *       or any operations that traverse the entire set. These operations 
+ *   <li><strong>NOT Safe:</strong> Bulk operations like {@code values()}, {@code iterator()},
+ *       or any operations that traverse the entire set. These operations
  *       require additional synchronization mechanisms beyond this controller.
  *       The {@code size()} will also be inconsistent if multiple threads are modifying the
  *       set concurrently, call {@code correctSize(int)} to correct it. </li>
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.LongAdder;
  * @param <E> Element type, which must be
  *       (1) a subclass of K, and
  *       (2) implementing {@link LightWeightGSet.LinkedElement} interface.
- * 
+ *
  * @see LightWeightGSet
  * @see GSetConcurrencyController
  */
@@ -61,20 +61,17 @@ public class LightWeightGSetConcurrencyController<K, E extends K>
    * Each lock protects a subset of keys based on their hash values.
    */
   private final Object[] locks;
-  
+
   /**
    * Reference to the underlying LightWeightGSet that this controller manages.
    */
   private final LightWeightGSet<K, E> lightWeightGSet;
 
-  /**
-   * 
-   */
   private final LongAdder size = new LongAdder();
 
   /**
    * Constructs a new concurrency controller for the given LightWeightGSet.
-   * 
+   *
    * @param lightWeightGSet the LightWeightGSet instance to control concurrent access for
    */
   public LightWeightGSetConcurrencyController(LightWeightGSet<K, E> lightWeightGSet) {
@@ -97,11 +94,11 @@ public class LightWeightGSetConcurrencyController<K, E extends K>
    * the size of the LightWeightGSet in an inconsistent state. It directly updates the
    * size field of the underlying set to the correct value.
    *
-   * @param size the correct size to set
+   * @param correctSize the correct size to set
    */
   @Override
-  public void correctSize(int size) {
-    lightWeightGSet.size = size;
+  public void correctSize(int correctSize) {
+    lightWeightGSet.size = correctSize;
   }
 
   @Override
@@ -116,16 +113,16 @@ public class LightWeightGSetConcurrencyController<K, E extends K>
 
   /**
    * Returns the lock object associated with the given key.
-   * 
+   *
    * <p>The lock is determined by:
    * <ol>
    *   <li>Computing the key's index using the underlying set's getIndex method</li>
    *   <li>Mapping the index to a lock using modulo operation</li>
    * </ol>
-   * 
+   *
    * <p>This ensures that the same key always maps to the same lock, while
    * distributing different keys across multiple locks for better concurrency.
-   * 
+   *
    * @param key the key for which to get the associated lock
    * @return the lock object that should be used for synchronizing operations on this key
    * @throws NullPointerException if key is null (depending on the underlying set's behavior)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightResizableGSet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LightWeightResizableGSet.java
@@ -150,4 +150,9 @@ public class LightWeightResizableGSet<K, E extends K>
       resize(capacity * 2);
     }
   }
+
+  @Override
+  public GSetConcurrencyController<K> newConcurrencyController() {
+    return SynchronizedGSetController.of();
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LockFreeGSetController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/LockFreeGSetController.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+/**
+ * A concurrency controller that does not use any lock.
+ */
+public enum LockFreeGSetController implements GSetConcurrencyController<Object> {
+  INSTANCE;
+
+  @Override
+  public Object getLock(Object key) {
+    return null;
+  }
+
+  @Override
+  public void correctSize(int size) {
+    // do nothing
+  }
+
+  @Override
+  public void addSize(int deltaSize) {
+    // do nothing
+  }
+
+  @Override
+  public void correctSize() {
+    // do nothing
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <K> GSetConcurrencyController<K> getInstance() {
+    return (GSetConcurrencyController<K>) INSTANCE;
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SynchronizedGSetController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SynchronizedGSetController.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+/**
+ * A concurrency controller that uses a single lock for all operations.
+ *
+ * @param <K> The type of the key.
+ */
+public class SynchronizedGSetController<K> implements GSetConcurrencyController<K> {
+
+  private final Object lock = new Object();
+
+  @Override
+  public Object getLock(K key) {
+    return lock;
+  }
+
+  @Override
+  public void correctSize(int size) {
+    // do nothing
+  }
+
+  @Override
+  public void addSize(int deltaSize) {
+    // do nothing
+  }
+
+  @Override
+  public void correctSize() {
+    // do nothing
+  }
+
+  public static <K> SynchronizedGSetController<K> of() {
+    return new SynchronizedGSetController<>();
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SynchronizedGSetController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SynchronizedGSetController.java
@@ -26,6 +26,12 @@ public class SynchronizedGSetController<K> implements GSetConcurrencyController<
 
   private final Object lock = new Object();
 
+  /**
+   * Create a new SynchronizedGSetController.
+   */
+  private SynchronizedGSetController() {
+  }
+
   @Override
   public Object getLock(K key) {
     return lock;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestLightWeightGSet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestLightWeightGSet.java
@@ -18,8 +18,15 @@
 package org.apache.hadoop.util;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Queue;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
 
 import org.apache.hadoop.util.LightWeightGSet.LinkedElement;
 import org.junit.jupiter.api.Test;
@@ -27,6 +34,7 @@ import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -113,4 +121,65 @@ public class TestLightWeightGSet {
       assertTrue(iter.next().getVal() <= mode);
     }
   }
+
+  @Test
+  @Timeout(value = 60)
+  public void testLightWeightGSetConcurrencyController() {
+    LightWeightGSet<TestElement, TestElement> set =
+        new LightWeightGSet<>(16);
+    testGSetConcurrencyController(set, set.newConcurrencyController());
+  }
+
+  @Test
+  @Timeout(value = 60)
+  public void testSynchronizedGSetConcurrencyController() {
+    LightWeightGSet<TestElement, TestElement> set =
+        new LightWeightGSet<>(16);
+    testGSetConcurrencyController(set, SynchronizedGSetController.of());
+  }
+
+  private void testGSetConcurrencyController(GSet<TestElement, TestElement> set,
+      GSetConcurrencyController<TestElement> controller) {
+    int numElements = 10000;
+    int numThreads = 10;
+
+    Queue<TestElement> queue = new LinkedBlockingDeque<>();
+    for (int i = 0; i < numElements; i++) {
+      queue.add(new TestElement(i));
+    }
+
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    CompletableFuture<?>[] futures = new CompletableFuture<?>[numThreads];
+    for (int i = 0; i < numThreads; i++) {
+      CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+        while (true) {
+          TestElement next = queue.poll();
+          if (next == null) {
+            break;
+          }
+          controller.doUnderLock(next, () -> {
+            set.put(next);
+            assertEquals(next, set.get(next));
+          });
+          controller.addSize(1);
+        }
+      }, executorService);
+      futures[i] = future;
+    }
+
+    CompletableFuture<Void> all = CompletableFuture.allOf(futures);
+    assertDoesNotThrow(() -> all.get());
+    executorService.shutdown();
+
+    controller.correctSize();
+
+    assertEquals(numElements, set.size());
+
+    Set<Integer> exist = new HashSet<>();
+    for (TestElement e : set) {
+      assertTrue(exist.add(e.getVal()));
+    }
+    assertEquals(numElements, exist.size());
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
@@ -527,6 +527,12 @@ public class PBHelperClient {
 
   public static InputStream vintPrefixed(final InputStream input)
       throws IOException {
+    int size = vintPrefixedSize(input);
+    return new LimitInputStream(input, size);
+  }
+
+  public static int vintPrefixedSize(final InputStream input)
+      throws IOException {
     final int firstByte = input.read();
     if (firstByte == -1) {
       throw new EOFException(
@@ -535,7 +541,7 @@ public class PBHelperClient {
 
     int size = CodedInputStream.readRawVarint32(firstByte, input);
     assert size >= 0;
-    return new LimitInputStream(input, size);
+    return size;
   }
 
   public static CipherOption convert(HdfsProtos.CipherOptionProto proto) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
@@ -531,6 +531,9 @@ public class PBHelperClient {
     return new LimitInputStream(input, size);
   }
 
+  /**
+   * Read the size of next message from input stream.
+   */
   public static int vintPrefixedSize(final InputStream input)
       throws IOException {
     final int firstByte = input.read();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1183,6 +1183,18 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.image.parallel.threads";
   public static final int DFS_IMAGE_PARALLEL_THREADS_DEFAULT = 4;
 
+  public static final String DFS_IMAGE_CONCURRENT_INIT_INODE_MAP_ENABLE =
+      "dfs.image.concurrent.init.inode.map.enable";
+  public static final boolean DFS_IMAGE_CONCURRENT_INIT_INODE_MAP_ENABLE_DEFAULT = false;
+
+  public static final String DFS_IMAGE_NAME_CACHE_INIT_THREAD_NUM =
+      "dfs.image.name.cache.init.thread.num";
+  public static final int DFS_IMAGE_NAME_CACHE_INIT_THREAD_DEFAULT = 1;
+
+  public static final String DFS_IMAGE_BLOCK_MAP_INIT_THREAD_NUM =
+      "dfs.image.block.map.init.thread.num";
+  public static final int DFS_IMAGE_BLOCK_MAP_INIT_THREAD_DEFAULT = 1;
+
   // Edit Log segment transfer timeout
   public static final String DFS_EDIT_LOG_TRANSFER_TIMEOUT_KEY =
       "dfs.edit.log.transfer.timeout";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -127,6 +127,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Daemon;
 import org.apache.hadoop.util.ExitUtil;
+import org.apache.hadoop.util.GSetConcurrencyController;
 import org.apache.hadoop.util.LightWeightGSet;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
@@ -5861,4 +5862,9 @@ public class BlockManager implements BlockStatsMXBean {
   public int getMinBlocksForWrite(BlockType blockType) {
     return placementPolicies.getPolicy(blockType).getMinBlocksForWrite();
   }
+
+  public GSetConcurrencyController<Block> newBlockGSetConcurrencyController() {
+    return blocksMap.newBlockGSetConcurrencyController();
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -5863,6 +5863,9 @@ public class BlockManager implements BlockStatsMXBean {
     return placementPolicies.getPolicy(blockType).getMinBlocksForWrite();
   }
 
+  /**
+   * @return A new concurrency controller for block map.
+   */
   public GSetConcurrencyController<Block> newBlockGSetConcurrencyController() {
     return blocksMap.newBlockGSetConcurrencyController();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlocksMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlocksMap.java
@@ -250,6 +250,9 @@ class BlocksMap {
     return totalECBlockGroups.longValue();
   }
 
+  /**
+   * @return A new concurrency controller for block map.
+   */
   public GSetConcurrencyController<Block> newBlockGSetConcurrencyController() {
     return blocks.newConcurrencyController();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlocksMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlocksMap.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.LongAdder;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.namenode.INodeId;
 import org.apache.hadoop.util.GSet;
+import org.apache.hadoop.util.GSetConcurrencyController;
 import org.apache.hadoop.util.LightWeightGSet;
 
 /**
@@ -248,4 +249,9 @@ class BlocksMap {
   long getECBlockGroups() {
     return totalECBlockGroups.longValue();
   }
+
+  public GSetConcurrencyController<Block> newBlockGSetConcurrencyController() {
+    return blocks.newConcurrencyController();
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/EncryptionZoneManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/EncryptionZoneManager.java
@@ -321,10 +321,14 @@ public class EncryptionZoneManager {
       CipherSuite suite, CryptoProtocolVersion version, String keyName) {
     final EncryptionZoneInt ez = new EncryptionZoneInt(
         inodeId, suite, version, keyName);
-    if (encryptionZones == null) {
-      encryptionZones = new TreeMap<>();
+    // during fsimage loading, this method may be called concurrently.
+    // See HDFS-17864 for more detail.
+    synchronized (this) {
+      if (encryptionZones == null) {
+        encryptionZones = new TreeMap<>();
+      }
+      encryptionZones.put(inodeId, ez);
     }
-    encryptionZones.put(inodeId, ez);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hdfs.server.namenode.startupprogress.Phase;
 import org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgress;
 import org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgress.Counter;
 import org.apache.hadoop.hdfs.server.namenode.startupprogress.Step;
+import org.apache.hadoop.hdfs.util.DelimitedProtoBufParseHelper;
 import org.apache.hadoop.hdfs.util.EnumCounters;
 import org.apache.hadoop.hdfs.util.ReadOnlyList;
 
@@ -375,8 +376,12 @@ public final class FSImageFormatPBINode {
       // EOF is encountered at the end of the stream.
       int cntr = 0;
       ArrayList<INode> inodeList = new ArrayList<>();
+      DelimitedProtoBufParseHelper<INodeSection.INode> parseHelper =
+          new DelimitedProtoBufParseHelper<>(in,
+              INodeSection.INode::parseFrom,
+              INodeSection.INode::parseFrom);
       while (true) {
-        INodeSection.INode p = INodeSection.INode.parseDelimitedFrom(in);
+        INodeSection.INode p = parseHelper.parseNext();
         if (p == null) {
           break;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
@@ -32,6 +32,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.util.GSetConcurrencyController;
+import org.apache.hadoop.util.LockFreeGSetController;
+import org.apache.hadoop.util.SynchronizedGSetController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.HadoopIllegalArgumentException;
@@ -193,13 +198,19 @@ public final class FSImageFormatPBINode {
       return dir;
     }
 
-    public static void updateBlocksMap(INodeFile file, BlockManager bm) {
+    public static void updateBlocksMap(INodeFile file, BlockManager bm,
+        GSetConcurrencyController<Block> synchronizer) {
       // Add file->block mapping
       final BlockInfo[] blocks = file.getBlocks();
       if (blocks != null) {
         for (int i = 0; i < blocks.length; i++) {
-          file.setBlock(i, bm.addBlockCollectionWithCheck(blocks[i], file));
+          BlockInfo block = blocks[i];
+          int blockIndex = i;
+          synchronizer.doUnderLock(block,
+              () -> file.setBlock(blockIndex, bm.addBlockCollectionWithCheck(block, file))
+          );
         }
+        synchronizer.addSize(blocks.length);
       }
     }
 
@@ -211,15 +222,33 @@ public final class FSImageFormatPBINode {
     private ExecutorService blocksMapUpdateExecutor;
     // update name cache by single thread asynchronously.
     private ExecutorService nameCacheUpdateExecutor;
+    private GSetConcurrencyController<INode> inodeMapSynchronizer =
+        SynchronizedGSetController.of();
+    private GSetConcurrencyController<Block> blockMapSynchronizer =
+        LockFreeGSetController.getInstance();
 
-    Loader(FSNamesystem fsn, final FSImageFormatProtobuf.Loader parent) {
+    Loader(FSNamesystem fsn, final FSImageFormatProtobuf.Loader parent, Configuration conf) {
       this.fsn = fsn;
       this.dir = fsn.dir;
       this.parent = parent;
-      // Note: these executors must be SingleThreadExecutor, as they
-      // are used to modify structures which are not thread safe.
-      blocksMapUpdateExecutor = Executors.newSingleThreadExecutor();
-      nameCacheUpdateExecutor = Executors.newSingleThreadExecutor();
+      setupExecutors(conf);
+    }
+
+    private void setupExecutors(Configuration conf) {
+      int nameCacheUpdateThreadNum = conf.getInt(DFSConfigKeys.DFS_IMAGE_NAME_CACHE_INIT_THREAD_NUM,
+          DFSConfigKeys.DFS_IMAGE_NAME_CACHE_INIT_THREAD_DEFAULT);
+      int blocksMapUpdateThreadNum = conf.getInt(DFSConfigKeys.DFS_IMAGE_BLOCK_MAP_INIT_THREAD_NUM,
+          DFSConfigKeys.DFS_IMAGE_BLOCK_MAP_INIT_THREAD_DEFAULT);
+      this.nameCacheUpdateExecutor = Executors.newFixedThreadPool(nameCacheUpdateThreadNum);
+      this.blocksMapUpdateExecutor = Executors.newFixedThreadPool(blocksMapUpdateThreadNum);
+
+      if (blocksMapUpdateThreadNum > 1) {
+        blockMapSynchronizer = fsn.getBlockManager().newBlockGSetConcurrencyController();
+      }
+      if (conf.getBoolean(DFSConfigKeys.DFS_IMAGE_CONCURRENT_INIT_INODE_MAP_ENABLE,
+          DFSConfigKeys.DFS_IMAGE_CONCURRENT_INIT_INODE_MAP_ENABLE_DEFAULT)) {
+        inodeMapSynchronizer = dir.getINodeMap().newINodeGSetConcurrencyController();
+      }
     }
 
     void loadINodeDirectorySectionInParallel(ExecutorService service,
@@ -329,10 +358,10 @@ public final class FSImageFormatPBINode {
       }
     }
 
-     // update blocks map with non-thread safe
+     // update blocks map with thread safe
     private void updateBlockMapInternal(ArrayList<INode> inodeList) {
       for (INode i : inodeList) {
-        updateBlocksMap(i.asFile(), fsn.getBlockManager());
+        updateBlocksMap(i.asFile(), fsn.getBlockManager(), blockMapSynchronizer);
       }
     }
 
@@ -340,6 +369,7 @@ public final class FSImageFormatPBINode {
       long start = System.currentTimeMillis();
       waitExecutorTerminated(blocksMapUpdateExecutor);
       waitExecutorTerminated(nameCacheUpdateExecutor);
+      blockMapSynchronizer.correctSize();
       LOG.info("Completed update blocks map and name cache, total waiting "
           + "duration {}ms.", (System.currentTimeMillis() - start));
     }
@@ -382,6 +412,7 @@ public final class FSImageFormatPBINode {
               INodeSection.INode::parseFrom);
       while (true) {
         INodeSection.INode p = parseHelper.parseNext();
+
         if (p == null) {
           break;
         }
@@ -391,9 +422,9 @@ public final class FSImageFormatPBINode {
           }
         } else {
           INode n = loadINode(p);
-          synchronized(this) {
-            dir.addToInodeMap(n);
-          }
+          inodeMapSynchronizer.doUnderLock(n,
+              () -> dir.addToInodeMap(n)
+          );
           fillUpInodeList(inodeList, n);
         }
         cntr++;
@@ -467,6 +498,7 @@ public final class FSImageFormatPBINode {
             "parallel, but loaded "+totalLoaded.get()+". The image may " +
             "be corrupt.");
       }
+      inodeMapSynchronizer.correctSize((int) expectedInodes);
       LOG.info("Completed loading all INode sections. Loaded {} inodes.",
           totalLoaded.get());
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
@@ -372,7 +372,7 @@ public final class FSImageFormatProtobuf {
       FileChannel channel = fin.getChannel();
 
       FSImageFormatPBINode.Loader inodeLoader = new FSImageFormatPBINode.Loader(
-          fsn, this);
+          fsn, this, conf);
       FSImageFormatPBSnapshot.Loader snapshotLoader = new FSImageFormatPBSnapshot.Loader(
           fsn, this);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
@@ -222,7 +223,10 @@ public final class FSImageFormatProtobuf {
       @Override
       public void work() {
         try {
+          long now = Time.now();
           digest = MD5FileUtils.computeMd5ForFile(file);
+          LOG.info("Computed MD5 for file {} in {}s", file,
+              TimeUnit.MILLISECONDS.toSeconds(Time.now() - now));
         } catch (IOException e) {
           ioe = e;
         } catch (Throwable t) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeMap.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.permission.PermissionStatus;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockStoragePolicySuite;
 import org.apache.hadoop.util.GSet;
+import org.apache.hadoop.util.GSetConcurrencyController;
 import org.apache.hadoop.util.LightWeightGSet;
 
 import org.apache.hadoop.util.Preconditions;
@@ -138,4 +139,9 @@ public class INodeMap {
   public void clear() {
     map.clear();
   }
+
+  public GSetConcurrencyController<INode> newINodeGSetConcurrencyController() {
+    return map.newConcurrencyController();
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeMap.java
@@ -140,6 +140,9 @@ public class INodeMap {
     map.clear();
   }
 
+  /**
+   * @return A new concurrency controller for inode map.
+   */
   public GSetConcurrencyController<INode> newINodeGSetConcurrencyController() {
     return map.newConcurrencyController();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
@@ -79,7 +79,7 @@ class NameCache<K> {
   final HashMap<K, K> cache = new HashMap<K, K>();
 
   /** Names and with number of occurrences tracked during initialization */
-  Map<K, UseCount> transientMap = new ConcurrentHashMap<>();
+  private Map<K, UseCount> transientMap = new ConcurrentHashMap<>();
 
   /**
    * Constructor

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
@@ -19,7 +19,11 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 
+import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * discarded and cache is ready for use.
  * 
  * <p>
- * This class must be synchronized externally.
+ * This class must be synchronized externally after initialized .
  * 
  * @param <K> name to be added to the cache
  */
@@ -45,21 +49,17 @@ class NameCache<K> {
    * Class for tracking use count of a name
    */
   private class UseCount {
-    int count;
+    private final AtomicInteger count = new AtomicInteger();
     final K value;  // Internal value for the name
 
     UseCount(final K value) {
-      count = 1;
       this.value = value;
     }
-    
-    void increment() {
-      count++;
+
+    int incrementAndGet() {
+      return count.incrementAndGet();
     }
-    
-    int get() {
-      return count;
-    }
+
   }
 
   static final Logger LOG = LoggerFactory.getLogger(NameCache.class.getName());
@@ -73,11 +73,13 @@ class NameCache<K> {
   /** of times a cache look up was successful */
   private int lookups = 0;
 
+  private final LongAdder lookupsBeforeInitialized = new LongAdder();
+
   /** Cached names */
   final HashMap<K, K> cache = new HashMap<K, K>();
 
   /** Names and with number of occurrences tracked during initialization */
-  Map<K, UseCount> transientMap = new HashMap<K, UseCount>();
+  Map<K, UseCount> transientMap = new ConcurrentHashMap<>();
 
   /**
    * Constructor
@@ -85,39 +87,37 @@ class NameCache<K> {
    *          cache
    */
   NameCache(int useThreshold) {
+    Preconditions.checkArgument(useThreshold > 0);
     this.useThreshold = useThreshold;
   }
   
   /**
    * Add a given name to the cache or track use count.
    * exist. If the name already exists, then the internal value is returned.
+   * If not initialized, this method is thread safe.
    * 
    * @param name name to be looked up
    * @return internal value for the name if found; otherwise null
    */
   K put(final K name) {
-    K internal = cache.get(name);
-    if (internal != null) {
-      lookups++;
-      return internal;
-    }
-
-    // Track the usage count only during initialization
-    if (!initialized) {
-      UseCount useCount = transientMap.get(name);
-      if (useCount != null) {
-        useCount.increment();
-        if (useCount.get() >= useThreshold) {
-          promote(name);
-        }
-        return useCount.value;
+    if (initialized) {
+      K internal = cache.get(name);
+      if (internal != null) {
+        lookups++;
       }
-      useCount = new UseCount(name);
-      transientMap.put(name, useCount);
+      return internal;
+    } else {
+      UseCount useCount = transientMap.computeIfAbsent(name, UseCount::new);
+      int count = useCount.incrementAndGet();
+      if (count == useThreshold) {
+        promote(useCount);
+      } else if (count > useThreshold) {
+        lookupsBeforeInitialized.increment();
+      }
+      return useCount.value;
     }
-    return null;
   }
-  
+
   /**
    * Lookup count when a lookup for a name returned cached object
    * @return number of successful lookups
@@ -140,16 +140,15 @@ class NameCache<K> {
    * save heap space.
    */
   void initialized() {
+    this.lookups = lookups + lookupsBeforeInitialized.intValue();
     LOG.info("initialized with " + size() + " entries " + lookups + " lookups");
     this.initialized = true;
-    transientMap.clear();
-    transientMap = null;
+    this.transientMap = null;
   }
   
   /** Promote a frequently used name to the cache */
-  private void promote(final K name) {
-    transientMap.remove(name);
-    cache.put(name, name);
+  private synchronized void promote(final UseCount useCount) {
+    cache.put(useCount.value, useCount.value);
     lookups += useThreshold;
   }
 
@@ -157,7 +156,7 @@ class NameCache<K> {
     initialized = false;
     cache.clear();
     if (transientMap == null) {
-      transientMap = new HashMap<K, UseCount>();
+      transientMap = new ConcurrentHashMap<>();
     } else {
       transientMap.clear();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/FSImageFormatPBSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/FSImageFormatPBSnapshot.java
@@ -82,6 +82,7 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot.Root;
 import org.apache.hadoop.hdfs.server.namenode.XAttrFeature;
 import org.apache.hadoop.hdfs.util.EnumCounters;
 
+import org.apache.hadoop.util.LockFreeGSetController;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 
@@ -294,7 +295,8 @@ public class FSImageFormatPBSnapshot {
     private void addToDeletedList(INode dnode, INodeDirectory parent) {
       dnode.setParent(parent);
       if (dnode.isFile()) {
-        updateBlocksMap(dnode.asFile(), fsn.getBlockManager());
+        updateBlocksMap(dnode.asFile(), fsn.getBlockManager(),
+            LockFreeGSetController.getInstance());
       }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/DelimitedProtoBufParseHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/DelimitedProtoBufParseHelper.java
@@ -42,8 +42,10 @@ import java.nio.ByteBuffer;
  *  <li>1. Small messages (≤ buffer size): Reuse pre-allocated ByteBuffer </li>
  *  <li>2. Large messages (> buffer size): Use streaming with LimitInputStream </li>
  * </ul>
- * 
+ *
  * mark sure to specific an appropriate buffer size so that most messages use mode 1
+ *
+ * @param <T> Type of the message.
  */
 public class DelimitedProtoBufParseHelper<T extends GeneratedMessageV3> {
 
@@ -55,8 +57,21 @@ public class DelimitedProtoBufParseHelper<T extends GeneratedMessageV3> {
   private final Parser<ByteBuffer, T> byteParser;
   private final Parser<InputStream, T> streamParser;
 
+  /**
+   * A parser interface defines how to parse Protocol Buffer messages.
+   *
+   * @param <T> Type of the source.
+   * @param <R> Type of the message.
+   */
   @FunctionalInterface
   public interface Parser<T, R extends GeneratedMessageV3> {
+    /**
+     * Parse a Protocol Buffer message from the source.
+     *
+     * @param source the source to parse from
+     * @return the parsed message
+     * @throws IOException if an I/O error occurs
+     */
     R parse(T source) throws IOException;
   }
 
@@ -92,6 +107,7 @@ public class DelimitedProtoBufParseHelper<T extends GeneratedMessageV3> {
    * Parse the next Protocol Buffer message with optimized memory usage.
    *
    * @return Next message object, or null if end of stream is reached
+   * @throws IOException if an I/O error occurs
    */
   public T parseNext() throws IOException {
     int size;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/DelimitedProtoBufParseHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/DelimitedProtoBufParseHelper.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.util;
+
+import org.apache.hadoop.hdfs.protocolPB.PBHelperClient;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.thirdparty.protobuf.GeneratedMessageV3;
+import org.apache.hadoop.util.LimitInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * This class is designed to reduce redundant byte array allocation
+ * when parsing large numbers of delimited ProtoBuf messages.
+ * <p>
+ * Protocol Buffer's parseDelimitedFrom() method creates a new 4096-byte array for
+ * each message parsed. When parsing large numbers of messages (such as
+ * INode entries in fsimage file), this results in significant memory
+ * allocation overhead and garbage collection pressure.
+ * <p>
+ * The helper uses a pre-allocated ByteBuffer for parsing small messages.
+ * It first read the next message size (vint encoded), then chooses one of two strategies:
+ * <ul>
+ *  <li>1. Small messages (≤ buffer size): Reuse pre-allocated ByteBuffer </li>
+ *  <li>2. Large messages (> buffer size): Use streaming with LimitInputStream </li>
+ * </ul>
+ * 
+ * mark sure to specific an appropriate buffer size so that most messages use mode 1
+ */
+public class DelimitedProtoBufParseHelper<T extends GeneratedMessageV3> {
+
+  private static final int DEFAULT_BUFFER_SIZE = 4096;
+
+  private final ByteBuffer buffer;
+  private final InputStream in;
+
+  private final Parser<ByteBuffer, T> byteParser;
+  private final Parser<InputStream, T> streamParser;
+
+  @FunctionalInterface
+  public interface Parser<T, R extends GeneratedMessageV3> {
+    R parse(T source) throws IOException;
+  }
+
+  /**
+   * Create a DelimitedProtoBufParseHelper with default buffer size (4096 bytes).
+   *
+   * @param in           input stream to parse
+   * @param byteParser   how to parse message from a ByteBuffer
+   * @param streamParser how to parse message from an InputStream
+   */
+  public DelimitedProtoBufParseHelper(InputStream in,
+      Parser<ByteBuffer, T> byteParser, Parser<InputStream, T> streamParser) {
+    this(DEFAULT_BUFFER_SIZE, in, byteParser, streamParser);
+  }
+
+  /**
+   * Create a DelimitedProtoBufParseHelper with custom buffer size.
+   *
+   * @param bufferSize   buffer size
+   * @param in           input stream to parse
+   * @param byteParser   how to parse message from a ByteBuffer
+   * @param streamParser how to parse message from an InputStream
+   */
+  public DelimitedProtoBufParseHelper(int bufferSize, InputStream in,
+      Parser<ByteBuffer, T> byteParser, Parser<InputStream, T> streamParser) {
+    this.buffer = ByteBuffer.allocate(bufferSize);
+    this.in = in;
+    this.byteParser = byteParser;
+    this.streamParser = streamParser;
+  }
+
+  /**
+   * Parse the next Protocol Buffer message with optimized memory usage.
+   *
+   * @return Next message object, or null if end of stream is reached
+   */
+  public T parseNext() throws IOException {
+    int size;
+    try {
+      size = PBHelperClient.vintPrefixedSize(in);
+    } catch (EOFException e) {
+      // EOF reached, return null to indicate parsing completion
+      return null;
+    }
+
+    if (size > buffer.capacity()) {
+      // LimitInputStream restricts bytes read to exactly the message size
+      return streamParser.parse(new LimitInputStream(in, size));
+    } else {
+      IOUtils.readFully(in, buffer.array(), 0, size);
+      buffer.position(0);
+      buffer.limit(size);
+      return byteParser.parse(buffer);
+    }
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1637,6 +1637,32 @@
 </property>
 
 <property>
+  <name>dfs.image.concurrent.init.inode.map.enable</name>
+  <value>false</value>
+  <description>
+        If true, NameNode will init INodeMap concurrently during startup.
+        The number of threads to use is equal to dfs.image.parallel.threads.
+        This config is effected only when dfs.image.parallel.load is true.
+  </description>
+</property>
+
+<property>
+  <name>dfs.image.name.cache.init.thread.num</name>
+  <value>1</value>
+  <description>
+        The number of threads to use when init NameCache during startup.
+  </description>
+</property>
+
+<property>
+  <name>dfs.image.block.map.init.thread.num</name>
+  <value>1</value>
+  <description>
+        The number of threads to use when init BlocksMap during startup.
+  </description>
+</property>
+
+<property>
   <name>dfs.edit.log.transfer.timeout</name>
   <value>30000</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImage.java
@@ -1221,4 +1221,81 @@ public class TestFSImage {
     SnapshotTestHelper.compareDumpedTreeInFile(
         preRestartTree, postRestartTree, true);
   }
+
+  @Test
+  public void testUpdateINodeMapAndBlocksMapAndNameCacheConcurrent() throws IOException {
+    Configuration conf = new Configuration();
+
+    conf.set(DFSConfigKeys.DFS_IMAGE_PARALLEL_LOAD_KEY, "true");
+    conf.set(DFSConfigKeys.DFS_IMAGE_PARALLEL_INODE_THRESHOLD_KEY, "1");
+    conf.set(DFSConfigKeys.DFS_IMAGE_PARALLEL_TARGET_SECTIONS_KEY, "4");
+    conf.set(DFSConfigKeys.DFS_IMAGE_PARALLEL_THREADS_KEY, "4");
+    conf.set(DFSConfigKeys.DFS_IMAGE_CONCURRENT_INIT_INODE_MAP_ENABLE, "true");
+    conf.set(DFSConfigKeys.DFS_IMAGE_NAME_CACHE_INIT_THREAD_NUM, "4");
+    conf.set(DFSConfigKeys.DFS_IMAGE_BLOCK_MAP_INIT_THREAD_NUM, "4");
+
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build();
+    cluster.waitActive();
+    DistributedFileSystem fs = cluster.getFileSystem();
+    FSDirectory fsdir = cluster.getNameNode().namesystem.getFSDirectory();
+    File workingDir = GenericTestUtils.getTestDir();
+
+    File preRestartTree = new File(workingDir, "preRestartTree");
+    File postRestartTree = new File(workingDir, "postRestartTree");
+
+    Path baseDir = new Path("/user/foo");
+    fs.mkdirs(baseDir);
+    fs.allowSnapshot(baseDir);
+    for (int i = 0; i < 5; i++) {
+      Path dir = new Path(baseDir, Integer.toString(i));
+      fs.mkdirs(dir);
+      for (int j = 0; j < 5; j++) {
+        Path file = new Path(dir, Integer.toString(j));
+        FSDataOutputStream os = fs.create(file);
+        os.write((byte) j);
+        os.close();
+      }
+      fs.createSnapshot(baseDir, "snap_"+i);
+      fs.rename(new Path(dir, "0"), new Path(dir, "renamed"));
+    }
+    SnapshotTestHelper.dumpTree2File(fsdir, preRestartTree);
+
+    long inodeNumPreRestart = cluster.getNameNode().namesystem.getFSDirectory().totalInodes();
+    long blockNumPreRestart = cluster.getNameNode().namesystem.getBlockManager().getTotalBlocks();
+
+    // checkpoint
+    fs.setSafeMode(SafeModeAction.ENTER);
+    fs.saveNamespace();
+    fs.setSafeMode(SafeModeAction.LEAVE);
+
+    cluster.restartNameNode();
+    cluster.waitActive();
+    fs = cluster.getFileSystem();
+    fsdir = cluster.getNameNode().namesystem.getFSDirectory();
+
+    // Ensure all the files created above exist, and blocks is correct.
+    for (int i = 0; i < 5; i++) {
+      Path dir = new Path(baseDir, Integer.toString(i));
+      assertTrue(fs.getFileStatus(dir).isDirectory());
+      for (int j = 0; j < 5; j++) {
+        Path file = new Path(dir, Integer.toString(j));
+        if (j == 0) {
+          file = new Path(dir, "renamed");
+        }
+        FSDataInputStream in = fs.open(file);
+        int n = in.readByte();
+        assertEquals(j, n);
+        in.close();
+      }
+    }
+    SnapshotTestHelper.dumpTree2File(fsdir, postRestartTree);
+    SnapshotTestHelper.compareDumpedTreeInFile(
+        preRestartTree, postRestartTree, true);
+
+    assertEquals(inodeNumPreRestart,
+        cluster.getNameNode().namesystem.getFSDirectory().totalInodes());
+    assertEquals(blockNumPreRestart,
+        cluster.getNameNode().namesystem.getBlockManager().getTotalBlocks());
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameCache.java
@@ -24,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
  * Test for {@link NameCache} class
  */
@@ -86,4 +89,54 @@ public class TestNameCache {
       assertEquals(lookupCount, cache.getLookupCount());
     }
   }
+
+  @Test
+  public void testInitializeWithMultipleThreads() throws Exception {
+    // Create dictionary with useThreshold 10
+    NameCache<String> cache = new NameCache<>(10);
+    String[] matching = {"part1", "part10000000", "fileabc", "abc", "filepart"};
+    String[] notMatching = {"spart1", "apart", "abcd", "def"};
+
+    int numThreads = 5;
+
+    ExecutorService executorService = Executors.newFixedThreadPool(5);
+
+    for (int i = 0; i <numThreads; i++) {
+      executorService.submit(() -> {
+        for (String s : matching) {
+          cache.put(s);
+          cache.put(s);
+        }
+
+        for (String s : notMatching) {
+          cache.put(s);
+        }
+      });
+    }
+
+    // Mark dictionary as initialized
+    cache.initialized();
+
+    for (String s : matching) {
+      verifyNameReuse(cache, s, true);
+    }
+    // Check dictionary size
+    assertEquals(matching.length, cache.size());
+
+    for (String s : notMatching) {
+      verifyNameReuse(cache, s, false);
+    }
+
+    cache.reset();
+    cache.initialized();
+
+    for (String s : matching) {
+      verifyNameReuse(cache, s, false);
+    }
+
+    for (String s : notMatching) {
+      verifyNameReuse(cache, s, false);
+    }
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestDelimitedProtoBufParseHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestDelimitedProtoBufParseHelper.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ipc.protobuf.TestProtos;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class TestDelimitedProtoBufParseHelper {
+
+  @Test
+  public void testParseMessages() throws IOException {
+    int bufferSize = 64;
+    int largeMessageSize = bufferSize * 2;
+    String smallMessageStrPrefix = "message";
+    String largeMessageStrPrefix = StringUtils.repeat('m', largeMessageSize - 1);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    for (int i = 0; i < 10; i++) { // write small messages 
+      TestProtos.EchoRequestProto.newBuilder()
+          .setMessage(smallMessageStrPrefix + i)
+          .build()
+          .writeDelimitedTo(output);
+    }
+
+    for (int i = 0; i < 10; i++) { // write large messages 
+      TestProtos.EchoRequestProto.newBuilder()
+          .setMessage(largeMessageStrPrefix + i)
+          .build()
+          .writeDelimitedTo(output);
+    }
+
+    DelimitedProtoBufParseHelper<TestProtos.EchoRequestProto> helper =
+        new DelimitedProtoBufParseHelper<>(
+            bufferSize,
+            new ByteArrayInputStream(output.toByteArray()),
+            TestProtos.EchoRequestProto::parseFrom,
+            TestProtos.EchoRequestProto::parseFrom
+        );
+
+    TestProtos.EchoRequestProto next;
+    int count = 0;
+    while ((next = helper.parseNext()) != null) {
+      if (count < 10) {
+        assertEquals(smallMessageStrPrefix + count, next.getMessage());
+      } else {
+        assertEquals(largeMessageStrPrefix + (count - 10), next.getMessage());
+      }
+      count++;
+    }
+
+    assertEquals(20, count);
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestDelimitedProtoBufParseHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestDelimitedProtoBufParseHelper.java
@@ -38,14 +38,14 @@ public class TestDelimitedProtoBufParseHelper {
     String largeMessageStrPrefix = StringUtils.repeat('m', largeMessageSize - 1);
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-    for (int i = 0; i < 10; i++) { // write small messages 
+    for (int i = 0; i < 10; i++) { // write small messages
       TestProtos.EchoRequestProto.newBuilder()
           .setMessage(smallMessageStrPrefix + i)
           .build()
           .writeDelimitedTo(output);
     }
 
-    for (int i = 0; i < 10; i++) { // write large messages 
+    for (int i = 0; i < 10; i++) { // write large messages
       TestProtos.EchoRequestProto.newBuilder()
           .setMessage(largeMessageStrPrefix + i)
           .build()


### PR DESCRIPTION
Refer to [HDFS-17864](https://issues.apache.org/jira/browse/HDFS-17864).

HDFS-14617 allows the inode and inode directory sections of the fsimage to be loaded in parallel.
However, increasing the configured number of sections and threads has diminishing returns as there are some synchronized points in the loading code to protect some in memory structures.

Currently, there are mainly 3 data structures that need to be protected by synchronized blocks:

1. INodeMap (internally based on LightWeightGSet, but it is not thread-safe)
2. BlocksMap (internally based on LightWeightGSet, but it is not thread-safe)  
3. NameCache (it is not thread-safe by itself)

To further improve FSImage loading speed, this PR attempts to make the above 3 data structures thread-safe, and then use multiple threads to initialize them when NameNode starts. 
Additionally, some optimizations have been made to reduce GC overheads during FSImage parsing.
In our tests, the FSImage loading time (165M inodes & 258M blocks) was reduced from 180s to 73s.

**1. Making LightWeightGSet thread-safe**
   LightWeightGSet is a HashMap-like data structure that uses a fixed-length array as hash buckets, with each array element storing the head node of an independent linked list.
   Since each linked list is independent, we can allocate a lock for each bucket to protect the corresponding linked list. 
   To trade off between memory consumption and concurrency, we can let multiple buckets share a lock and use a hash-based mapping.
   To minimize changes, we don't plan to implement a completely thread-safe GSet to replace LightWeightGSet, as this would require significant changes and is unnecessary since all operations on LightWeightGSet are synchronized once NameNode finishes starting up.
   We introduced an external synchronization tool GSetConcurrencyController to ensure the thread safety of LightWeightGSet during NameNode startup.
   Another issue that needs to be addressed is the GSet's size. Currently, the size in LightWeightGSet is not an atomic variable, and even if we use segmented locks to protect hash buckets, the size is still inaccurate.
   Fortunately, in the FSImage loading scenario, we can clearly know the expected size of INodeMap and BlocksMap after loading, so we can correct its size after loading is complete.


**2. Making NameCache thread-safe**
   This is simpler compared to LightWeightGSet. We only need to combine ConcurrentHashMap and AtomicInteger to implement a thread-safe version of NameCache.


**3. Reducing GC pressure during FSImage loading**
   After completing steps 1 and 2, we found that GC gradually became a new bottleneck. After analysis, we discovered that the parseDelimitedFrom method in ProtoBuffer creates a 4096-byte array as cache when parsing each INode object. 
   To optimize this issue, we introduced the DelimitedProtoBufParseHelper utility class to reuse the cache array.

**Appendix:** Test environment and configuration information
**Hadoop version**: current master, including previous fsimage loading optimizations: HDFS-13694, HDFS-14617, HDFS-15493
**FSImage information:**
    Size: 20G (165M inodes & 258M blocks)
**Config:**
      dfs.image.parallel.threads=16
      dfs.image.parallel.target.sections=128
      dfs.image.parallel.load=true

**new config in this patch:**
      dfs.image.concurrent.init.inode.map.enable=true
      dfs.image.name.cache.init.thread.num=16
      dfs.image.block.map.init.thread.num=16
