### PR TITLE
HADOOP-19761: Exclude jetty-alpn-java-client from Solr transitive dependencies

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -138,6 +138,10 @@
                     <artifactId>jetty-alpn-client</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-java-client</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.eclipse.jetty.http2</groupId>
                     <artifactId>http2-hpack</artifactId>
                 </exclusion>


### PR DESCRIPTION
### Description of PR

After submission of #8146 , I started seeing builds fail with this dependency convergence error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (depcheck) on project hadoop-yarn-applications-catalog-webapp: 
[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.DependencyConvergence failed with message:
[ERROR] Failed while enforcing releasability.
[ERROR] 
[ERROR] Dependency convergence error for org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.58.v20250814 paths to dependency are:
[ERROR] +-org.apache.hadoop:hadoop-yarn-applications-catalog-webapp:war:3.5.0-SNAPSHOT
[ERROR]   +-org.eclipse.jetty.http2:http2-http-client-transport:jar:9.4.58.v20250814:compile
[ERROR]     +-org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.58.v20250814:compile
[ERROR] and
[ERROR] +-org.apache.hadoop:hadoop-yarn-applications-catalog-webapp:war:3.5.0-SNAPSHOT
[ERROR]   +-org.apache.solr:solr-solrj:jar:8.11.2:compile
[ERROR]     +-org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.44.v20210927:compile
[ERROR] -> [Help 1]
```

I think we additionally need to exclude the jetty-alpn-java-client transitive dependency coming in through Solr.

### How was this patch tested?

```
mvn clean verify -DskipTests
```

Verified the build completed successfully with no dependency convergence errors.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

