### PR TITLE
HADOOP-19756 make std_error adopters have less friction with hadoop n…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
@@ -110,14 +110,17 @@ jthrowable newIOException(JNIEnv* env, const char *fmt, ...)
 
 const char* terror(int errnum)
 {
-// MT-Safe under Solaris or glibc >= 2.32 not supporting sys_errlist/sys_nerr
-#if defined(__sun)
-  #define USE_STR_ERROR
-#elif defined(__GLIBC_PREREQ)
-  #if __GLIBC_PREREQ(2, 32)
-    #define USE_STR_ERROR
+/* STD_ERROR is the new standard. Alpine musc does not want to be 'detected' it want to be pure and modern. Thus we detect the old glib and handle. */  
+#ifdef __GLIBC__
+  #if defined(__GLIBC_PREREQ)
+    #if __GLIBC_PREREQ(2, 32)
+      #define USE_STR_ERROR
+    #endif
   #endif
+#else
+  #define USE_STR_ERROR
 #endif
+
 
 #if defined(USE_STR_ERROR)
   return strerror(errnum); 


### PR DESCRIPTION
…ative

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

