### PR TITLE
HADOOP-19760: hadoop-azure JavaDoc build fails

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -169,7 +169,7 @@ public final class AbfsHttpConstants {
   /**
    * HTTP status code indicating that the server has received too many requests and the client should
    * qualify for retrying the operation, as described in the Microsoft Azure documentation.
-   * {@link "https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#error-handling"}.
+   * {@see https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#error-handling}.
    */
   public static final int HTTP_TOO_MANY_REQUESTS = 429;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferManagerV2.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferManagerV2.java
@@ -1145,7 +1145,7 @@ public final class ReadBufferManagerV2 extends ReadBufferManager {
   public static class ReadThreadPoolStats extends ResourceUtilizationStats {
 
     /**
-     * Constructs a {@link .ReadThreadPoolStats} instance containing thread pool
+     * Constructs a {@link ReadThreadPoolStats} instance containing thread pool
      * metrics and JVM/system resource utilization details.
      *
      * @param currentPoolSize the current number of threads in the pool


### PR DESCRIPTION
### Description of PR

While attempting a full distro build on current trunk, I discovered a few hadoop-azure JavaDoc errors that stopped the build:

* [HADOOP-17377](https://issues.apache.org/jira/browse/HADOOP-17377) introduced a `@link` tag trying to reference an external link instead of a Java symbol. This was probably meant to be a `@see` tag.
* [HADOOP-19737](https://issues.apache.org/jira/browse/HADOOP-19737) introduced a `@link` tag with an apparent typo on the symbol it was trying to reference.

Both of these changes are in trunk. [HADOOP-17337](https://issues.apache.org/jira/browse/HADOOP-17337) was cherry-picked to branch-3.4, but [HADOOP-19737](https://issues.apache.org/jira/browse/HADOOP-19737) wasn't. This patch to fix JavaDoc will need a small merge conflict resolution for a cherry-pick.

### How was this patch tested?

Running `mvn javadoc:javaodoc` within the hadoop-azure module on trunk fails. After applying this patch locally, the same command succeeds. It also unblocked my attempt to do a full distro build.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

