### PR TITLE
YARN-11912: Suppress Spotbugs warnings introduced in recent trunk changes

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
+++ b/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
@@ -791,7 +791,7 @@
 
   <Match>
     <Class name="org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService$PublicLocalizer" />
-    <Method name="run" />
+    <Method name="work" />
     <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION" />
   </Match>
 
@@ -805,5 +805,10 @@
     <Class name="org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.WeightQueueCapacityCalculator" />
     <Method name="calculateMinimumResource" />
     <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
+  </Match>
+
+  <Match>
+    <Class name="org.apache.hadoop.yarn.server.resourcemanager.ResourceManager" />
+    <Bug pattern="IS2_INCONSISTENT_SYNC" />
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
### Description of PR

Suppress Spotbugs warnings introduced in recent trunk changes

1. There was a pre-existing exclusion of a potential NPE warning in `ResourceLocalizationService`. #8062 changed the relevant method from `run()` to `work()`, so the exclusion needs a corresponding change to match.
2. The Spotbugs upgrade triggered numerous new warnings. #8053 was intended to update exclusions to cover these new warnings. I think that just missed a thread synchronization warning in `ResourceManager`.

### How was this patch tested?

1. Run `mvn -o test-compile spotbugs:spotbugs -DskipTests` locally.
2. Confirm the warnings are no longer present in `hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/target/spotbugs.xml`.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

