### PR TITLE
HADOOP-17540 Backport ModuleUtil fix

### DIFF
--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -247,6 +247,7 @@
                         <exclude>META-INF/versions/9/module-info.class</exclude>
                         <exclude>META-INF/versions/11/module-info.class</exclude>
                         <exclude>META-INF/versions/18/module-info.class</exclude>
+                        <exclude>META-INF/versions/9/javax/xml/bind/ModuleUtil.class</exclude>
                       </excludes>
                     </filter>
 


### PR DESCRIPTION
### Description of PR

This file breaks using jaxb in the same classpath where Hadoop is present if JVM 9+ See ticket: https://issues.apache.org/jira/browse/HADOOP-17540
This was fixed on https://github.com/apache/hadoop/pull/7019 for trunk, but the 3.4 branch still has the problem, I am not sure if you are planning to cut a new release from 3.4 but as I see that there has been commits in that branch I assume that it will happen eventually.
In fact, we would love a 3.3 backport, as I am not sure if Spark 3 will work with Hadoop 3.4 which is our setup.

### How was this patch tested?

I have not tested it as I don't have the setup for this project done.
But it should be as simple as generating the shaded jars, expanding, and confirming that the file is not there anymore.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

