### PR TITLE
HADOOP-19763: Remove deprecated properties from core-default.xml

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -892,13 +892,6 @@
 </property>
 
 <property>
-  <name>io.bytes.per.checksum</name>
-  <value>512</value>
-  <description>The number of bytes per checksum.  Must not be larger than
-  io.file.buffer.size.</description>
-</property>
-
-<property>
   <name>io.skip.checksum.errors</name>
   <value>false</value>
   <description>If true, when a checksum error is encountered while
@@ -1095,13 +1088,6 @@
   uri's scheme determines the config property (fs.SCHEME.impl) naming
   the FileSystem implementation class.  The uri's authority is used to
   determine the host, port, etc. for a filesystem.</description>
-</property>
-
-<property>
-  <name>fs.default.name</name>
-  <value>file:///</value>
-  <description>Deprecated. Use (fs.defaultFS) property
-  instead</description>
 </property>
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfigurationDeprecation.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfigurationDeprecation.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.conf;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,7 +27,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +39,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 
@@ -49,6 +54,8 @@ import org.junit.jupiter.api.Timeout;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Uninterruptibles;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 public class TestConfigurationDeprecation {
   private Configuration conf;
@@ -465,4 +472,30 @@ public class TestConfigurationDeprecation {
         "Property should be accessible through new key");
   }
 
+  @Test
+  public void testNoDeprecationsByDefault() throws Exception {
+    // Force initialization to make sure deprecations are recorded for later calls to isDeprecated.
+    new Configuration();
+
+    // This test directly parses the default XML configuration file to check for deprecated
+    // properties, bypassing normalization logic in the Configuration class that might hide them.
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    List<String> deprecatedProps = new ArrayList<>();
+
+    try (InputStream is = getClass().getResourceAsStream("/core-default.xml")) {
+      Document doc = db.parse(is);
+      NodeList props = doc.getElementsByTagName("name");
+      for (int i = 0; i < props.getLength(); ++i) {
+        String prop = props.item(i).getTextContent();
+        if (Configuration.isDeprecated(prop)) {
+          deprecatedProps.add(prop);
+        }
+      }
+    }
+
+    assertThat(deprecatedProps)
+        .as("By default, deprecated properties should be empty: %s", deprecatedProps)
+        .isEmpty();
+  }
 }


### PR DESCRIPTION
### Description of PR

Recent trunk changes now produce more assertive warnings about use of deprecated configuration properties. With some of these deprecated properties included in core-default.xml, that means every process launched logs the warnings. Remove them from core-default.xml to avoid these warnings. (Note that this does not take the step of actually removing the code that uses the deprecated properties. They'll continue to work. We just don't want warnings logged by default if the user didn't specifically use these properties.)

```
hadoop fs -ls /

2025-12-26 23:17:33,154 INFO Configuration.deprecation: fs.default.name in core-default.xml is deprecated. Instead, use fs.defaultFS
2025-12-26 23:17:33,307 INFO Configuration.deprecation: io.bytes.per.checksum in core-default.xml is deprecated. Instead, use dfs.bytes-per-checksum
```

### How was this patch tested?

Build the distro:

```
mvn clean package -Pdist -Dtar -DskipTests
```

Verify the command above no longer produces deprecation warnings.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

