### PR TITLE
HDFS-17865. Prevent updateNameDirSize() from blocking rollEditLog()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Storage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Storage.java
@@ -403,7 +403,7 @@ public abstract class Storage extends StorageInfo {
     /**
      * Get storage directory size.
      */
-    public long getDirecorySize() {
+    public long getDirectorySize() {
       try {
         if (!isShared() && root != null && root.exists()) {
           return FileUtils.sizeOfDirectory(root);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImage.java
@@ -1186,8 +1186,7 @@ public class FSImage implements Closeable {
     } finally {
       removeFromCheckpointing(imageTxId);
     }
-    //Update NameDirSize Metric
-    getStorage().updateNameDirSize();
+    getStorage().invalidateNameDirSizeCache();
 
     if (exitAfterSave.get()) {
       LOG.error("NameNode process will exit now... The saved FsImage " +
@@ -1386,8 +1385,7 @@ public class FSImage implements Closeable {
     // we won't miss this log segment on a restart if the edits directories
     // go missing.
     storage.writeTransactionIdFileToStorage(getEditLog().getCurSegmentTxId());
-    //Update NameDirSize Metric
-    getStorage().updateNameDirSize();
+    getStorage().invalidateNameDirSizeCache();
     return new CheckpointSignature(this);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorage.java
@@ -57,6 +57,8 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.DNS;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Time;
+
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.eclipse.jetty.util.ajax.JSON;
 
 import org.apache.hadoop.classification.VisibleForTesting;
@@ -161,7 +163,7 @@ public class NNStorage extends Storage implements Closeable,
   /**
    * Name directories size for metric.
    */
-  private Map<String, Long> nameDirSizeMap = new HashMap<>();
+  private Map<String, Long> nameDirSizeMap;
 
   /**
    * Construct the NNStorage.
@@ -181,7 +183,7 @@ public class NNStorage extends Storage implements Closeable,
                           Lists.newArrayList(editsDirs),
                           FSNamesystem.getSharedEditsDirs(conf));
     //Update NameDirSize metric value after NN start
-    updateNameDirSize();
+    nameDirSizeMap = calculateNameDirSize();
   }
 
   @Override // Storage
@@ -1145,20 +1147,40 @@ public class NNStorage extends Storage implements Closeable,
     return new NamespaceInfo(this);
   }
 
+  /**
+   * Gets a string dump of {@link #nameDirSizeMap}. Recalculates the map if stale.
+   */
   public String getNNDirectorySize() {
-    return JSON.toString(nameDirSizeMap);
+    Map<String, Long> snapshot = nameDirSizeMap;
+    if (snapshot == null) {
+      snapshot = calculateNameDirSize();
+      nameDirSizeMap = snapshot;
+    }
+    return JSON.toString(snapshot);
   }
 
-  public void updateNameDirSize() {
+  /**
+   * Invalidates the metrics map result, making
+   * metric queries recalculate the map in {@link #getNNDirectorySize}.
+   */
+  public void invalidateNameDirSizeCache() {
+    nameDirSizeMap = null;
+  }
+
+  /**
+   * Scans all storage dirs and calculates their sizes.
+   * @return an immutable map of storage dir sizes
+   */
+  @VisibleForTesting
+  public ImmutableMap<String, Long> calculateNameDirSize() {
     Map<String, Long> nnDirSizeMap = new HashMap<>();
     for (Iterator<StorageDirectory> it = dirIterator(); it.hasNext();) {
       StorageDirectory sd = it.next();
       if (!sd.isShared()) {
-        nnDirSizeMap.put(sd.getRoot().getAbsolutePath(), sd.getDirecorySize());
+        nnDirSizeMap.put(sd.getRoot().getAbsolutePath(), sd.getDirectorySize());
       }
     }
-    nameDirSizeMap.clear();
-    nameDirSizeMap.putAll(nnDirSizeMap);
+    return ImmutableMap.copyOf(nnDirSizeMap);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/EditLogTailer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/EditLogTailer.java
@@ -547,9 +547,8 @@ public class EditLogTailer {
             NameNode.getNameNodeMetrics().addEditLogTailTime(
                 timer.monotonicNow() - startTime);
           }
-          //Update NameDirSize Metric
           if (triggeredLogRoll) {
-            namesystem.getFSImage().getStorage().updateNameDirSize();
+            namesystem.getFSImage().getStorage().invalidateNameDirSizeCache();
           }
         } catch (EditLogInputException elie) {
           LOG.warn("Error while reading edits from disk. Will try again.", elie);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.server.namenode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
@@ -58,12 +59,14 @@ import org.apache.hadoop.io.nativeio.NativeIO;
 import org.apache.hadoop.io.nativeio.NativeIO.POSIX.NoMlockCacheManipulator;
 import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.VersionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +91,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.spy;
 
 /**
  * Class for testing {@link NameNodeMXBean} implementation
@@ -832,17 +836,30 @@ public class TestNameNodeMXBean {
       fs = cluster.getFileSystem(0);
       DFSTestUtil.createFile(fs, new Path("/file"), 0, (short) 1, 0L);
 
+      final AtomicInteger recalculations = new AtomicInteger(0);
+      NNStorage spyStorage = spy(nn0.getFSImage().getStorage());
+      Mockito.doAnswer(invocation -> {
+        recalculations.incrementAndGet();
+        return invocation.callRealMethod();
+      }).when(spyStorage).calculateNameDirSize();
+      Whitebox.setInternalState(nn0.getFSImage(), "storage", spyStorage);
       //rollEditLog
       HATestUtil.waitForStandbyToCatchUp(cluster.getNameNode(0),
           cluster.getNameNode(1));
+      // Expensive IO bound nnDirSizeMap calculation should not run during rollEditLog
+      assertEquals(0, recalculations.get());
       checkNNDirSize(cluster.getNameDirs(0), nn0.getNameDirSize());
+      // And should only run during metrics query
+      assertEquals(1, recalculations.get());
       checkNNDirSize(cluster.getNameDirs(1), nn1.getNameDirSize());
 
       //Test metric after call saveNamespace
       DFSTestUtil.createFile(fs, new Path("/file"), 0, (short) 1, 0L);
       nn0.setSafeMode(SafeModeAction.SAFEMODE_ENTER);
       nn0.saveNamespace(0, 0);
+      assertEquals(1, recalculations.get());
       checkNNDirSize(cluster.getNameDirs(0), nn0.getNameDirSize());
+      assertEquals(2, recalculations.get());
     } finally {
       cluster.shutdown();
     }


### PR DESCRIPTION
### Description of PR

updateNameDirSize() has only metrics functionality (i.e. not very critical) but has a fair bit of performance impact in one of the more critical methods (rollEditLog). It's better to either reduce the metrics update frequency or make it update asynchronously to avoid interference with rollEditLog().

### How was this patch tested?

UT, and production environment.

Before
<img width="1588" height="434" alt="image" src="https://github.com/user-attachments/assets/41aa501e-5df2-4186-bbbb-a2b3479ffe7c" />

After
<img width="1490" height="442" alt="image" src="https://github.com/user-attachments/assets/c67c855d-2f04-44d8-a037-7c304000498e" />
