### PR TITLE
HADOOP-19757: WASB. Force Init with Blob Endpoint

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
@@ -379,6 +379,8 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
       + "exists first. If it is not publicly available, you have to provide "
       + "account credentials.";
 
+  private static boolean wasInitialisedWithDFS = false;
+
   /**
    * A test hook interface that can modify the operation context we use for
    * Azure Storage operations, e.g. to inject errors.
@@ -741,6 +743,37 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
   }
 
   /**
+   * Marks that the file system was initialized with DFS endpoint.
+   * Sets the static flag to true.
+   */
+  void markInitialisedWithDFS() {
+    wasInitialisedWithDFS = true;
+  }
+
+  /**
+   * Checks if the file system was initialized with DFS.
+   *
+   * @return true if initialized with DFS, false otherwise
+   */
+  boolean getWasInitialisedWithDFS() {
+    return wasInitialisedWithDFS;
+  }
+
+  /**
+   * Returns the original account name, replacing ".blob." with ".dfs." if the file system
+   * was initialized with DFS.
+   *
+   * @param accountName the account name to process
+   * @return the original or modified account name depending on initialization
+   */
+  String getOriginalAccountName(String accountName) {
+    if (getWasInitialisedWithDFS()) {
+      return accountName.replace(".blob.", ".dfs.");
+    }
+    return accountName;
+  }
+
+  /**
    * Set the configuration parameters for this client storage session with
    * Azure.
    *
@@ -1096,7 +1129,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
 
       // Check whether we have a shared access signature for that container.
       String propertyValue = sessionConfiguration.get(KEY_ACCOUNT_SAS_PREFIX
-          + containerName + "." + accountName);
+          + containerName + "." + getOriginalAccountName(accountName));
       if (propertyValue != null) {
         // SAS was found. Connect using that.
         connectUsingSASCredentials(accountName, containerName, propertyValue);
@@ -1104,7 +1137,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
       }
 
       // Check whether the account is configured with an account key.
-      propertyValue = getAccountKeyFromConfiguration(accountName,
+      propertyValue = getAccountKeyFromConfiguration(getOriginalAccountName(accountName),
           sessionConfiguration);
       if (StringUtils.isNotEmpty(propertyValue)) {
         // Account key was found.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -111,6 +111,11 @@ import com.microsoft.azure.storage.StorageException;
 public class NativeAzureFileSystem extends FileSystem {
   private static final int USER_WX_PERMISION = 0300;
   private static final String USER_HOME_DIR_PREFIX_DEFAULT = "/user";
+  private static final String BLOB_ENDPOINT = ".blob.";
+  private static final String DFS_ENDPOINT = ".dfs.";
+
+  private static boolean isInitialisedWithDfsEndpoint = false;
+
   /**
    * A description of a folder rename operation, including the source and
    * destination keys, and descriptions of the files in the source folder.
@@ -1262,7 +1267,6 @@ public class NativeAzureFileSystem extends FileSystem {
 
   private URI uri;
   private NativeFileSystemStore store;
-  private AzureNativeFileSystemStore actualStore;
   private Path workingDir;
   private AzureFileSystemInstrumentation instrumentation;
   private String metricsSourceName;
@@ -1397,9 +1401,31 @@ public class NativeAzureFileSystem extends FileSystem {
         getConf())));
   }
 
+/**
+ * Converts a DFS endpoint URI to a Blob endpoint URI
+ * If the input URI contains ".dfs.", it replaces it with ".blob." and returns the new URI.
+ * Also sets the isInitialisedWithDfsEndpoint flag to true if conversion occurs.
+ *
+ * @param uri the original URI, possibly with a DFS endpoint
+ * @return a URI with the Blob endpoint if conversion was needed, otherwise the original URI
+ */
+private URI convertToBlobEndpoint(URI uri) {
+  if (uri.toString().contains(DFS_ENDPOINT)) {
+    isInitialisedWithDfsEndpoint = true;
+    LOG.debug("Filesystem initialized with DFS endpoint. Initializing with Blob endpoint instead.");
+    return URI.create(uri.toString().replace(DFS_ENDPOINT, BLOB_ENDPOINT));
+  } else {
+    return uri;
+  }
+}
+
   @Override
   public void initialize(URI uri, Configuration conf)
       throws IOException, IllegalArgumentException {
+
+    // Convert DFS endpoint to Blob endpoint if needed.
+    uri = convertToBlobEndpoint(uri);
+
     // Check authority for the URI to guarantee that it is non-null.
     uri = reconstructAuthorityIfNeeded(uri, conf);
     if (null == uri.getAuthority()) {
@@ -1421,6 +1447,10 @@ public class NativeAzureFileSystem extends FileSystem {
       String sourceDesc = "Azure Storage Volume File System metrics";
       AzureFileSystemMetricsSystem.registerSource(metricsSourceName, sourceDesc,
         instrumentation);
+    }
+
+    if (isInitialisedWithDfsEndpoint) {
+      getStore().markInitialisedWithDFS();
     }
 
     store.initialize(uri, conf, instrumentation);
@@ -1485,12 +1515,12 @@ public class NativeAzureFileSystem extends FileSystem {
   }
 
   private NativeFileSystemStore createDefaultStore(Configuration conf) {
-    actualStore = new AzureNativeFileSystemStore();
+    store = new AzureNativeFileSystemStore();
 
     if (suppressRetryPolicy) {
-      actualStore.suppressRetryPolicy();
+      ((AzureNativeFileSystemStore) store).suppressRetryPolicy();
     }
-    return actualStore;
+    return store;
   }
 
   /**
@@ -1588,7 +1618,7 @@ public class NativeAzureFileSystem extends FileSystem {
    */
   @VisibleForTesting
   public AzureNativeFileSystemStore getStore() {
-    return actualStore;
+    return (AzureNativeFileSystemStore) store;
   }
 
   NativeFileSystemStore getStoreInterface() {

--- a/hadoop-tools/hadoop-azure/src/site/markdown/index.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/index.md
@@ -802,16 +802,15 @@ requests. User can specify them as fixed SAS Token to be used across all the req
 ### User-bound SAS
 - **Description**: The user-bound SAS auth type allows to track the usage of the SAS token generated- something
  that was not possible in user-delegation SAS authentication type. Reach out to us at 'askabfs@microsoft.com' for more information.
- To use this authentication type, both custom SAS token provider class (that implements org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider) as
-    well as OAuth 2.0 provider type need to be specified.
-    - Refer to 'Shared Access Signature (SAS) Token Provider' section above for user-delegation SAS token provider class details and example class implementation.
-    - There are multiple identity configurations for OAuth settings. Listing the main ones below:
+ To use this authentication type, both custom SAS token provider class as well as OAuth 2.0 provider type need to be specified.
+    - Read the section below for SAS Token Provider class details and example class implementation.
+    - There are multiple identity configurations for OAuth Token Provider settings. Listing the main ones below:
         - Client Credentials
         - Custom token provider
         - Managed Identity
         - Workload Identity
 
-      Refer to respective OAuth 2.0 sections above to correctly chose the OAuth provider type
+      Refer to respective OAuth 2.0 sections above to correctly choose the OAuth provider type
     - NOTE: User-bound SAS Authentication is **only supported** with HNS Enabled accounts.
 
 - **Configuration**: To use this method with ABFS Driver, specify the following properties in your `core-site.xml` file:
@@ -837,6 +836,57 @@ requests. User can specify them as fixed SAS Token to be used across all the req
           <value>CUSTOM_SAS_TOKEN_PROVIDER_CLASS</value>
         </property>
         ```
+       - ABFS allows you to implement your custom SAS Token Provider. The declared class must implement 
+           `org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider`. ABFS Hadoop Driver provides a [MockUserBoundSASTokenProvider](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/MockUserBoundSASTokenProvider.java)
+           implementation that can be used as an example on how to implement your own custom
+           SASTokenProvider. This requires the Application credentials to be specifed using
+           the following configurations apart from above three:
+
+  4. Delegator App Service Principal Tenant Id:
+      ```xml
+      <property>
+        <name>fs.azure.test.app.service.principal.tenant.id</name>
+        <value>DELEGATOR_TENANT_ID</value>
+      </property>
+      ```
+  5. Delegator App Service Principal Object Id:
+      ```xml
+      <property>
+        <name>fs.azure.test.app.service.principal.object.id</name>
+        <value>DELEGATOR_OBJECT_ID</value>
+      </property>
+      ```
+  6. End-user App Service Principal Tenant Id:
+     ```xml
+      <property>
+        <name>fs.azure.test.end.user.tenant.id</name>
+        <value>DELEGATED_TENANT_ID</value>
+      </property>
+      ```
+
+   7. End-user App Service Principal Object Id:
+      ```xml
+      <property>
+        <name>fs.azure.test.end.user.object.id</name>
+        <value>DELEGATED_OBJECT_ID</value>
+      </property>
+      ```
+  
+  8. Delegator App Id:
+      ```xml
+      <property>
+        <name>fs.azure.test.app.id</name>
+        <value>APPLICATION_ID</value>
+      </property>
+     ```
+  9. Delegator App Secret:
+     ```xml
+     <property>
+       <name>fs.azure.test.app.secret</name>
+       <value>APPLICATION_SECRET</value>
+     </property>
+     ```
+  - Add all additional configs required by the chosen OAuth Token provider from the sections above as well.
 
 ## <a name="technical"></a> Technical notes
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
@@ -454,6 +454,20 @@ public final class AzureBlobStorageTestAccount implements AutoCloseable,
         Base64.encode(new byte[] { 1, 2, 3 }));  
   }
 
+  /**
+   * Sets a mock SAS (Shared Access Signature) key in the given configuration for the specified container and account.
+   *
+   * @param conf        The Hadoop configuration to update.
+   * @param container   The name of the container.
+   * @param accountName The name of the account.
+   */
+  public static void setMockSASKey(Configuration conf,
+      String container,
+      String accountName) {
+    conf.set(SAS_PROPERTY_NAME + container + "." + accountName,
+        Base64.encode(new byte[]{1, 2, 3}));
+  }
+
   private static URI createAccountUri(String accountName)
       throws URISyntaxException {
     return new URI(WASB_SCHEME + ":" + PATH_DELIMITER + PATH_DELIMITER

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.fs.azure;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.WASB_AUTHORITY_DELIMITER;
+import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.setMockAccountKey;
+import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.setMockSASKey;
 import static org.apache.hadoop.fs.azure.NativeAzureFileSystem.RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -28,6 +31,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.Date;
 import java.util.EnumSet;
@@ -61,6 +65,15 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
 
   private static final int FILE_SIZE = 4096;
   private static final String PATH_DELIMITER = "/";
+  private static final String ACCOUNT_NAME = "account";
+  private static final String CONTAINER_NAME = "container";
+  private static final String WASB_URI_SCHEME  = "wasb://";
+  private static final String BLOB_ENDPOINT_SUFFIX =
+      ".blob.core.windows.net";
+  private static final String DFS_ENDPOINT_SUFFIX =
+      ".dfs.core.windows.net";
+  private static final String CUSTOM_ENDPOINT_SUFFIX =
+      ".custom.core.windows.net";
 
   protected String accountName;
   protected String accountKey;
@@ -75,9 +88,16 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
   }
 
   @BeforeEach
-  public void setMode() {
+  public void setMode() throws IllegalAccessException, NoSuchFieldException {
     runningInSASMode = AzureBlobStorageTestAccount.createTestConfiguration().
         getBoolean(AzureNativeFileSystemStore.KEY_USE_SECURE_MODE, false);
+    Field isDfsEndpointInitializedField = NativeAzureFileSystem.class.getDeclaredField("isInitialisedWithDfsEndpoint");
+    isDfsEndpointInitializedField.setAccessible(true);
+    isDfsEndpointInitializedField.setBoolean(null, false);
+    
+    Field isStoreInitializedWithDfsField = AzureNativeFileSystemStore.class.getDeclaredField("wasInitialisedWithDFS");
+    isStoreInitializedWithDfsField.setAccessible(true);
+    isStoreInitializedWithDfsField.setBoolean(null, false);
   }
 
   private boolean validateIOStreams(Path filePath) throws IOException {
@@ -252,7 +272,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
   @Test
   public void testConnectToFullyQualifiedAccountMock() throws Exception {
     Configuration conf = new Configuration();
-    AzureBlobStorageTestAccount.setMockAccountKey(conf,
+    setMockAccountKey(conf,
         "mockAccount.mock.authority.net");
     AzureNativeFileSystemStore store = new AzureNativeFileSystemStore();
     MockStorageInterface mockStorage = new MockStorageInterface();
@@ -659,6 +679,206 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
     } finally {
       testAccount.cleanup();
       FileSystem.closeAll();
+    }
+  }
+
+  private enum AuthType {
+    ACCOUNT_KEY,
+    SAS
+  }
+
+  private enum FsCreationMode {
+    DEFAULT,
+    WITH_STORE
+  }
+
+  /**
+   * Creates a Hadoop {@link Configuration} object and sets up mock credentials
+   * for the specified authentication type and account endpoint.
+   *
+   * @param authType the authentication type to use (ACCOUNT_KEY or SAS)
+   * @param accountEndpoint the account endpoint to use for credentials
+   * @return a {@link Configuration} object with the appropriate mock credentials set
+   */
+  private static Configuration createConf(
+      AuthType authType, String accountEndpoint) {
+
+    Configuration conf = new Configuration();
+
+    if (authType == AuthType.ACCOUNT_KEY) {
+      setMockAccountKey(conf, accountEndpoint);
+    } else if (authType == AuthType.SAS) {
+      setMockSASKey(conf, CONTAINER_NAME, accountEndpoint);
+    }
+
+    return conf;
+  }
+
+  /**
+   * Creates a {@link NativeAzureFileSystem} instance using the default constructor and initializes it with the given URI and configuration.
+   *
+   * @param uri  the URI to initialize the file system with
+   * @param conf the Hadoop configuration
+   * @return a new initialized {@link NativeAzureFileSystem}
+   * @throws Exception if initialization fails
+   */
+  private static NativeAzureFileSystem createFsDefault(URI uri,
+      Configuration conf) throws Exception {
+    NativeAzureFileSystem fs = new NativeAzureFileSystem();
+    fs.initialize(uri, conf);
+    return fs;
+  }
+
+  /**
+   * Creates a {@link NativeAzureFileSystem} instance using a custom store and mock storage interface.
+   *
+   * @param uri  the URI to initialize the file system with
+   * @param conf the Hadoop configuration
+   * @return a new initialized {@link NativeAzureFileSystem}
+   * @throws Exception if initialization fails
+   */
+  private static NativeAzureFileSystem createFsWithStore(URI uri,
+      Configuration conf) throws Exception {
+    AzureNativeFileSystemStore store = new AzureNativeFileSystemStore();
+    MockStorageInterface mockStorage = new MockStorageInterface();
+    store.setAzureStorageInteractionLayer(mockStorage);
+    NativeAzureFileSystem fs = new NativeAzureFileSystem(store);
+    fs.initialize(uri, conf);
+    return fs;
+  }
+
+  /**
+   * Creates a {@link NativeAzureFileSystem} instance based on the specified creation mode.
+   *
+   * @param mode the file system creation mode (DEFAULT or WITH_STORE)
+   * @param uri  the URI to initialize the file system with
+   * @param conf the Hadoop configuration
+   * @return a new initialized {@link NativeAzureFileSystem}
+   * @throws Exception if initialization fails or mode is unknown
+   */
+  private static NativeAzureFileSystem createFs(
+      FsCreationMode mode, URI uri, Configuration conf) throws Exception {
+
+    if (mode == FsCreationMode.DEFAULT) {
+      return createFsDefault(uri, conf);
+    } else if (mode == FsCreationMode.WITH_STORE) {
+      return createFsWithStore(uri, conf);
+    }
+
+    throw new IllegalArgumentException("Unknown FsCreationMode: " + mode);
+  }
+
+  /**
+   * Asserts the transformation of a WASB URI based on the expected endpoint and authentication type.
+   *
+   * @param inputUri            The input URI to test.
+   * @param accountEndpointHost The expected account endpoint host in the transformed URI.
+   * @param expectChange        Whether a transformation of the URI is expected.
+   * @param authType            The authentication type (ACCOUNT_KEY or SAS).
+   * @param mode                The file system creation mode.
+   * @throws Exception if an error occurs during the test.
+   */
+  private static void assertUriTransformation(
+      URI inputUri,
+      String accountEndpointHost,
+      boolean expectChange,
+      AuthType authType,
+      FsCreationMode mode) throws Exception {
+
+    Configuration conf =
+        createConf(authType, inputUri.getHost());
+
+    NativeAzureFileSystem fs = createFs(mode, inputUri, conf);
+    URI resultUri = fs.getUri();
+
+    if (expectChange) {
+      assertTrue(
+          resultUri.toString().contains(accountEndpointHost),
+          "URI should be converted to expected endpoint"
+      );
+      assertFalse(
+          resultUri.toString().contains(inputUri.getHost()),
+          "URI should not contain original endpoint"
+      );
+    } else {
+      assertEquals(
+          inputUri,
+          resultUri,
+          "URI should remain unchanged"
+      );
+    }
+  }
+
+  /**
+   * Tests that a WASB URI using the DFS endpoint is automatically transformed
+   * to use the BLOB endpoint during initialization, for all authentication types
+   * and file system creation modes.
+   */
+  @Test
+  public void testDfsEndpointIsTransformedToBlobEndpoint() throws Exception {
+    URI dfsUri =
+        new URI(WASB_URI_SCHEME + CONTAINER_NAME + WASB_AUTHORITY_DELIMITER
+            + ACCOUNT_NAME
+            + DFS_ENDPOINT_SUFFIX);
+
+    for (AuthType auth : AuthType.values()) {
+      for (FsCreationMode mode : FsCreationMode.values()) {
+        assertUriTransformation(
+            dfsUri,
+            BLOB_ENDPOINT_SUFFIX,
+            true,
+            auth,
+            mode
+        );
+      }
+    }
+  }
+
+  /**
+   * Tests that when a WASB URI already uses the blob endpoint,
+   * the URI remains unchanged after initialization, regardless of authentication type or file system creation mode.
+   */
+  @Test
+  public void testBlobEndpointRemainsUnchangedForBlobUri() throws Exception {
+    URI blobUri =
+        new URI(WASB_URI_SCHEME + CONTAINER_NAME + WASB_AUTHORITY_DELIMITER
+            + ACCOUNT_NAME
+            + BLOB_ENDPOINT_SUFFIX);
+
+    for (AuthType auth : AuthType.values()) {
+      for (FsCreationMode mode : FsCreationMode.values()) {
+        assertUriTransformation(
+            blobUri,
+            blobUri.getHost(),
+            false,
+            auth,
+            mode
+        );
+      }
+    }
+  }
+
+  /**
+   * Tests that when a WASB URI uses a custom endpoint (not blob or dfs),
+   * the URI remains unchanged after initialization, regardless of authentication type or file system creation mode.
+   */
+  @Test
+  public void testCustomEndpointUriRemainsUnchanged() throws Exception {
+    URI customUri =
+        new URI(WASB_URI_SCHEME + CONTAINER_NAME + WASB_AUTHORITY_DELIMITER
+            + ACCOUNT_NAME
+            + CUSTOM_ENDPOINT_SUFFIX);
+
+    for (AuthType auth : AuthType.values()) {
+      for (FsCreationMode mode : FsCreationMode.values()) {
+        assertUriTransformation(
+            customUri,
+            customUri.getHost(),
+            false,
+            auth,
+            mode
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of PR
We have observed cases of WASB being initialised with DFS which is not a supported endpoint. 
Force initializing WASB with Blob endpoint in such cases.

### How was this patch tested?
We tested the patch for WASB test suite with account configured with DFS endpoint.