### PR TITLE
YARN-11909. Fix for fetching logs for a running application

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java
@@ -151,6 +151,9 @@ public class LogsCLI extends Configured implements Tool {
       if (webServiceClient != null) {
         webServiceClient.close();
       }
+      if (sslFactory != null) {
+        sslFactory.destroy();
+      }
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java
@@ -28,6 +28,7 @@ import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,6 +42,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
+import javax.net.ssl.HttpsURLConnection;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientRequestContext;
@@ -64,6 +66,7 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptReport;
@@ -122,6 +125,7 @@ public class LogsCLI extends Configured implements Tool {
   private PrintStream outStream = System.out;
   private YarnClient yarnClient = null;
   private Client webServiceClient = null;
+  private static SSLFactory sslFactory = null;
 
   private static final int DEFAULT_MAX_RETRIES = 30;
   private static final long DEFAULT_RETRY_INTERVAL = 1000;
@@ -428,6 +432,7 @@ public class LogsCLI extends Configured implements Tool {
     LogsCLI logDumper = new LogsCLI();
     logDumper.setConf(conf);
     WebServiceClient.initialize(conf);
+    sslFactory = WebServiceClient.getSSLFactory();
     int exitCode = logDumper.run(args);
     WebServiceClient.destroy();
     System.exit(exitCode);
@@ -1551,18 +1556,29 @@ public class LogsCLI extends Configured implements Tool {
       }
     }
 
-    private void checkUrlConnectivity(URI uri) throws IOException {
+    private void checkUrlConnectivity(URI uri) throws IOException, GeneralSecurityException {
       URL url = uri.toURL();
+      HttpURLConnection connection = null;
+      try {
+        connection = (HttpURLConnection) url.openConnection();
+        if (sslFactory != null) {
+          HttpsURLConnection httpsConn = (HttpsURLConnection) connection;
+          httpsConn.setSSLSocketFactory(sslFactory.createSSLSocketFactory());
+          httpsConn.setHostnameVerifier(sslFactory.getHostnameVerifier());
+        }
+        connection.setRequestMethod("HEAD");
+        connection.setConnectTimeout(TIME_OUT);
+        connection.setReadTimeout(TIME_OUT);
 
-      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-      connection.setRequestMethod("HEAD");
-      connection.setConnectTimeout(TIME_OUT);
-      connection.setReadTimeout(TIME_OUT);
-
-      // The purpose of getting the `responseCode` here is to check if the service is online.
-      int responseCode = connection.getResponseCode();
-      if (responseCode >= 400) {
-        throw new IOException("URL connectivity check failed with HTTP code " + responseCode);
+        // The purpose of getting the `responseCode` here is to check if the service is online.
+        int responseCode = connection.getResponseCode();
+        if (responseCode >= 400) {
+          throw new IOException("URL connectivity check failed with HTTP code " + responseCode);
+        }
+      } finally {
+        if (connection != null) {
+          connection.disconnect();
+        }
       }
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebServiceClient.java
@@ -67,8 +67,7 @@ public class WebServiceClient {
     return instance;
   }
 
-  @VisibleForTesting
-  SSLFactory getSSLFactory() {
+  public static SSLFactory getSSLFactory() {
     return sslFactory;
   }
 


### PR DESCRIPTION
Change-Id: I6af1b8805e6b056fb226aea99e01ab21c5bfd179

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
URL connectivity check in YARN Logs CLI can not connect to the RM on a secured environment when getting the logs for a running application.

Jersey 2 upgrade introduced a new logic for checking URL connectivity before getting the logs from the appropriate services.

This logic uses HttpURLConnection that can not load SSL configuration from the ssl-client.xml on a secure environment. As I can see in such cases we need to use HttpsURLConnection

### How was this patch tested?
Tested on a secured and unsecured environment:
- logs for a running application can be fetched on both
- when I stopped the NMs, retry logic keeps trying the connections

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

