### PR TITLE
YARN-11913: Remove deprecated properties from yarn-default.xml

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1074,15 +1074,6 @@
 
   <property>
     <description>The setting that controls whether yarn system metrics is
-    published to the Timeline server (version one) or not, by RM.
-    This configuration is now deprecated in favor of
-    yarn.system-metrics-publisher.enabled.</description>
-    <name>yarn.resourcemanager.system-metrics-publisher.enabled</name>
-    <value>false</value>
-  </property>
-
-  <property>
-    <description>The setting that controls whether yarn system metrics is
     published on the Timeline service or not by RM And NM.</description>
     <name>yarn.system-metrics-publisher.enabled</name>
     <value>false</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfiguration.java
@@ -19,13 +19,22 @@
 package org.apache.hadoop.yarn.conf;
 
 import java.net.InetSocketAddress;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.jupiter.api.Test;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -265,5 +274,32 @@ public class TestYarnConfiguration {
     String rmAmExpiryIntervalMS1 = conf.get(YarnConfiguration.RM_AM_EXPIRY_INTERVAL_MS);
     assertTrue(NumberUtils.isDigits(rmAmExpiryIntervalMS1));
     assertEquals(600000, Long.parseLong(rmAmExpiryIntervalMS1));
+  }
+
+  @Test
+  public void testNoDeprecationsByDefault() throws Exception {
+    // Force initialization to make sure deprecations are recorded for later calls to isDeprecated.
+    new YarnConfiguration();
+
+    // This test directly parses the default XML configuration file to check for deprecated
+    // properties, bypassing normalization logic in the Configuration class that might hide them.
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    List<String> deprecatedProps = new ArrayList<>();
+
+    try (InputStream is = getClass().getResourceAsStream("/yarn-default.xml")) {
+      Document doc = db.parse(is);
+      NodeList props = doc.getElementsByTagName("name");
+      for (int i = 0; i < props.getLength(); ++i) {
+        String prop = props.item(i).getTextContent();
+        if (YarnConfiguration.isDeprecated(prop)) {
+          deprecatedProps.add(prop);
+        }
+      }
+    }
+
+    assertThat(deprecatedProps)
+        .as("By default, deprecated properties should be empty: %s", deprecatedProps)
+        .isEmpty();
   }
 }


### PR DESCRIPTION
### Description of PR

Recent trunk changes now produce more assertive warnings about use of deprecated configuration properties. With some of these deprecated properties included in yarn-default.xml, that means every process launched logs the warnings. Remove them from core-default.xml to avoid these warnings. (Note that this does not take the step of actually removing the code that uses the deprecated properties. They'll continue to work. We just don't want warnings logged by default if the user didn't specifically use these properties.)

```
yarn application -list

2025-12-27 00:15:55,914 INFO Configuration.deprecation: yarn.resourcemanager.system-metrics-publisher.enabled in yarn-default.xml is deprecated. Instead, use yarn.system-metrics-publisher.enabled
```

### How was this patch tested?

Build the distro:

```
mvn clean package -Pdist -Dtar -DskipTests
```

Verify the command above no longer produces deprecation warnings.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

