### PR TITLE
YARN-11899. TestRouterMetrics is order dependent

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.yarn.server.router;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +62,19 @@ public class TestRouterMetrics {
         metrics.getAppAttemptsFailedRetrieved());
 
     LOG.info("Test: aggregate metrics are updated correctly");
+  }
+
+  @BeforeEach
+  public void setup() {
+    //reset metrics before each test
+    RouterMetrics.destroy();
+    metrics = RouterMetrics.getMetrics();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    RouterMetrics.destroy();
+    metrics = RouterMetrics.getMetrics();
   }
 
   /**


### PR DESCRIPTION
### Description of PR

The following tests are order dependent if they are interleaved with some other tests. 

```
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testAppsFailedCreated
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testAppsFailedKilled
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testAppsFailedSubmitted
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testAppsReportFailed
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testMulipleAppsReportFailed
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testSucceededAppsCreated
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testSucceededAppsKilled
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testSucceededAppsReport
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testSucceededAppsSubmitted
org.apache.hadoop.yarn.server.router.TestRouterMetrics.testSucceededMultipleAppsReport
```

I believe this is because the Router is being used by some other module, causing the statistics to be inaccurate.  To address this problem, ``RouterMetrics`` should be reset before and after every test. This PR creates a setup and teardown to perform this action


### How was this patch tested?
Existing tests in TestRouterMetrics that pass continue to pass, and tests that fail in TestRouterMetrics continue to fail. 


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

