### PR TITLE
HADOOP-19766: ABFS. Force Blob Instance for FNS Accounts

### DIFF
--- a/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
+++ b/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
@@ -48,14 +48,6 @@ runHNSSharedKeyDFSTest()
   triggerRun "HNS-SharedKey-DFS" "$accountName"  "$runTest" $processCount "$cleanUpTestContainers"
 }
 
-runNonHNSSharedKeyDFSTest()
-{
-  accountName=$(xmlstarlet sel -t -v '//property[name = "fs.azure.nonHnsTestAccountName"]/value' -n $azureTestXmlPath)
-  PROPERTIES=("fs.azure.account.auth.type")
-  VALUES=("SharedKey")
-  triggerRun "NonHNS-SharedKey-DFS" "$accountName" "$runTest" $processCount "$cleanUpTestContainers"
-}
-
 runAppendBlobHNSOAuthDFSTest()
 {
   accountName=$(xmlstarlet sel -t -v '//property[name = "fs.azure.hnsTestAccountName"]/value' -n $azureTestXmlPath)
@@ -71,14 +63,6 @@ runNonHNSSharedKeyBlobTest()
   PROPERTIES=("fs.azure.account.auth.type")
   VALUES=("SharedKey")
   triggerRun "NonHNS-SharedKey-Blob" "${accountName}_blob" "$runTest" $processCount "$cleanUpTestContainers"
-}
-
-runNonHNSOAuthDFSTest()
-{
-  accountName=$(xmlstarlet sel -t -v '//property[name = "fs.azure.nonHnsTestAccountName"]/value' -n $azureTestXmlPath)
-  PROPERTIES=("fs.azure.account.auth.type")
-  VALUES=("OAuth")
-  triggerRun "NonHNS-OAuth-DFS" "$accountName" "$runTest" $processCount "$cleanUpTestContainers"
 }
 
 runNonHNSOAuthBlobTest()
@@ -105,14 +89,6 @@ runHNSOAuthDFSIngressBlobTest()
   PROPERTIES=("fs.azure.account.auth.type" "fs.azure.ingress.service.type")
   VALUES=("OAuth" "blob")
   triggerRun "HNS-Oauth-DFS-IngressBlob" "$accountName" "$runTest" $processCount "$cleanUpTestContainers"
-}
-
-runNonHNSOAuthDFSIngressBlobTest()
-{
-  accountName=$(xmlstarlet sel -t -v '//property[name = "fs.azure.nonHnsTestAccountName"]/value' -n $azureTestXmlPath)
-  PROPERTIES=("fs.azure.account.auth.type" "fs.azure.ingress.service.type")
-  VALUES=("OAuth" "blob")
-  triggerRun "NonHNS-OAuth-DFS-IngressBlob" "$accountName" "$runTest" $processCount "$cleanUpTestContainers"
 }
 
 runTest=false
@@ -192,20 +168,12 @@ do
          runHNSSharedKeyDFSTest
          break
          ;;
-      NonHNS-SharedKey-DFS)
-         runNonHNSSharedKeyDFSTest
-         break
-         ;;
        AppendBlob-HNS-OAuth-DFS)
          runAppendBlobHNSOAuthDFSTest
          break
          ;;
        NonHNS-SharedKey-Blob)
          runNonHNSSharedKeyBlobTest
-         break
-         ;;
-        NonHNS-OAuth-DFS)
-         runNonHNSOAuthDFSTest
          break
          ;;
         NonHNS-OAuth-Blob)
@@ -220,10 +188,6 @@ do
          runHNSOAuthDFSIngressBlobTest
          break
          ;;
-        NonHNS-Oauth-DFS-IngressBlob)
-         runNonHNSOAuthDFSIngressBlobTest
-         break
-         ;;
       AllCombinationsTestRun)
         if [ $runTest == false ]
         then
@@ -232,14 +196,11 @@ do
         fi
         runHNSOAuthDFSTest
         runHNSSharedKeyDFSTest
-        runNonHNSSharedKeyDFSTest
         runAppendBlobHNSOAuthDFSTest
         runNonHNSSharedKeyBlobTest
-        runNonHNSOAuthDFSTest
         runNonHNSOAuthBlobTest
         runAppendBlobNonHNSOAuthBlobTest
         runHNSOAuthDFSIngressBlobTest
-        runNonHNSOAuthDFSIngressBlobTest
          break
          ;;
       Quit)

--- a/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
+++ b/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
@@ -157,7 +157,7 @@ done
 
 echo ' '
 echo 'Set the active test combination to run the action:'
-select combo in HNS-OAuth-DFS HNS-SharedKey-DFS NonHNS-SharedKey-DFS AppendBlob-HNS-OAuth-DFS NonHNS-SharedKey-Blob NonHNS-OAuth-DFS NonHNS-OAuth-Blob AppendBlob-NonHNS-OAuth-Blob HNS-Oauth-DFS-IngressBlob NonHNS-Oauth-DFS-IngressBlob AllCombinationsTestRun Quit
+select combo in HNS-OAuth-DFS HNS-SharedKey-DFS AppendBlob-HNS-OAuth-DFS NonHNS-SharedKey-Blob NonHNS-OAuth-Blob AppendBlob-NonHNS-OAuth-Blob HNS-Oauth-DFS-IngressBlob AllCombinationsTestRun Quit
 do
    case $combo in
       HNS-OAuth-DFS)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -93,7 +93,7 @@ public class AbfsConfiguration{
   private final String accountName;
   private String fsName;
   // Service type identified from URL used to initialize FileSystem.
-  private AbfsServiceType fsConfiguredServiceType;
+  private AbfsServiceType fsConfiguredServiceTypeFromUrl;
   private final boolean isSecure;
   private static final Logger LOG = LoggerFactory.getLogger(AbfsConfiguration.class);
   private Trilean isNamespaceEnabled = null;
@@ -663,18 +663,18 @@ public class AbfsConfiguration{
    * Constructor for AbfsConfiguration for specified service type.
    * @param rawConfig used to initialize the configuration.
    * @param accountName the name of the azure storage account.
-   * @param fsConfiguredServiceType service type configured for the file system.
+   * @param fsConfiguredServiceTypeFromUrl service type configured for the file system.
    * @throws IllegalAccessException if the field is not accessible.
    * @throws IOException if an I/O error occurs.
    */
   public AbfsConfiguration(final Configuration rawConfig,
       String accountName,
-      AbfsServiceType fsConfiguredServiceType)
+      AbfsServiceType fsConfiguredServiceTypeFromUrl)
       throws IllegalAccessException, IOException {
     this.rawConfig = ProviderUtils.excludeIncompatibleCredentialProviders(
         rawConfig, AzureBlobFileSystem.class);
     this.accountName = accountName;
-    this.fsConfiguredServiceType = fsConfiguredServiceType;
+    this.fsConfiguredServiceTypeFromUrl = fsConfiguredServiceTypeFromUrl;
     this.isSecure = getBoolean(FS_AZURE_SECURE_MODE, false);
 
     Field[] fields = this.getClass().getDeclaredFields();
@@ -701,16 +701,16 @@ public class AbfsConfiguration{
    * @param rawConfig used to initialize the configuration.
    * @param accountName the name of the azure storage account.
    * @param fsName the name of the file system (container name).
-   * @param fsConfiguredServiceType service type configured for the file system.
+   * @param fsConfiguredServiceTypeFromUrl service type configured for the file system.
    * @throws IllegalAccessException if the field is not accessible.
    * @throws IOException if an I/O error occurs.
    */
   public AbfsConfiguration(final Configuration rawConfig,
       String accountName,
       String fsName,
-      AbfsServiceType fsConfiguredServiceType)
+      AbfsServiceType fsConfiguredServiceTypeFromUrl)
       throws IllegalAccessException, IOException {
-    this(rawConfig, accountName, fsConfiguredServiceType);
+    this(rawConfig, accountName, fsConfiguredServiceTypeFromUrl);
     this.fsName = fsName;
   }
 
@@ -749,7 +749,7 @@ public class AbfsConfiguration{
    * @return the service type.
    */
   public AbfsServiceType getFsConfiguredServiceType() {
-    return getCaseInsensitiveEnum(FS_AZURE_FNS_ACCOUNT_SERVICE_TYPE, fsConfiguredServiceType);
+    return getCaseInsensitiveEnum(FS_AZURE_FNS_ACCOUNT_SERVICE_TYPE, fsConfiguredServiceTypeFromUrl);
   }
 
   /**
@@ -757,8 +757,8 @@ public class AbfsConfiguration{
    *
    * @return the configured AbfsServiceType from the URL
    */
-  public AbfsServiceType getFsConfiguredServiceTypeFromURL() {
-    return fsConfiguredServiceType;
+  public AbfsServiceType getFsConfiguredServiceTypeFromUrl() {
+    return fsConfiguredServiceTypeFromUrl;
   }
 
   /**
@@ -799,13 +799,9 @@ public class AbfsConfiguration{
     if (isHNSEnabled && getConfiguredServiceTypeForFNSAccounts() == AbfsServiceType.BLOB) {
       throw new InvalidConfigurationValueException(
           FS_AZURE_FNS_ACCOUNT_SERVICE_TYPE, "Service Type Cannot be BLOB for HNS Account");
-    } else if (isHNSEnabled && fsConfiguredServiceType == AbfsServiceType.BLOB) {
+    } else if (isHNSEnabled && fsConfiguredServiceTypeFromUrl == AbfsServiceType.BLOB) {
       throw new InvalidConfigurationValueException(FS_DEFAULT_NAME_KEY,
           "Blob Endpoint Url Cannot be used to initialize filesystem for HNS Account");
-    } else if (getFsConfiguredServiceType() == AbfsServiceType.BLOB
-        && getIngressServiceType() == AbfsServiceType.DFS) {
-      throw new InvalidConfigurationValueException(
-          FS_AZURE_INGRESS_SERVICE_TYPE, INCORRECT_INGRESS_TYPE);
     }
   }
 
@@ -1809,11 +1805,11 @@ public class AbfsConfiguration{
   }
 
   /**
-   * Sets the configured service type to BLOB.
-   * Majorly required to correctly set user agent for FNS-Blob
+   * Sets the configured service type.
+   * Used to update the service type identified from the URL.
    */
-  void setFsConfiguredServiceTypetoBlob() {
-    this.fsConfiguredServiceType = AbfsServiceType.BLOB;
+  void setFsConfiguredServiceType(AbfsServiceType serviceType) {
+    this.fsConfiguredServiceTypeFromUrl = serviceType;
   }
 
   public int getReadAheadRange() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -93,7 +93,7 @@ public class AbfsConfiguration{
   private final String accountName;
   private String fsName;
   // Service type identified from URL used to initialize FileSystem.
-  private final AbfsServiceType fsConfiguredServiceType;
+  private AbfsServiceType fsConfiguredServiceType;
   private final boolean isSecure;
   private static final Logger LOG = LoggerFactory.getLogger(AbfsConfiguration.class);
   private Trilean isNamespaceEnabled = null;
@@ -1797,6 +1797,10 @@ public class AbfsConfiguration{
   @VisibleForTesting
   void setReadAheadEnabled(final boolean enabledReadAhead) {
     this.enabledReadAhead = enabledReadAhead;
+  }
+
+  void setFsConfiguredServiceTypetoBlob() {
+    this.fsConfiguredServiceType = AbfsServiceType.BLOB;
   }
 
   public int getReadAheadRange() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -80,7 +80,6 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.*;
-import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.INCORRECT_INGRESS_TYPE;
 
 /**
  * Configuration for Azure Blob FileSystem.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -752,6 +752,11 @@ public class AbfsConfiguration{
     return getCaseInsensitiveEnum(FS_AZURE_FNS_ACCOUNT_SERVICE_TYPE, fsConfiguredServiceType);
   }
 
+  /**
+   * Returns the service type identified from the URL used to initialize the FileSystem.
+   *
+   * @return the configured AbfsServiceType from the URL
+   */
   public AbfsServiceType getFsConfiguredServiceTypeFromURL() {
     return fsConfiguredServiceType;
   }
@@ -1803,6 +1808,10 @@ public class AbfsConfiguration{
     this.enabledReadAhead = enabledReadAhead;
   }
 
+  /**
+   * Sets the configured service type to BLOB.
+   * Majorly required to correctly set user agent for FNS-Blob
+   */
   void setFsConfiguredServiceTypetoBlob() {
     this.fsConfiguredServiceType = AbfsServiceType.BLOB;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -752,6 +752,10 @@ public class AbfsConfiguration{
     return getCaseInsensitiveEnum(FS_AZURE_FNS_ACCOUNT_SERVICE_TYPE, fsConfiguredServiceType);
   }
 
+  public AbfsServiceType getFsConfiguredServiceTypeFromURL() {
+    return fsConfiguredServiceType;
+  }
+
   /**
    * Returns the service type configured for FNS Accounts to override the
    * service type identified by URL used to initialize the filesystem.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1558,7 +1558,7 @@ public class AzureBlobFileSystem extends FileSystem
     return true;
   }
 
-  private void createFileSystem(TracingContext tracingContext) throws IOException {
+  void createFileSystem(TracingContext tracingContext) throws IOException {
     LOG.debug(
         "AzureBlobFileSystem.createFileSystem uri: {}", uri);
     try {
@@ -1828,6 +1828,16 @@ public class AzureBlobFileSystem extends FileSystem
     return clientCorrelationId;
   }
 
+  TracingContext initFSTracingContext;
+
+  // Package-private getter for test access to the tracing header
+  String getInitFSTracingHeader() {
+    if (initFSTracingContext != null) {
+      return initFSTracingContext.getHeader();
+    }
+    return null;
+  }
+
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
@@ -1870,4 +1880,3 @@ public class AzureBlobFileSystem extends FileSystem
     return abfsCounters != null ? abfsCounters.getIOStatistics() : null;
   }
 }
-

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -156,6 +156,7 @@ public class AzureBlobFileSystem extends FileSystem
    */
   private boolean isClosed = true;
   private final String fileSystemId = UUID.randomUUID().toString();
+  private final String DFS_DOMAIN_INDICATOR = ".dfs.";
 
   private boolean delegationTokenEnabled = false;
   private AbfsDelegationTokenManager delegationTokenManager;
@@ -313,6 +314,14 @@ public class AzureBlobFileSystem extends FileSystem
     } catch (AzureBlobFileSystemException ex) {
       LOG.debug("Failed to determine account type for service type validation", ex);
       throw new InvalidConfigurationValueException(FS_AZURE_ACCOUNT_IS_HNS_ENABLED, ex);
+    }
+
+    // For FNS-DFS accounts, reset the endpoint to Blob and update the tracing
+    // context to add metric to show endpoint conversion.
+    if (!tryGetIsNamespaceEnabled(new TracingContext(initFSTracingContext))
+        && uri.toString().contains(DFS_DOMAIN_INDICATOR)) {
+      abfsStore.resetEndpointforFNS();
+      initFSTracingContext.setFNSEndpointConverted();
     }
 
     // Create the file system if it does not exist.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -129,6 +129,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE
 import static org.apache.hadoop.fs.azurebfs.constants.FSOperationType.CREATE_FILESYSTEM;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DATA_BLOCKS_BUFFER_DEFAULT;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DFS_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_CREATE_ON_ROOT;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_INVALID_ABFS_STATE;
@@ -156,7 +157,6 @@ public class AzureBlobFileSystem extends FileSystem
    */
   private boolean isClosed = true;
   private final String fileSystemId = UUID.randomUUID().toString();
-  private final String DFS_DOMAIN_INDICATOR = ".dfs.";
 
   private boolean delegationTokenEnabled = false;
   private AbfsDelegationTokenManager delegationTokenManager;
@@ -316,12 +316,17 @@ public class AzureBlobFileSystem extends FileSystem
       throw new InvalidConfigurationValueException(FS_AZURE_ACCOUNT_IS_HNS_ENABLED, ex);
     }
 
-    // For FNS-DFS accounts, reset the endpoint to Blob and update the tracing
-    // context to add metric to show endpoint conversion.
-    if (!tryGetIsNamespaceEnabled(new TracingContext(initFSTracingContext))
-        && uri.toString().contains(DFS_DOMAIN_INDICATOR)) {
-      abfsStore.resetEndpointforFNS();
-      initFSTracingContext.setFNSEndpointConverted();
+    /*
+     * For FNS-DFS accounts, reset the endpoint to Blob and update the tracing
+     * context to add metric to show endpoint conversion.
+     */
+    if (!tryGetIsNamespaceEnabled(new TracingContext(initFSTracingContext))) {
+      // Required to correctly set user agent for FNS-Blob
+      abfsStore.restrictServiceTypeToBlob();
+      if (uri.toString().contains(ABFS_DFS_DOMAIN_NAME)){
+        abfsStore.resetEndpointFromDFSToBlob();
+        initFSTracingContext.setFNSEndpointConverted();
+      }
     }
 
     // Create the file system if it does not exist.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -318,14 +318,12 @@ public class AzureBlobFileSystem extends FileSystem
 
     /*
      * For FNS accounts, restrict the endpoint and service type to Blob
-     * For FNS-DFS, also update the default client service type to BLOB and update
-     * tracing context to add metric to show endpoint conversion.
+     * For FNS-DFS, also update the tracing context to add metric to show endpoint conversion.
      */
     if (!tryGetIsNamespaceEnabled(new TracingContext(initFSTracingContext))) {
-      // Required to correctly set user agent for FNS-Blob and restrict ingress service type
+      LOG.debug("FNS account detected; restricting service type to Blob.");
       abfsStore.restrictServiceTypeToBlob();
-      if (uri.toString().contains(ABFS_DFS_DOMAIN_NAME)){
-        abfsStore.resetEndpointFromDFSToBlob();
+      if (uri.toString().contains(ABFS_DFS_DOMAIN_NAME)) {
         initFSTracingContext.setFNSEndpointConverted();
       }
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -317,11 +317,12 @@ public class AzureBlobFileSystem extends FileSystem
     }
 
     /*
-     * For FNS-DFS accounts, reset the endpoint to Blob and update the tracing
-     * context to add metric to show endpoint conversion.
+     * For FNS accounts, restrict the endpoint and service type to Blob
+     * For FNS-DFS, also update the default client service type to BLOB and update
+     * tracing context to add metric to show endpoint conversion.
      */
     if (!tryGetIsNamespaceEnabled(new TracingContext(initFSTracingContext))) {
-      // Required to correctly set user agent for FNS-Blob
+      // Required to correctly set user agent for FNS-Blob and restrict ingress service type
       abfsStore.restrictServiceTypeToBlob();
       if (uri.toString().contains(ABFS_DFS_DOMAIN_NAME)){
         abfsStore.resetEndpointFromDFSToBlob();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1558,7 +1558,7 @@ public class AzureBlobFileSystem extends FileSystem
     return true;
   }
 
-  void createFileSystem(TracingContext tracingContext) throws IOException {
+  private void createFileSystem(TracingContext tracingContext) throws IOException {
     LOG.debug(
         "AzureBlobFileSystem.createFileSystem uri: {}", uri);
     try {
@@ -1826,16 +1826,6 @@ public class AzureBlobFileSystem extends FileSystem
   @VisibleForTesting
   String getClientCorrelationId() {
     return clientCorrelationId;
-  }
-
-  TracingContext initFSTracingContext;
-
-  // Package-private getter for test access to the tracing header
-  String getInitFSTracingHeader() {
-    if (initFSTracingContext != null) {
-      return initFSTracingContext.getHeader();
-    }
-    return null;
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1909,20 +1909,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   /**
-   * Restricts the service type to BLOB for the current client handler and configuration when FNS account detected
-   * This method sets the ingress service type and the configured service type to {@code AbfsServiceType.BLOB}.
-   */
-  public void restrictServiceTypeToBlob() {
-    clientHandler.setIngressServiceType(AbfsServiceType.BLOB);
-    getAbfsConfiguration().setFsConfiguredServiceType(AbfsServiceType.BLOB);
-  }
-
-  /**
-   * Resets default service type to use BLOB.
+   * Restricts all service types to BLOB when FNS account detected
    * Updates the client to reflect the new default service type.
    */
-  public void resetEndpointFromDFSToBlob() {
+  public void restrictServiceTypeToBlob() {
     clientHandler.setDefaultServiceType(AbfsServiceType.BLOB);
+    clientHandler.setIngressServiceType(AbfsServiceType.BLOB);
+    getAbfsConfiguration().setFsConfiguredServiceType(AbfsServiceType.BLOB);
     this.client = clientHandler.getClient();
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -152,10 +152,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.FILE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.ROOT_PATH;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TOKEN_VERSION;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_ABFS_ENDPOINT;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_FOOTER_READ_BUFFER_SIZE;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_BUFFERED_PREAD_DISABLE;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_IDENTITY_TRANSFORM_CLASS;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.INFINITE_LEASE_DURATION;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_BLOB_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_MS_ENCRYPTION_CONTEXT;
@@ -798,16 +795,18 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       ContextEncryptionAdapter contextEncryptionAdapter,
       TracingContext tracingContext) throws AzureBlobFileSystemException {
     int bufferSize = abfsConfiguration.getWriteBufferSize();
+    getClientHandler().initServiceType(abfsConfiguration);
+
     if (isAppendBlob && bufferSize > FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE) {
       bufferSize = FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE;
     }
 
     // Separate ingress service type is only supported for HNS accounts
     // FNS accounts shall use default service type (Blob) for all operations
-    AbfsServiceType ingressServiceType
-        = client.getIsNamespaceEnabled()
-        ? clientHandler.getDefaultIngressServiceType()
-        : clientHandler.getDefaultServiceType();
+//    AbfsServiceType ingressServiceType
+//        = getClient().getIsNamespaceEnabled()
+//        ? clientHandler.getDefaultIngressServiceType()
+//        : clientHandler.getDefaultServiceType();
 
     return new AbfsOutputStreamContext(abfsConfiguration.getSasTokenRenewPeriodForStreamsInSeconds())
             .withWriteBufferSize(bufferSize)
@@ -832,7 +831,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             .withWriteThreadPoolManager(writeThreadPoolSizeManager)
             .withTracingContext(tracingContext)
             .withAbfsBackRef(fsBackRef)
-            .withIngressServiceType(ingressServiceType)
+            .withIngressServiceType(clientHandler.getDefaultIngressServiceType())
             .withDFSToBlobFallbackEnabled(abfsConfiguration.isDfsToBlobFallbackEnabled())
             .withETag(eTag)
             .build();
@@ -1919,7 +1918,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * Updates the client to reflect the new default service type.
    */
   public void resetEndpointforFNS() {
+    getAbfsConfiguration().setFsConfiguredServiceTypetoBlob();
     getClientHandler().setDefaultServiceType(AbfsServiceType.BLOB);
+    getClientHandler().setIngressServiceType(AbfsServiceType.BLOB);
     this.client = getClientHandler().getClient();
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1908,13 +1908,17 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return new AbfsPerfInfo(abfsPerfTracker, callerName, calleeName);
   }
 
-  public void restrictServiceTypeToBlob(){
+  /**
+   * Restricts the service type to BLOB for the current client handler and configuration when FNS account detected
+   * This method sets the ingress service type and the configured service type to {@code AbfsServiceType.BLOB}.
+   */
+  public void restrictServiceTypeToBlob() {
     clientHandler.setIngressServiceType(AbfsServiceType.BLOB);
     getAbfsConfiguration().setFsConfiguredServiceType(AbfsServiceType.BLOB);
   }
 
   /**
-   * Resets all service types to use BLOB.
+   * Resets default service type to use BLOB.
    * Updates the client to reflect the new default service type.
    */
   public void resetEndpointFromDFSToBlob() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -152,7 +152,10 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.FILE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.ROOT_PATH;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TOKEN_VERSION;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_ABFS_ENDPOINT;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_FOOTER_READ_BUFFER_SIZE;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_BUFFERED_PREAD_DISABLE;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_IDENTITY_TRANSFORM_CLASS;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.INFINITE_LEASE_DURATION;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_BLOB_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_MS_ENCRYPTION_CONTEXT;
@@ -793,20 +796,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       long position,
       String eTag,
       ContextEncryptionAdapter contextEncryptionAdapter,
-      TracingContext tracingContext) throws AzureBlobFileSystemException {
+      TracingContext tracingContext) {
     int bufferSize = abfsConfiguration.getWriteBufferSize();
     getClientHandler().initServiceType(abfsConfiguration);
 
     if (isAppendBlob && bufferSize > FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE) {
       bufferSize = FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE;
     }
-
-    // Separate ingress service type is only supported for HNS accounts
-    // FNS accounts shall use default service type (Blob) for all operations
-//    AbfsServiceType ingressServiceType
-//        = getClient().getIsNamespaceEnabled()
-//        ? clientHandler.getDefaultIngressServiceType()
-//        : clientHandler.getDefaultServiceType();
 
     return new AbfsOutputStreamContext(abfsConfiguration.getSasTokenRenewPeriodForStreamsInSeconds())
             .withWriteBufferSize(bufferSize)
@@ -1914,7 +1910,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   /**
-   * Resets the endpoint for FNS accounts to use the BLOB service type.
+   * Resets all service types to use BLOB.
    * Updates the client to reflect the new default service type.
    */
   public void resetEndpointforFNS() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -796,11 +796,19 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       long position,
       String eTag,
       ContextEncryptionAdapter contextEncryptionAdapter,
-      TracingContext tracingContext) {
+      TracingContext tracingContext) throws AzureBlobFileSystemException {
     int bufferSize = abfsConfiguration.getWriteBufferSize();
     if (isAppendBlob && bufferSize > FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE) {
       bufferSize = FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE;
     }
+
+    // Separate ingress service type is only supported for HNS accounts
+    // FNS accounts shall use default service type (Blob) for all operations
+    AbfsServiceType ingressServiceType
+        = client.getIsNamespaceEnabled()
+        ? clientHandler.getDefaultIngressServiceType()
+        : clientHandler.getDefaultServiceType();
+
     return new AbfsOutputStreamContext(abfsConfiguration.getSasTokenRenewPeriodForStreamsInSeconds())
             .withWriteBufferSize(bufferSize)
             .enableExpectHeader(abfsConfiguration.isExpectHeaderEnabled())
@@ -824,7 +832,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             .withWriteThreadPoolManager(writeThreadPoolSizeManager)
             .withTracingContext(tracingContext)
             .withAbfsBackRef(fsBackRef)
-            .withIngressServiceType(abfsConfiguration.getIngressServiceType())
+            .withIngressServiceType(ingressServiceType)
             .withDFSToBlobFallbackEnabled(abfsConfiguration.isDfsToBlobFallbackEnabled())
             .withETag(eTag)
             .build();
@@ -1904,6 +1912,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   private AbfsPerfInfo startTracking(String callerName, String calleeName) {
     return new AbfsPerfInfo(abfsPerfTracker, callerName, calleeName);
+  }
+
+  /**
+   * Resets the endpoint for FNS accounts to use the BLOB service type.
+   * Updates the client to reflect the new default service type.
+   */
+  public void resetEndpointforFNS() {
+    getClientHandler().setDefaultServiceType(AbfsServiceType.BLOB);
+    this.client = getClientHandler().getClient();
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -798,7 +798,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       ContextEncryptionAdapter contextEncryptionAdapter,
       TracingContext tracingContext) {
     int bufferSize = abfsConfiguration.getWriteBufferSize();
-    getClientHandler().initServiceType(abfsConfiguration);
 
     if (isAppendBlob && bufferSize > FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE) {
       bufferSize = FileSystemConfigurations.APPENDBLOB_MAX_WRITE_BUFFER_SIZE;
@@ -827,7 +826,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             .withWriteThreadPoolManager(writeThreadPoolSizeManager)
             .withTracingContext(tracingContext)
             .withAbfsBackRef(fsBackRef)
-            .withIngressServiceType(clientHandler.getDefaultIngressServiceType())
+            .withIngressServiceType(clientHandler.getIngressServiceType())
             .withDFSToBlobFallbackEnabled(abfsConfiguration.isDfsToBlobFallbackEnabled())
             .withETag(eTag)
             .build();
@@ -1909,15 +1908,18 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return new AbfsPerfInfo(abfsPerfTracker, callerName, calleeName);
   }
 
+  public void restrictServiceTypeToBlob(){
+    clientHandler.setIngressServiceType(AbfsServiceType.BLOB);
+    getAbfsConfiguration().setFsConfiguredServiceType(AbfsServiceType.BLOB);
+  }
+
   /**
    * Resets all service types to use BLOB.
    * Updates the client to reflect the new default service type.
    */
-  public void resetEndpointforFNS() {
-    getAbfsConfiguration().setFsConfiguredServiceTypetoBlob();
-    getClientHandler().setDefaultServiceType(AbfsServiceType.BLOB);
-    getClientHandler().setIngressServiceType(AbfsServiceType.BLOB);
-    this.client = getClientHandler().getClient();
+  public void resetEndpointFromDFSToBlob() {
+    clientHandler.setDefaultServiceType(AbfsServiceType.BLOB);
+    this.client = clientHandler.getClient();
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/MsiTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/MsiTokenProvider.java
@@ -42,6 +42,14 @@ public class MsiTokenProvider extends AccessTokenProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(AccessTokenProvider.class);
 
+  /**
+   * Constructs an MsiTokenProvider.
+   *
+   * @param authEndpoint the authentication endpoint for MSI
+   * @param tenantGuid   the tenant GUID
+   * @param clientId     the client ID for MSI
+   * @param authority    the authority URL
+   */
   public MsiTokenProvider(final String authEndpoint, final String tenantGuid,
       final String clientId, final String authority) {
     this.authEndpoint = authEndpoint;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1373,7 +1373,7 @@ public abstract class AbfsClient implements Closeable {
     // Add a unique identifier in FNS-Blob user agent string
     // Current filesystem init restricts HNS-Blob combination
     // so namespace check not required.
-    if (abfsConfiguration.getFsConfiguredServiceType() == BLOB) {
+    if (abfsConfiguration.getFsConfiguredServiceTypeFromURL() == BLOB) {
       sb.append(SEMICOLON)
           .append(SINGLE_WHITE_SPACE)
           .append(FNS_BLOB_USER_AGENT_IDENTIFIER);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1374,7 +1374,7 @@ public abstract class AbfsClient implements Closeable {
     // Current filesystem init restricts HNS-Blob combination
     // so namespace check not required.
     // We need to rely on URL check to identify Blob service instead of user config
-    if (abfsConfiguration.getFsConfiguredServiceTypeFromURL() == BLOB) {
+    if (abfsConfiguration.getFsConfiguredServiceTypeFromUrl() == BLOB) {
       sb.append(SEMICOLON)
           .append(SINGLE_WHITE_SPACE)
           .append(FNS_BLOB_USER_AGENT_IDENTIFIER);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1324,7 +1324,7 @@ public abstract class AbfsClient implements Closeable {
 
   @VisibleForTesting
   String initializeUserAgent(final AbfsConfiguration abfsConfiguration,
-      final String sslProviderName) {
+      final String sslProviderName) throws TrileanConversionException {
 
     StringBuilder sb = new StringBuilder();
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1324,7 +1324,7 @@ public abstract class AbfsClient implements Closeable {
 
   @VisibleForTesting
   String initializeUserAgent(final AbfsConfiguration abfsConfiguration,
-      final String sslProviderName) throws TrileanConversionException {
+      final String sslProviderName) {
 
     StringBuilder sb = new StringBuilder();
 
@@ -1373,6 +1373,7 @@ public abstract class AbfsClient implements Closeable {
     // Add a unique identifier in FNS-Blob user agent string
     // Current filesystem init restricts HNS-Blob combination
     // so namespace check not required.
+    // We need to rely on URL check to identify Blob service instead of user config
     if (abfsConfiguration.getFsConfiguredServiceTypeFromURL() == BLOB) {
       sb.append(SEMICOLON)
           .append(SINGLE_WHITE_SPACE)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
@@ -86,7 +86,7 @@ public class AbfsClientHandler implements Closeable {
    * Initialize the default service type based on the user configuration.
    * @param abfsConfiguration set by user.
    */
-  public void initServiceType(final AbfsConfiguration abfsConfiguration) {
+  private void initServiceType(final AbfsConfiguration abfsConfiguration) {
     this.defaultServiceType = abfsConfiguration.getFsConfiguredServiceType();
     this.ingressServiceType = abfsConfiguration.getIngressServiceType();
   }
@@ -110,20 +110,11 @@ public class AbfsClientHandler implements Closeable {
   }
 
   /**
-   * Gets the default service type.
-   *
-   * @return the default service type
-   */
-  public AbfsServiceType getDefaultServiceType() {
-    return defaultServiceType;
-  }
-
-  /**
    * Gets the default ingress service type.
    *
    * @return the default ingress service type
    */
-  public AbfsServiceType getDefaultIngressServiceType() {
+  public AbfsServiceType getIngressServiceType() {
     return ingressServiceType;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
@@ -92,6 +92,33 @@ public class AbfsClientHandler implements Closeable {
   }
 
   /**
+   * Sets the default service type.
+   *
+   * @param defaultServiceType the service type to set as default
+   */
+  public void setDefaultServiceType(AbfsServiceType defaultServiceType) {
+    this.defaultServiceType = defaultServiceType;
+  }
+
+  /**
+   * Gets the default service type.
+   *
+   * @return the default service type
+   */
+  public AbfsServiceType getDefaultServiceType() {
+    return defaultServiceType;
+  }
+
+  /**
+   * Gets the default ingress service type.
+   *
+   * @return the default ingress service type
+   */
+  public AbfsServiceType getDefaultIngressServiceType() {
+    return ingressServiceType;
+  }
+
+  /**
    * Get the AbfsClient based on the default service type.
    * @return AbfsClient
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
@@ -100,6 +100,11 @@ public class AbfsClientHandler implements Closeable {
     this.defaultServiceType = defaultServiceType;
   }
 
+  /**
+   * Sets the ingress service type.
+   *
+   * @param ingressServiceType the ingress service type
+   */
   public void setIngressServiceType(AbfsServiceType ingressServiceType) {
     this.ingressServiceType = ingressServiceType;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientHandler.java
@@ -86,7 +86,7 @@ public class AbfsClientHandler implements Closeable {
    * Initialize the default service type based on the user configuration.
    * @param abfsConfiguration set by user.
    */
-  private void initServiceType(final AbfsConfiguration abfsConfiguration) {
+  public void initServiceType(final AbfsConfiguration abfsConfiguration) {
     this.defaultServiceType = abfsConfiguration.getFsConfiguredServiceType();
     this.ingressServiceType = abfsConfiguration.getIngressServiceType();
   }
@@ -98,6 +98,10 @@ public class AbfsClientHandler implements Closeable {
    */
   public void setDefaultServiceType(AbfsServiceType defaultServiceType) {
     this.defaultServiceType = defaultServiceType;
+  }
+
+  public void setIngressServiceType(AbfsServiceType ingressServiceType) {
+    this.ingressServiceType = ingressServiceType;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -320,7 +320,11 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
       boolean isSwitch,
       AzureBlockManager blockManager) throws IOException {
     this.client = clientHandler.getClient(serviceType);
-    if (isDFSToBlobFallbackEnabled && serviceTypeAtInit != AbfsServiceType.DFS) {
+
+    // Check ingress service type is also set to DFS along with enabling the config for fallback
+    // Separate ingress service type is only allowed for HNS accounts
+    if (isDFSToBlobFallbackEnabled && client.getIsNamespaceEnabled()
+        && serviceTypeAtInit != AbfsServiceType.DFS) {
       throw new InvalidConfigurationValueException(
           "The ingress service type must be configured as DFS");
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
@@ -36,6 +36,13 @@ public class ListResponseData {
   private String continuationToken;
 
   /**
+   * Default constructor for ListResponseData.
+   */
+  public ListResponseData() {
+    // do nothing
+  }
+
+  /**
    * Returns the list of VersionedFileStatus objects.
    * @return the list of VersionedFileStatus objects
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListingSupport.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListingSupport.java
@@ -29,6 +29,10 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
+
+/**
+ * Interface for listing support in Azure Blob File System.
+ */
 public interface ListingSupport {
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/Listener.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/Listener.java
@@ -32,6 +32,7 @@ public interface Listener {
   Listener getClone();
   void setOperation(FSOperationType operation);
   void updateIngressHandler(String ingressHandler);
+  void updateFNSEndpointConverted();
   void updatePosition(String position);
   void updateReadType(ReadType readType);
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -67,6 +67,8 @@ public class TracingContext {
   //final concatenated ID list set into x-ms-client-request-id header
   private String header = EMPTY_STRING;
   private String ingressHandler = EMPTY_STRING;
+  private Boolean FNSEndpointConverted = false;
+  private String FNSEndptConvertedIndicator = "T";
   private String position = EMPTY_STRING; // position of read/write in remote file
   private String metricResults = EMPTY_STRING;
   private ReadType readType = ReadType.UNKNOWN_READ;
@@ -148,6 +150,7 @@ public class TracingContext {
     this.format = originalTracingContext.format;
     this.position = originalTracingContext.getPosition();
     this.ingressHandler = originalTracingContext.getIngressHandler();
+    this.FNSEndpointConverted = originalTracingContext.FNSEndpointConverted;
     this.operatedBlobCount = originalTracingContext.operatedBlobCount;
     if (originalTracingContext.listener != null) {
       this.listener = originalTracingContext.listener.getClone();
@@ -233,11 +236,13 @@ public class TracingContext {
           + opType + COLON
           + getRetryHeader(previousFailure, retryPolicyAbbreviation) + COLON
           + ingressHandler + COLON
+          + (FNSEndpointConverted ? FNSEndptConvertedIndicator : EMPTY_STRING) + COLON
           + position + COLON
           + operatedBlobCount + COLON
           + getOperationSpecificHeader(opType) + COLON
           + httpOperation.getTracingContextSuffix() + COLON
           + metricResults + COLON + resourceUtilizationMetricResults;
+      System.out.println(header);
       break;
     case TWO_ID_FORMAT:
       header = TracingHeaderVersion.getCurrentVersion() + COLON
@@ -368,6 +373,13 @@ public class TracingContext {
     this.ingressHandler = ingressHandler;
     if (listener != null) {
       listener.updateIngressHandler(ingressHandler);
+    }
+  }
+
+  public void setFNSEndpointConverted() {
+    this.FNSEndpointConverted = true;
+    if (listener != null) {
+      listener.updateFNSEndpointConverted();
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -67,8 +67,8 @@ public class TracingContext {
   //final concatenated ID list set into x-ms-client-request-id header
   private String header = EMPTY_STRING;
   private String ingressHandler = EMPTY_STRING;
-  private Boolean FNSEndpointConverted = false;
-  private String FNSEndptConvertedIndicator = "T";
+  private Boolean fnsEndpointConverted = false;
+  private String fnsEndptConvertedIndicator = "T";
   private String position = EMPTY_STRING; // position of read/write in remote file
   private String metricResults = EMPTY_STRING;
   private ReadType readType = ReadType.UNKNOWN_READ;
@@ -150,7 +150,7 @@ public class TracingContext {
     this.format = originalTracingContext.format;
     this.position = originalTracingContext.getPosition();
     this.ingressHandler = originalTracingContext.getIngressHandler();
-    this.FNSEndpointConverted = originalTracingContext.FNSEndpointConverted;
+    this.fnsEndpointConverted = originalTracingContext.fnsEndpointConverted;
     this.operatedBlobCount = originalTracingContext.operatedBlobCount;
     if (originalTracingContext.listener != null) {
       this.listener = originalTracingContext.listener.getClone();
@@ -215,6 +215,7 @@ public class TracingContext {
    *   <li>operatedBlobCount - number of blobs operated on by this request</li>
    *   <li>operationSpecificHeader - different operation types can publish info relevant to that operation</li>
    *   <li>httpOperationHeader - suffix for network library used</li>
+   *   <li>fnsEndpointConverted - if endpoint was converted to Blob for FNS accounts</li>
    * </ul>
    * @param httpOperation AbfsHttpOperation instance to set header into
    *                      connection
@@ -241,8 +242,7 @@ public class TracingContext {
           + getOperationSpecificHeader(opType) + COLON
           + httpOperation.getTracingContextSuffix() + COLON
           + metricResults + COLON + resourceUtilizationMetricResults + COLON
-          + (FNSEndpointConverted ? FNSEndptConvertedIndicator : EMPTY_STRING);
-      System.out.println(header);
+          + (fnsEndpointConverted ? fnsEndptConvertedIndicator : EMPTY_STRING);
       break;
     case TWO_ID_FORMAT:
       header = TracingHeaderVersion.getCurrentVersion() + COLON
@@ -354,9 +354,6 @@ public class TracingContext {
   public String getIngressHandler() {
     return ingressHandler;
   }
-  public boolean getFNSEndptConvertedIndicator() {
-    return FNSEndpointConverted;
-  }
 
   /**
    * Gets the position.
@@ -379,8 +376,12 @@ public class TracingContext {
     }
   }
 
+/**
+   * Marks that the endpoint was force converted to Blob for FNS account
+   * Sets the fnsEndpointConverted flag to true and notifies the listener if present.
+   */
   public void setFNSEndpointConverted() {
-    this.FNSEndpointConverted = true;
+    this.fnsEndpointConverted = true;
     if (listener != null) {
       listener.updateFNSEndpointConverted();
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -354,6 +354,9 @@ public class TracingContext {
   public String getIngressHandler() {
     return ingressHandler;
   }
+  public boolean getFNSEndptConvertedIndicator() {
+    return FNSEndpointConverted;
+  }
 
   /**
    * Gets the position.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -236,12 +236,12 @@ public class TracingContext {
           + opType + COLON
           + getRetryHeader(previousFailure, retryPolicyAbbreviation) + COLON
           + ingressHandler + COLON
-          + (FNSEndpointConverted ? FNSEndptConvertedIndicator : EMPTY_STRING) + COLON
           + position + COLON
           + operatedBlobCount + COLON
           + getOperationSpecificHeader(opType) + COLON
           + httpOperation.getTracingContextSuffix() + COLON
-          + metricResults + COLON + resourceUtilizationMetricResults;
+          + metricResults + COLON + resourceUtilizationMetricResults + COLON
+          + (FNSEndpointConverted ? FNSEndptConvertedIndicator : EMPTY_STRING);
       System.out.println(header);
       break;
     case TWO_ID_FORMAT:

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -68,6 +68,7 @@ public class TracingContext {
   private String header = EMPTY_STRING;
   private String ingressHandler = EMPTY_STRING;
   private Boolean fnsEndpointConverted = false;
+  // Represents endpoint was converted to Blob for FNS; "T" stands for "True"
   private String fnsEndptConvertedIndicator = "T";
   private String position = EMPTY_STRING; // position of read/write in remote file
   private String metricResults = EMPTY_STRING;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
@@ -44,10 +44,10 @@ public enum TracingHeaderVersion {
    * This version is used for the current tracing header schema.
    * Schema: version:clientCorrelationId:clientRequestId:fileSystemId
    *         :primaryRequestId:streamId:opType:retryHeader:ingressHandler
-   *         :position:operatedBlobCount:operationSpecificHeader:httpOperationHeader
-   *         :aggregatedMetrics:resourceUtilizationMetrics
+   *         :FNSEndptConvertedIndicator:position:operatedBlobCount:operationSpecificHeader
+   *         :httpOperationHeader:aggregatedMetrics:resourceUtilizationMetrics
    */
-  V2("v2", 15);
+  V2("v2", 16);
 
   private final String versionString;
   private final int fieldCount;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
@@ -44,8 +44,8 @@ public enum TracingHeaderVersion {
    * This version is used for the current tracing header schema.
    * Schema: version:clientCorrelationId:clientRequestId:fileSystemId
    *         :primaryRequestId:streamId:opType:retryHeader:ingressHandler
-   *         :FNSEndptConvertedIndicator:position:operatedBlobCount:operationSpecificHeader
-   *         :httpOperationHeader:aggregatedMetrics:resourceUtilizationMetrics
+   *         :position:operatedBlobCount:operationSpecificHeader:httpOperationHeader
+   *         :aggregatedMetrics:resourceUtilizationMetrics:fnsEndptConvertedIndicator
    */
   V2("v2", 16);
 

--- a/hadoop-tools/hadoop-azure/src/site/markdown/index.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/index.md
@@ -844,7 +844,6 @@ requests. User can specify them as fixed SAS Token to be used across all the req
       implementation that can be used as an example on how to implement your own custom
       SASTokenProvider. This requires the Application credentials to be specifed using
       the following configurations apart from above three:
-  
     4. Delegator App Service Principal Tenant Id:
         ```xml
         <property>

--- a/hadoop-tools/hadoop-azure/src/site/markdown/index.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/index.md
@@ -802,16 +802,15 @@ requests. User can specify them as fixed SAS Token to be used across all the req
 ### User-bound SAS
 - **Description**: The user-bound SAS auth type allows to track the usage of the SAS token generated- something
  that was not possible in user-delegation SAS authentication type. Reach out to us at 'askabfs@microsoft.com' for more information.
- To use this authentication type, both custom SAS token provider class (that implements org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider) as
-    well as OAuth 2.0 provider type need to be specified.
-    - Refer to 'Shared Access Signature (SAS) Token Provider' section above for user-delegation SAS token provider class details and example class implementation.
-    - There are multiple identity configurations for OAuth settings. Listing the main ones below:
+- To use this authentication type, both custom SAS token provider class as well as OAuth 2.0 provider type need to be specified.
+    - Read the section below for SAS Token Provider class details and example class implementation.
+    - There are multiple identity configurations for OAuth Token Provider settings. Listing the main ones below:
         - Client Credentials
         - Custom token provider
         - Managed Identity
         - Workload Identity
 
-      Refer to respective OAuth 2.0 sections above to correctly chose the OAuth provider type
+      Refer to respective OAuth 2.0 sections above to correctly choose the OAuth provider type
     - NOTE: User-bound SAS Authentication is **only supported** with HNS Enabled accounts.
 
 - **Configuration**: To use this method with ABFS Driver, specify the following properties in your `core-site.xml` file:
@@ -837,6 +836,58 @@ requests. User can specify them as fixed SAS Token to be used across all the req
           <value>CUSTOM_SAS_TOKEN_PROVIDER_CLASS</value>
         </property>
         ```
+
+    - ABFS allows you to implement your custom SAS Token Provider. The declared class must implement
+      `org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider`.
+      ABFS Hadoop Driver provides
+      a [MockUserBoundSASTokenProvider](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/MockUserBoundSASTokenProvider.java)
+      implementation that can be used as an example on how to implement your own custom
+      SASTokenProvider. This requires the Application credentials to be specifed using
+      the following configurations apart from above three:
+  
+    4. Delegator App Service Principal Tenant Id:
+        ```xml
+        <property>
+          <name>fs.azure.test.app.service.principal.tenant.id</name>
+          <value>DELEGATOR_TENANT_ID</value>
+        </property>
+        ```
+    5. Delegator App Service Principal Object Id:
+        ```xml
+        <property>
+          <name>fs.azure.test.app.service.principal.object.id</name>
+          <value>DELEGATOR_OBJECT_ID</value>
+        </property>
+        ```
+    6. End-user App Service Principal Tenant Id:
+       ```xml
+        <property>
+          <name>fs.azure.test.end.user.tenant.id</name>
+          <value>DELEGATED_TENANT_ID</value>
+        </property>
+        ```
+    7. End-user App Service Principal Object Id:
+       ```xml
+       <property>
+         <name>fs.azure.test.end.user.object.id</name>
+         <value>DELEGATED_OBJECT_ID</value>
+       </property>
+       ```
+    8. Delegator App Id:
+       ```xml
+       <property>
+       <name>fs.azure.test.app.id</name>
+       <value>APPLICATION_ID</value>
+       </property>
+       ```
+    9. Delegator App Secret:
+       ```xml
+       <property>
+         <name>fs.azure.test.app.secret</name>
+         <value>APPLICATION_SECRET</value>
+       </property>
+       ```
+    - Add all additional configs required by the chosen OAuth Token provider from the sections above as well.
 
 ## <a name="technical"></a> Technical notes
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -223,9 +223,7 @@ public class ITestAzureBlobFileSystemAppend extends
         createPath(makeQualified(testPath).toUri().getPath(), true, false,
             permissions, false, null,
             null, getTestTracingContext(fs, true));
-    fs.getAbfsStore()
-        .getAbfsConfiguration()
-        .set(FS_AZURE_INGRESS_SERVICE_TYPE, AbfsServiceType.BLOB.name());
+    fs.getAbfsStore().getClientHandler().setIngressServiceType(AbfsServiceType.BLOB);
     FSDataOutputStream outputStream = fs.append(testPath);
     AzureIngressHandler ingressHandler
         = ((AbfsOutputStream) outputStream.getWrappedStream()).getIngressHandler();
@@ -262,9 +260,7 @@ public class ITestAzureBlobFileSystemAppend extends
         createPath(makeQualified(testPath).toUri().getPath(), true, false,
             permissions, false, null,
             null, getTestTracingContext(fs, true));
-    fs.getAbfsStore()
-        .getAbfsConfiguration()
-        .set(FS_AZURE_INGRESS_SERVICE_TYPE, AbfsServiceType.BLOB.name());
+    fs.getAbfsStore().getClientHandler().setIngressServiceType(AbfsServiceType.BLOB);
     ExecutorService executorService = Executors.newFixedThreadPool(5);
     List<Future<?>> futures = new ArrayList<>();
 
@@ -328,9 +324,7 @@ public class ITestAzureBlobFileSystemAppend extends
         createPath(makeQualified(testPath).toUri().getPath(), true, false,
             permissions, false, null,
             null, getTestTracingContext(fs, true));
-    fs.getAbfsStore()
-        .getAbfsConfiguration()
-        .set(FS_AZURE_INGRESS_SERVICE_TYPE, AbfsServiceType.BLOB.name());
+    fs.getAbfsStore().getClientHandler().setIngressServiceType(AbfsServiceType.BLOB);
     FSDataOutputStream out1 = fs.create(testPath);
     fs.getAbfsStore().getClientHandler().getDfsClient().
         createPath(makeQualified(testPath1).toUri().getPath(), true, false,
@@ -389,10 +383,7 @@ public class ITestAzureBlobFileSystemAppend extends
       fs.getAbfsStore()
           .getAbfsConfiguration()
           .setBoolean(FS_AZURE_ENABLE_DFSTOBLOB_FALLBACK, true);
-      fs.getAbfsStore()
-          .getAbfsConfiguration()
-          .set(FS_AZURE_INGRESS_SERVICE_TYPE,
-              String.valueOf(AbfsServiceType.DFS));
+      fs.getAbfsStore().getClientHandler().setIngressServiceType(AbfsServiceType.DFS);
       fs.getAbfsStore().getClientHandler().getBlobClient().
           createPath(makeQualified(testPath).toUri().getPath(), true, false,
               permissions, false, null,
@@ -438,10 +429,7 @@ public class ITestAzureBlobFileSystemAppend extends
       fs.getAbfsStore()
           .getAbfsConfiguration()
           .setBoolean(FS_AZURE_ENABLE_DFSTOBLOB_FALLBACK, true);
-      fs.getAbfsStore()
-          .getAbfsConfiguration()
-          .set(FS_AZURE_INGRESS_SERVICE_TYPE,
-              String.valueOf(AbfsServiceType.DFS));
+      fs.getAbfsStore().getClientHandler().setIngressServiceType(AbfsServiceType.DFS);
       fs.getAbfsStore().getClientHandler().getBlobClient().
           createPath(makeQualified(testPath).toUri().getPath(), true, false,
               permissions, true, null,
@@ -483,9 +471,7 @@ public class ITestAzureBlobFileSystemAppend extends
         createPath(makeQualified(testPath).toUri().getPath(), true, false,
             permissions, true, null,
             null, getTestTracingContext(fs, true));
-    fs.getAbfsStore()
-        .getAbfsConfiguration()
-        .set(FS_AZURE_INGRESS_SERVICE_TYPE, AbfsServiceType.BLOB.name());
+    fs.getAbfsStore().getClientHandler().setIngressServiceType(AbfsServiceType.BLOB);
     FSDataOutputStream outputStream = fs.append(testPath);
     AzureIngressHandler ingressHandler
         = ((AbfsOutputStream) outputStream.getWrappedStream()).getIngressHandler();
@@ -507,59 +493,90 @@ public class ITestAzureBlobFileSystemAppend extends
         .isInstanceOf(AbfsDfsClient.class);
   }
 
+  private void validateIngressHandler(AbfsServiceType ingressServiceType,
+          Class<? extends AzureIngressHandler> expectedIngressHandler,
+          Class<? extends AbfsClient> expectedClient)
+          throws IOException {
 
-  /**
-   * Tests the correct retrieval of the AzureIngressHandler based on the configured ingress service type.
-   *
-   * @throws IOException if an I/O error occurs
-   */
-  @Test
-  public void testValidateIngressHandler() throws IOException {
     Configuration configuration = getRawConfiguration();
     configuration.set(FS_AZURE_INGRESS_SERVICE_TYPE,
-        AbfsServiceType.BLOB.name());
-    try (AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
-        configuration)) {
-      Path testPath = path(TEST_FILE_PATH);
-      AzureBlobFileSystemStore.Permissions permissions
-          = new AzureBlobFileSystemStore.Permissions(false,
-          FsPermission.getDefault(), FsPermission.getUMask(fs.getConf()));
-      fs.getAbfsStore().getClientHandler().getBlobClient().
-          createPath(makeQualified(testPath).toUri().getPath(), true,
-              false,
-              permissions, false, null,
-              null, getTestTracingContext(fs, true));
-      FSDataOutputStream outputStream = fs.append(testPath);
-      AzureIngressHandler ingressHandler
-          = ((AbfsOutputStream) outputStream.getWrappedStream()).getIngressHandler();
-      assertThat(ingressHandler)
-          .as("Blob Ingress handler instance is not correct")
-          .isInstanceOf(AzureBlobIngressHandler.class);
-      AbfsClient client = ingressHandler.getClient();
-      assertThat(client)
-          .as("Blob client was not used correctly")
-          .isInstanceOf(AbfsBlobClient.class);
+            ingressServiceType.name());
 
-      Path testPath1 = new Path("testFile1");
-      fs.getAbfsStore().getClientHandler().getBlobClient().
-          createPath(makeQualified(testPath1).toUri().getPath(), true,
-              false,
-              permissions, false, null,
-              null, getTestTracingContext(fs, true));
+    try (AzureBlobFileSystem fs =
+                 (AzureBlobFileSystem) FileSystem.newInstance(configuration)) {
+
+      Path testPath = path(TEST_FILE_PATH);
+      AzureBlobFileSystemStore.Permissions permissions =
+              new AzureBlobFileSystemStore.Permissions(
+                      false,
+                      FsPermission.getDefault(),
+                      FsPermission.getUMask(fs.getConf()));
+
       fs.getAbfsStore()
-          .getAbfsConfiguration()
-          .set(FS_AZURE_INGRESS_SERVICE_TYPE, AbfsServiceType.DFS.name());
-      FSDataOutputStream outputStream1 = fs.append(testPath1);
-      AzureIngressHandler ingressHandler1
-          = ((AbfsOutputStream) outputStream1.getWrappedStream()).getIngressHandler();
-      assertThat(ingressHandler1)
-          .as("DFS Ingress handler instance is not correct")
-          .isInstanceOf(AzureDFSIngressHandler.class);
-      AbfsClient client1 = ingressHandler1.getClient();
-      assertThat(client1)
-          .as("Dfs client was not used correctly")
-          .isInstanceOf(AbfsDfsClient.class);
+              .getClientHandler()
+              .getBlobClient()
+              .createPath(
+                      makeQualified(testPath).toUri().getPath(),
+                      true,
+                      false,
+                      permissions,
+                      false,
+                      null,
+                      null,
+                      getTestTracingContext(fs, true));
+
+      FSDataOutputStream outputStream = fs.append(testPath);
+      AzureIngressHandler ingressHandler =
+              ((AbfsOutputStream) outputStream.getWrappedStream())
+                      .getIngressHandler();
+
+      assertThat(ingressHandler)
+              .as("Unexpected ingress handler type")
+              .isInstanceOf(expectedIngressHandler);
+
+      assertThat(ingressHandler.getClient())
+              .as("Unexpected client used by ingress handler")
+              .isInstanceOf(expectedClient);
     }
+  }
+
+  /**
+   * Validates that for FNS, both DFS and BLOB ingress service types force the use of
+   * AzureBlobIngressHandler and AbfsBlobClient.
+   *
+   * @throws IOException if an I/O error occurs during validation
+   */
+  @Test
+  public void testValidateIngressHandlerForFNS() throws IOException {
+    assumeHnsDisabled();
+
+    validateIngressHandler(AbfsServiceType.DFS,
+            AzureBlobIngressHandler.class,
+            AbfsBlobClient.class);
+    validateIngressHandler(AbfsServiceType.BLOB,
+            AzureBlobIngressHandler.class,
+            AbfsBlobClient.class);
+  }
+
+
+  /**
+   * Validates that for HNS, the correct ingress handler and client
+   * are used for both DFS and BLOB service types.
+   * For DFS ingress service type, expects AzureDFSIngressHandler and AbfsDfsClient.
+   * For BLOB ingress service type, expects AzureBlobIngressHandler and AbfsBlobClient.
+   *
+   * @throws IOException if an I/O error occurs during validation
+   */
+  @Test
+  public void testValidateIngressHandlerForHNS() throws IOException {
+    assumeHnsEnabled();
+
+    validateIngressHandler(AbfsServiceType.DFS,
+            AzureDFSIngressHandler.class,
+            AbfsDfsClient.class);
+    validateIngressHandler(AbfsServiceType.BLOB,
+            AzureBlobIngressHandler.class,
+            AbfsBlobClient.class);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -493,6 +493,15 @@ public class ITestAzureBlobFileSystemAppend extends
         .isInstanceOf(AbfsDfsClient.class);
   }
 
+  /**
+   * Validates that the correct ingress handler and client are used for the specified
+   * ingress service type.
+   *
+   * @param ingressServiceType     the ingress service type to test (e.g., DFS or BLOB)
+   * @param expectedIngressHandler the expected class of the AzureIngressHandler
+   * @param expectedClient         the expected class of the AbfsClient
+   * @throws IOException if an I/O error occurs during validation
+   */
   private void validateIngressHandler(AbfsServiceType ingressServiceType,
           Class<? extends AzureIngressHandler> expectedIngressHandler,
           Class<? extends AbfsClient> expectedClient)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -20,14 +20,12 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
 import java.net.URI;
-import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +70,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
   @BeforeEach
   @Override
   public void setup() throws Exception {
-    //super.setup();
+    super.setup();
   }
 
   @AfterEach
@@ -167,16 +165,27 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
             mockedFs.initialize(fs.getUri(), getRawConfiguration()));
   }
 
+  /**
+   * Test to verify that the fnsEndptConvertedIndicator ("T") is present in the tracing header
+   * after endpoint conversion during AzureBlobFileSystem initialization.
+   *
+   * @throws Exception if any error occurs during the test
+   */
   @Test
-  public void testFNSEndptConvertedIndicatorInHeaderAfterInitialize() throws Exception {
+  public void testFNSEndptConvertedIndicatorInHeader() throws Exception {
+    assumeHnsDisabled();
+    String scheme = "abfs";
+    String dfsDomain = "dfs.core.windows.net";
+    String endptConversionIndicatorInTc = "T";
     Configuration conf = new Configuration(getRawConfiguration());
     conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
 
     String dfsUri = String.format("%s://%s@%s.%s/",
-            "abfs", getFileSystemName(),
-            getAccountName().substring(0, getAccountName().indexOf('.')),
-            "dfs.core.windows.net");
+            scheme, getFileSystemName(),
+            getAccountName().substring(0, getAccountName().indexOf(DOT)),
+            dfsDomain);
 
+    // Initialize filesystem with DFS endpoint
     AzureBlobFileSystem fs =
             (AzureBlobFileSystem) FileSystem.newInstance(new URI(dfsUri), conf);
 
@@ -187,140 +196,21 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
     Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
     Mockito.doReturn(spiedClient).when(spiedStore).getClient();
 
-// re-init the FS so the spy wiring is used
+    // re-init the FS so the spy wiring is used
     spiedFs.initialize(fs.getUri(), conf);
-
-// ---- Capturing the TracingContext ----
     ArgumentCaptor<TracingContext> ctxCaptor = ArgumentCaptor.forClass(TracingContext.class);
-
-// Trigger the flow
-    //spiedFs.listStatus(new Path("/")); // or whatever causes createFilesystem() internally
-
-// Verify & capture
     verify(spiedClient, atLeastOnce())
             .getFilesystemProperties(ctxCaptor.capture());
 
-// Extract captured value
     TracingContext captured = ctxCaptor.getValue();
-    System.out.print(captured.getFNSEndptConvertedIndicator());
 
     AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
     captured.constructHeader(abfsHttpOperation, null,
             EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
+
+    // The tracing context being used FS Initialization should have the endpoint conversion indicator set to 'T'
     String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
-    System.out.print("hellooo"+captured.getHeader());
-    org.assertj.core.api.Assertions.assertThat(endpointConversionIndicator)
-            .describedAs("Endpoint conversion indicator should be present")
-            .isNotEmpty();
-
-//    List<TracingContext> tracingContextList = ctxCaptor.getAllValues();
-//
-//      for (TracingContext tracingContext : tracingContextList) {
-//          System.out.println(tracingContext);
-//      }
-//    System.out.println("Captured context: " + captured.getHeader());
-
+    Assertions.assertFalse(endpointConversionIndicator.isEmpty(), "Endpoint conversion indicator should be present");
+    Assertions.assertEquals(endptConversionIndicatorInTc, endpointConversionIndicator, "Endpoint conversion indicator should be 'T'");
   }
-
-
-  /**
-   * Test that FNSEndptConvertedIndicator ("T") is added to the header after endpoint conversion in initialize().
-   */
-//  @Test
-//  public void testFNSEndptConvertedIndicatorInHeaderAfterInitialize() throws Exception {
-//      String scheme = "abfs";
-//      String dfsDomain = "dfs.core.windows.net";
-//      String accountNameNoDns = getAccountName().substring(0, getAccountName().indexOf('.'));
-//
-//      Configuration conf = new Configuration(getRawConfiguration());
-//      conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
-//
-//      String dfsUri = String.format("%s://%s@%s.%s/",
-//              scheme, getFileSystemName(), accountNameNoDns, dfsDomain);
-//
-//      AzureBlobFileSystem fs = (AzureBlobFileSystem)
-//              FileSystem.newInstance(new URI(dfsUri), conf);
-//
-//    AzureBlobFileSystem spiedFs = Mockito.spy(fs);
-//    AzureBlobFileSystemStore spiedStore = Mockito.spy(spiedFs.getAbfsStore());
-//    AbfsClient spiedClient = Mockito.spy(spiedStore.getClient());
-//    Mockito.doReturn(spiedClient).when(spiedStore).getClient();
-//    Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
-//
-//    // Spy FS so private/inner transitions are preserved
-//   // AzureBlobFileSystem fs = Mockito.spy(realFs);
-//
-//// Create a mock store and inject it
-////    AzureBlobFileSystemStore mockStore = Mockito.mock(AzureBlobFileSystemStore.class);
-////    doReturn(mockStore).when(fs).getAbfsStore();
-//
-//      // Initialize (this triggers account check, endpoint reset, and createFileSystem call)
-//    spiedFs.initialize(fs.getUri(), conf);
-//
-//      // Capture the TracingContext passed into createFileSystem
-//    ArgumentCaptor<TracingContext> captor = ArgumentCaptor.forClass(TracingContext.class);
-//
-//// Now call initialize (this triggers the conversion + createFileSystem)
-//
-//// Verify and capture
-////    verify(fs, times(2))
-////            .createFileSystem(captor.capture());
-////
-////    TracingContext ctx = captor.getValue();
-////    System.out.println("hiii"+ctx);
-////    Assertions.assertNotNull(ctx, "Expected a TracingContext passed into createFileSystem");
-////
-////// Now! the header exists
-////    String header = ctx.getHeader();
-////    System.out.println("hiiiiiiiii"+header);
-//
-////    ArgumentCaptor<TracingContext> captor9 = ArgumentCaptor.forClass(TracingContext.class);
-////
-////    verify(spiedFs.getAbfsStore().getClient(), times(1)).createFilesystem(captor9.capture());
-//
-//    TracingContext[] capturedContext = new TracingContext[1];
-//    doAnswer(invocation -> {
-//      capturedContext[0] = invocation.getArgument(0);
-//      return null; // or appropriate return value
-//    }).when(spiedFs.getAbfsStore().getClient()).createFilesystem(any(TracingContext.class));
-//
-////    List<TracingContext> tracingContextList = captor9.getAllValues();
-////    System.out.println(tracingContextList);
-//
-////    Assertions.assertNotNull(header, "Tracing header should be generated");
-////    Assertions.assertTrue(header.endsWith("T"),
-////            "Expected FNSEndptConvertedIndicator 'T' at the end of the header, got: " + header);
-////
-////    System.out.println("Captured Header: " + header);
-//
-//
-//
-////    String scheme = "abfs";
-////    String dfsDomain = "dfs.core.windows.net";
-////    String accountNameNoDns = getAccountName().substring(0,
-////            getAccountName().indexOf("."));
-////    Configuration conf = new Configuration(getRawConfiguration());
-////    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
-////
-////    String dfsUri = String.format("%s://%s@%s.%s/", scheme, getFileSystemName(),
-////            accountNameNoDns, dfsDomain);
-////
-////    AzureBlobFileSystem fs = (AzureBlobFileSystem)
-////            FileSystem.newInstance(new URI(dfsUri), conf);
-////
-////    // triggers endpoint conversion but NO header yet
-////    fs.initialize(fs.getUri(), conf);
-////
-////    // FORCE an operation to cause constructHeader() execution
-////    fs.create(new Path("/testHeaderTrigger"));
-////
-////    // Now the tracing header is actually created
-////    String header = fs.getInitFSTracingHeader();
-////    System.out.println("Header = " + header);
-////
-////    Assertions.assertNotNull(header, "Tracing header should be available after actual request");
-////    Assertions.assertTrue(header.endsWith("T"),
-////            "Tracing header should end with 'T' for FNSEndptConvertedIndicator, but was: " + header);
-//  }
-
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -45,15 +45,20 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
-import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.*;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_INGRESS_SERVICE_TYPE;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.accountProperty;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_BLOB_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DFS_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.INCORRECT_INGRESS_TYPE;
 import static org.apache.hadoop.fs.azurebfs.services.RetryPolicyConstants.EXPONENTIAL_RETRY_POLICY_ABBREVIATION;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Assertions;
 
@@ -92,16 +97,16 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
         getRawConfiguration()));
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsStore().getClient(AbfsServiceType.DFS));
-    doReturn(client).when(store).getClient(AbfsServiceType.DFS);
+    Mockito.doReturn(client).when(store).getClient(AbfsServiceType.DFS);
     store.getAbfsConfiguration().setIsNamespaceEnabledAccountForTesting(Trilean.UNKNOWN);
 
     TracingContext tracingContext = getSampleTracingContext(fs, true);
-    doReturn(Mockito.mock(AbfsRestOperation.class))
+    Mockito.doReturn(Mockito.mock(AbfsRestOperation.class))
         .when(client)
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
     store.getIsNamespaceEnabled(tracingContext);
 
-    verify(client, Mockito.times(1))
+    Mockito.verify(client, Mockito.times(1))
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
   }
 
@@ -111,16 +116,16 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
         getRawConfiguration()));
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
-    doReturn(client).when(store).getClient();
+    Mockito.doReturn(client).when(store).getClient();
 
-    doReturn(true)
+    Mockito.doReturn(true)
         .when(store)
         .isNamespaceEnabled();
 
     TracingContext tracingContext = getSampleTracingContext(fs, true);
     store.getIsNamespaceEnabled(tracingContext);
 
-    verify(client, Mockito.times(0))
+    Mockito.verify(client, Mockito.times(0))
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
   }
 
@@ -186,31 +191,31 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
             dfsDomain);
 
     // Initialize filesystem with DFS endpoint
-    AzureBlobFileSystem fs =
-            (AzureBlobFileSystem) FileSystem.newInstance(new URI(dfsUri), conf);
+    try (AzureBlobFileSystem fs =
+                 (AzureBlobFileSystem) FileSystem.newInstance(new URI(dfsUri), conf)) {
+      AzureBlobFileSystem spiedFs = Mockito.spy(fs);
+      AzureBlobFileSystemStore spiedStore = Mockito.spy(spiedFs.getAbfsStore());
+      AbfsClient spiedClient = Mockito.spy(spiedStore.getClient());
 
-    AzureBlobFileSystem spiedFs = Mockito.spy(fs);
-    AzureBlobFileSystemStore spiedStore = Mockito.spy(spiedFs.getAbfsStore());
-    AbfsClient spiedClient = Mockito.spy(spiedStore.getClient());
+      Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
+      Mockito.doReturn(spiedClient).when(spiedStore).getClient();
 
-    Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
-    Mockito.doReturn(spiedClient).when(spiedStore).getClient();
+      // re-init the FS so the spy wiring is used
+      spiedFs.initialize(fs.getUri(), conf);
+      ArgumentCaptor<TracingContext> ctxCaptor = ArgumentCaptor.forClass(TracingContext.class);
+      Mockito.verify(spiedClient, Mockito.atLeastOnce())
+              .getFilesystemProperties(ctxCaptor.capture());
 
-    // re-init the FS so the spy wiring is used
-    spiedFs.initialize(fs.getUri(), conf);
-    ArgumentCaptor<TracingContext> ctxCaptor = ArgumentCaptor.forClass(TracingContext.class);
-    verify(spiedClient, atLeastOnce())
-            .getFilesystemProperties(ctxCaptor.capture());
+      TracingContext captured = ctxCaptor.getValue();
 
-    TracingContext captured = ctxCaptor.getValue();
+      AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
+      captured.constructHeader(abfsHttpOperation, null,
+              EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
 
-    AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
-    captured.constructHeader(abfsHttpOperation, null,
-            EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
-
-    // The tracing context being used FS Initialization should have the endpoint conversion indicator set to 'T'
-    String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
-    Assertions.assertFalse(endpointConversionIndicator.isEmpty(), "Endpoint conversion indicator should be present");
-    Assertions.assertEquals(endptConversionIndicatorInTc, endpointConversionIndicator, "Endpoint conversion indicator should be 'T'");
+      // The tracing context being used FS Initialization should have the endpoint conversion indicator set to 'T'
+      String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
+      Assertions.assertFalse(endpointConversionIndicator.isEmpty(), "Endpoint conversion indicator should be present");
+      Assertions.assertEquals(endptConversionIndicatorInTc, endpointConversionIndicator, "Endpoint conversion indicator should be 'T'");
+    }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -37,25 +37,17 @@ import org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
-import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationValueException;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_INGRESS_SERVICE_TYPE;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.accountProperty;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION;
-import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_BLOB_DOMAIN_NAME;
-import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DFS_DOMAIN_NAME;
-import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.INCORRECT_INGRESS_TYPE;
 import static org.apache.hadoop.fs.azurebfs.services.RetryPolicyConstants.EXPONENTIAL_RETRY_POLICY_ABBREVIATION;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.mockito.ArgumentMatchers.any;
@@ -129,33 +121,6 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
   }
 
-  /**
-   * Test to verify that the initialization of the AzureBlobFileSystem fails
-   * when an invalid ingress service type is configured.
-   *
-   * This test sets up a configuration with an invalid ingress service type
-   * (DFS) for a Blob endpoint and expects an InvalidConfigurationValueException
-   * to be thrown during the initialization of the filesystem.
-   *
-   * @throws Exception if an error occurs during the test execution
-   */
-  @Test
-  public void testFileSystemInitializationFailsForInvalidIngress() throws Exception {
-    assumeHnsDisabled();
-    Configuration configuration = new Configuration(getRawConfiguration());
-    String defaultUri = configuration.get(FS_DEFAULT_NAME_KEY);
-    String accountKey = configuration.get(
-        accountProperty(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME, getAccountName()),
-        configuration.get(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME));
-    configuration.set(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME,
-        accountKey.replace(ABFS_DFS_DOMAIN_NAME, ABFS_BLOB_DOMAIN_NAME));
-    configuration.set(FS_AZURE_INGRESS_SERVICE_TYPE, AbfsServiceType.DFS.name());
-    String blobUri = defaultUri.replace(ABFS_DFS_DOMAIN_NAME, ABFS_BLOB_DOMAIN_NAME);
-    intercept(InvalidConfigurationValueException.class,
-        INCORRECT_INGRESS_TYPE, () ->
-            FileSystem.newInstance(new Path(blobUri).toUri(), configuration));
-  }
-
   @Test
   public void testFileSystemInitFailsIfNotAbleToDetermineAccountType() throws Exception {
     AzureBlobFileSystem fs = ((AzureBlobFileSystem) FileSystem.newInstance(
@@ -213,7 +178,8 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
               EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
 
       // The tracing context being used FS Initialization should have the endpoint conversion indicator set to 'T'
-      String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
+      final int ENDPOINT_CONVERSION_INDICATOR_INDEX = 15;
+      String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[ENDPOINT_CONVERSION_INDICATOR_INDEX];
       Assertions.assertFalse(endpointConversionIndicator.isEmpty(), "Endpoint conversion indicator should be present");
       Assertions.assertEquals(endptConversionIndicatorInTc, endpointConversionIndicator, "Endpoint conversion indicator should be 'T'");
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -178,8 +178,8 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
               EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
 
       // The tracing context being used FS Initialization should have the endpoint conversion indicator set to 'T'
-      final int ENDPOINT_CONVERSION_INDICATOR_INDEX = 15;
-      String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[ENDPOINT_CONVERSION_INDICATOR_INDEX];
+      final int endpointConversionIndicatorIndex  = 15;
+      String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[endpointConversionIndicatorIndex ];
       Assertions.assertFalse(endpointConversionIndicator.isEmpty(), "Endpoint conversion indicator should be present");
       Assertions.assertEquals(endptConversionIndicatorInTc, endpointConversionIndicator, "Endpoint conversion indicator should be 'T'");
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -19,15 +19,20 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
+import java.net.URI;
+import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
+import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType;
@@ -42,15 +47,16 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_INGRESS_SERVICE_TYPE;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.accountProperty;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.*;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_BLOB_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DFS_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.INCORRECT_INGRESS_TYPE;
+import static org.apache.hadoop.fs.azurebfs.services.RetryPolicyConstants.EXPONENTIAL_RETRY_POLICY_ABBREVIATION;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import org.junit.jupiter.api.Assertions;
 
 /**
@@ -66,7 +72,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
   @BeforeEach
   @Override
   public void setup() throws Exception {
-    super.setup();
+    //super.setup();
   }
 
   @AfterEach
@@ -88,16 +94,16 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
         getRawConfiguration()));
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsStore().getClient(AbfsServiceType.DFS));
-    Mockito.doReturn(client).when(store).getClient(AbfsServiceType.DFS);
+    doReturn(client).when(store).getClient(AbfsServiceType.DFS);
     store.getAbfsConfiguration().setIsNamespaceEnabledAccountForTesting(Trilean.UNKNOWN);
 
     TracingContext tracingContext = getSampleTracingContext(fs, true);
-    Mockito.doReturn(Mockito.mock(AbfsRestOperation.class))
+    doReturn(Mockito.mock(AbfsRestOperation.class))
         .when(client)
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
     store.getIsNamespaceEnabled(tracingContext);
 
-    Mockito.verify(client, Mockito.times(1))
+    verify(client, Mockito.times(1))
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
   }
 
@@ -107,16 +113,16 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
         getRawConfiguration()));
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
-    Mockito.doReturn(client).when(store).getClient();
+    doReturn(client).when(store).getClient();
 
-    Mockito.doReturn(true)
+    doReturn(true)
         .when(store)
         .isNamespaceEnabled();
 
     TracingContext tracingContext = getSampleTracingContext(fs, true);
     store.getIsNamespaceEnabled(tracingContext);
 
-    Mockito.verify(client, Mockito.times(0))
+    verify(client, Mockito.times(0))
         .getAclStatus(Mockito.anyString(), any(TracingContext.class));
   }
 
@@ -160,4 +166,161 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
         FS_AZURE_ACCOUNT_IS_HNS_ENABLED, () ->
             mockedFs.initialize(fs.getUri(), getRawConfiguration()));
   }
+
+  @Test
+  public void testFNSEndptConvertedIndicatorInHeaderAfterInitialize() throws Exception {
+    Configuration conf = new Configuration(getRawConfiguration());
+    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
+
+    String dfsUri = String.format("%s://%s@%s.%s/",
+            "abfs", getFileSystemName(),
+            getAccountName().substring(0, getAccountName().indexOf('.')),
+            "dfs.core.windows.net");
+
+    AzureBlobFileSystem fs =
+            (AzureBlobFileSystem) FileSystem.newInstance(new URI(dfsUri), conf);
+
+    AzureBlobFileSystem spiedFs = Mockito.spy(fs);
+    AzureBlobFileSystemStore spiedStore = Mockito.spy(spiedFs.getAbfsStore());
+    AbfsClient spiedClient = Mockito.spy(spiedStore.getClient());
+
+    Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
+    Mockito.doReturn(spiedClient).when(spiedStore).getClient();
+
+// re-init the FS so the spy wiring is used
+    spiedFs.initialize(fs.getUri(), conf);
+
+// ---- Capturing the TracingContext ----
+    ArgumentCaptor<TracingContext> ctxCaptor = ArgumentCaptor.forClass(TracingContext.class);
+
+// Trigger the flow
+    //spiedFs.listStatus(new Path("/")); // or whatever causes createFilesystem() internally
+
+// Verify & capture
+    verify(spiedClient, atLeastOnce())
+            .getFilesystemProperties(ctxCaptor.capture());
+
+// Extract captured value
+    TracingContext captured = ctxCaptor.getValue();
+    System.out.print(captured.getFNSEndptConvertedIndicator());
+
+    AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
+    captured.constructHeader(abfsHttpOperation, null,
+            EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
+    String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
+    System.out.print("hellooo"+captured.getHeader());
+    org.assertj.core.api.Assertions.assertThat(endpointConversionIndicator)
+            .describedAs("Endpoint conversion indicator should be present")
+            .isNotEmpty();
+
+//    List<TracingContext> tracingContextList = ctxCaptor.getAllValues();
+//
+//      for (TracingContext tracingContext : tracingContextList) {
+//          System.out.println(tracingContext);
+//      }
+//    System.out.println("Captured context: " + captured.getHeader());
+
+  }
+
+
+  /**
+   * Test that FNSEndptConvertedIndicator ("T") is added to the header after endpoint conversion in initialize().
+   */
+//  @Test
+//  public void testFNSEndptConvertedIndicatorInHeaderAfterInitialize() throws Exception {
+//      String scheme = "abfs";
+//      String dfsDomain = "dfs.core.windows.net";
+//      String accountNameNoDns = getAccountName().substring(0, getAccountName().indexOf('.'));
+//
+//      Configuration conf = new Configuration(getRawConfiguration());
+//      conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
+//
+//      String dfsUri = String.format("%s://%s@%s.%s/",
+//              scheme, getFileSystemName(), accountNameNoDns, dfsDomain);
+//
+//      AzureBlobFileSystem fs = (AzureBlobFileSystem)
+//              FileSystem.newInstance(new URI(dfsUri), conf);
+//
+//    AzureBlobFileSystem spiedFs = Mockito.spy(fs);
+//    AzureBlobFileSystemStore spiedStore = Mockito.spy(spiedFs.getAbfsStore());
+//    AbfsClient spiedClient = Mockito.spy(spiedStore.getClient());
+//    Mockito.doReturn(spiedClient).when(spiedStore).getClient();
+//    Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
+//
+//    // Spy FS so private/inner transitions are preserved
+//   // AzureBlobFileSystem fs = Mockito.spy(realFs);
+//
+//// Create a mock store and inject it
+////    AzureBlobFileSystemStore mockStore = Mockito.mock(AzureBlobFileSystemStore.class);
+////    doReturn(mockStore).when(fs).getAbfsStore();
+//
+//      // Initialize (this triggers account check, endpoint reset, and createFileSystem call)
+//    spiedFs.initialize(fs.getUri(), conf);
+//
+//      // Capture the TracingContext passed into createFileSystem
+//    ArgumentCaptor<TracingContext> captor = ArgumentCaptor.forClass(TracingContext.class);
+//
+//// Now call initialize (this triggers the conversion + createFileSystem)
+//
+//// Verify and capture
+////    verify(fs, times(2))
+////            .createFileSystem(captor.capture());
+////
+////    TracingContext ctx = captor.getValue();
+////    System.out.println("hiii"+ctx);
+////    Assertions.assertNotNull(ctx, "Expected a TracingContext passed into createFileSystem");
+////
+////// Now! the header exists
+////    String header = ctx.getHeader();
+////    System.out.println("hiiiiiiiii"+header);
+//
+////    ArgumentCaptor<TracingContext> captor9 = ArgumentCaptor.forClass(TracingContext.class);
+////
+////    verify(spiedFs.getAbfsStore().getClient(), times(1)).createFilesystem(captor9.capture());
+//
+//    TracingContext[] capturedContext = new TracingContext[1];
+//    doAnswer(invocation -> {
+//      capturedContext[0] = invocation.getArgument(0);
+//      return null; // or appropriate return value
+//    }).when(spiedFs.getAbfsStore().getClient()).createFilesystem(any(TracingContext.class));
+//
+////    List<TracingContext> tracingContextList = captor9.getAllValues();
+////    System.out.println(tracingContextList);
+//
+////    Assertions.assertNotNull(header, "Tracing header should be generated");
+////    Assertions.assertTrue(header.endsWith("T"),
+////            "Expected FNSEndptConvertedIndicator 'T' at the end of the header, got: " + header);
+////
+////    System.out.println("Captured Header: " + header);
+//
+//
+//
+////    String scheme = "abfs";
+////    String dfsDomain = "dfs.core.windows.net";
+////    String accountNameNoDns = getAccountName().substring(0,
+////            getAccountName().indexOf("."));
+////    Configuration conf = new Configuration(getRawConfiguration());
+////    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
+////
+////    String dfsUri = String.format("%s://%s@%s.%s/", scheme, getFileSystemName(),
+////            accountNameNoDns, dfsDomain);
+////
+////    AzureBlobFileSystem fs = (AzureBlobFileSystem)
+////            FileSystem.newInstance(new URI(dfsUri), conf);
+////
+////    // triggers endpoint conversion but NO header yet
+////    fs.initialize(fs.getUri(), conf);
+////
+////    // FORCE an operation to cause constructHeader() execution
+////    fs.create(new Path("/testHeaderTrigger"));
+////
+////    // Now the tracing header is actually created
+////    String header = fs.getInitFSTracingHeader();
+////    System.out.println("Header = " + header);
+////
+////    Assertions.assertNotNull(header, "Tracing header should be available after actual request");
+////    Assertions.assertTrue(header.endsWith("T"),
+////            "Tracing header should end with 'T' for FNSEndptConvertedIndicator, but was: " + header);
+//  }
+
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestGetNameSpaceEnabled.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestGetNameSpaceEnabled.java
@@ -435,7 +435,7 @@ public class ITestGetNameSpaceEnabled extends AbstractAbfsIntegrationTest {
     AzureBlobFileSystem mockFileSystem = Mockito.spy((AzureBlobFileSystem)
         FileSystem.newInstance(getConfigurationWithoutHnsConfig()));
     AzureBlobFileSystemStore mockStore = Mockito.spy(mockFileSystem.getAbfsStore());
-    AbfsClient abfsClient = Mockito.spy(mockStore.getClient());
+    AbfsClient abfsClient = Mockito.spy(mockStore.getClient(AbfsServiceType.DFS));
     Mockito.doReturn(abfsClient).when(mockStore).getClient();
     Mockito.doReturn(abfsClient).when(mockStore).getClient(any());
     abfsClient.getIsNamespaceEnabled();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -381,7 +381,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
     AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
     tracingContext.constructHeader(abfsHttpOperation, null,
         EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
-    String endpointConversionIndicator = tracingContext.getHeader().split(COLON, SPLIT_NO_LIMIT)[9];
+    String endpointConversionIndicator = tracingContext.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
     Assertions.assertThat(endpointConversionIndicator)
         .describedAs("Endpoint conversion indicator should be present")
         .isNotEmpty();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,8 +36,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
-import org.apache.hadoop.fs.azurebfs.services.AbfsBlobClient;
-import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
@@ -52,7 +49,6 @@ import org.opentest4j.TestAbortedException;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CHAR_HYPHEN;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
-import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLIENT_CORRELATIONID;
@@ -352,51 +348,5 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
       Assertions.assertThat(previousReqContext.split("_")).describedAs(
           "Only Retry Count should be present").hasSize(1);
     }
-  }
-
-  @Test
-  public void testFNSEndptConversionIndicator() throws Exception {
-    assumeHnsDisabled();
-    String scheme = "abfs";
-    String dfsDomain = "dfs.core.windows.net";
-    String accountNameNoDns = getAccountName().substring(0,
-        getAccountName().indexOf(DOT));
-
-    // Initialize filesystem with DFS endpoint
-    String dfsUri = String.format("%s://%s@%s.%s/", scheme, getFileSystemName(),
-        accountNameNoDns, dfsDomain);
-
-    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
-        new java.net.URI(dfsUri), getRawConfiguration());
-
-    // Filesystem initialization should have forced to use Blob instance for FNS-DFS
-    AbfsClient abfsClient = fs.getAbfsStore().getClient();
-    Assertions.assertThat(abfsClient)
-        .as("abfsClient should be instance of AbfsBlobClient")
-        .isInstanceOf(AbfsBlobClient.class);
-
-    TracingContext tracingContext
-        = getTracingContext(fs);
-    tracingContext.setFNSEndpointConverted();
-    AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
-    tracingContext.constructHeader(abfsHttpOperation, null,
-        EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
-    String endpointConversionIndicator = tracingContext.getHeader().split(COLON, SPLIT_NO_LIMIT)[15];
-    Assertions.assertThat(endpointConversionIndicator)
-        .describedAs("Endpoint conversion indicator should be present")
-        .isNotEmpty();
-  }
-
-  private static TracingContext getTracingContext(final AzureBlobFileSystem fs) {
-    final String fileSystemId = fs.getFileSystemId();
-    final String clientCorrelationId = fs.getClientCorrelationId();
-    final TracingHeaderFormat tracingHeaderFormat
-        = TracingHeaderFormat.ALL_ID_FORMAT;
-    return new TracingContext(clientCorrelationId,
-        fileSystemId, FSOperationType.TEST_OP, tracingHeaderFormat,
-        new TracingHeaderValidator(
-            fs.getAbfsStore().getAbfsConfiguration().getClientCorrelationId(),
-            fs.getFileSystemId(), FSOperationType.TEST_OP, false,
-            0));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,6 +37,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
+import org.apache.hadoop.fs.azurebfs.services.AbfsBlobClient;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
@@ -49,6 +52,7 @@ import org.opentest4j.TestAbortedException;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CHAR_HYPHEN;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLIENT_CORRELATIONID;
@@ -348,5 +352,51 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
       Assertions.assertThat(previousReqContext.split("_")).describedAs(
           "Only Retry Count should be present").hasSize(1);
     }
+  }
+
+  @Test
+  public void testFNSEndptConversionIndicator() throws Exception {
+    assumeHnsDisabled();
+    String scheme = "abfs";
+    String dfsDomain = "dfs.core.windows.net";
+    String accountNameNoDns = getAccountName().substring(0,
+        getAccountName().indexOf(DOT));
+
+    // Initialize filesystem with DFS endpoint
+    String dfsUri = String.format("%s://%s@%s.%s/", scheme, getFileSystemName(),
+        accountNameNoDns, dfsDomain);
+
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
+        new java.net.URI(dfsUri), getRawConfiguration());
+
+    // Filesystem initialization should have forced to use Blob instance for FNS-DFS
+    AbfsClient abfsClient = fs.getAbfsStore().getClient();
+    Assertions.assertThat(abfsClient)
+        .as("abfsClient should be instance of AbfsBlobClient")
+        .isInstanceOf(AbfsBlobClient.class);
+
+    TracingContext tracingContext
+        = getTracingContext(fs);
+    tracingContext.setFNSEndpointConverted();
+    AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
+    tracingContext.constructHeader(abfsHttpOperation, null,
+        EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
+    String endpointConversionIndicator = tracingContext.getHeader().split(COLON, SPLIT_NO_LIMIT)[9];
+    Assertions.assertThat(endpointConversionIndicator)
+        .describedAs("Endpoint conversion indicator should be present")
+        .isNotEmpty();
+  }
+
+  private static TracingContext getTracingContext(final AzureBlobFileSystem fs) {
+    final String fileSystemId = fs.getFileSystemId();
+    final String clientCorrelationId = fs.getClientCorrelationId();
+    final TracingHeaderFormat tracingHeaderFormat
+        = TracingHeaderFormat.ALL_ID_FORMAT;
+    return new TracingContext(clientCorrelationId,
+        fileSystemId, FSOperationType.TEST_OP, tracingHeaderFormat,
+        new TracingHeaderValidator(
+            fs.getAbfsStore().getAbfsConfiguration().getClientCorrelationId(),
+            fs.getFileSystemId(), FSOperationType.TEST_OP, false,
+            0));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -370,9 +370,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
   @Test
   // Test to verify the unique identifier in user agent string for FNS-Blob accounts
-  public void verifyUserAgentForFNSBlob() throws Exception {
+  public void verifyUserAgentForFNS() throws Exception {
     assumeHnsDisabled();
-    assumeBlobServiceType();
     final AzureBlobFileSystem fs = getFileSystem();
     final AbfsConfiguration configuration = fs.getAbfsStore()
         .getAbfsConfiguration();
@@ -384,24 +383,6 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
             "User-Agent string for FNS accounts on Blob endpoint should contain "
                 + FNS_BLOB_USER_AGENT_IDENTIFIER)
         .contains(FNS_BLOB_USER_AGENT_IDENTIFIER);
-  }
-
-  @Test
-  // Test to verify that the user agent string for non-FNS-Blob accounts
-  // does not contain the FNS identifier.
-  public void verifyUserAgentForDFS() throws Exception {
-    assumeDfsServiceType();
-    final AzureBlobFileSystem fs = getFileSystem();
-    final AbfsConfiguration configuration = fs.getAbfsStore()
-        .getAbfsConfiguration();
-
-    String userAgentStr = getUserAgentString(configuration, false);
-    verifyBasicInfo(userAgentStr);
-    Assertions.assertThat(userAgentStr)
-        .describedAs(
-            "User-Agent string for non-FNS-Blob accounts should not contain"
-                + FNS_BLOB_USER_AGENT_IDENTIFIER)
-        .doesNotContain(FNS_BLOB_USER_AGENT_IDENTIFIER);
   }
 
   public static AbfsClient createTestClientFromCurrentContext(

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -850,6 +850,33 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     fs.close();
   }
 
+  /**
+   * Test to verify that when initializing a filesystem with a DFS endpoint for a FNS account,
+   * we force to Blob endpoint internally.
+   *
+   * @throws Exception if the test fails
+   */
+  @Test
+  public void testFNSDfsUsesBlobInstance() throws Exception {
+    assumeHnsDisabled();
+    String scheme = "abfs";
+    String dfsDomain = "dfs.core.windows.net";
+    String blobDomain = "blob.core.windows.net";
+    String accountNameNoDns = getAccountName().substring(0,
+        getAccountName().indexOf(DOT));
+
+    // Initialize filesystem with DFS endpoint
+    String dfsUri = String.format("%s://%s@%s.%s/", scheme, getFileSystemName(),
+        accountNameNoDns, dfsDomain);
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
+        new java.net.URI(dfsUri), getRawConfiguration());
+
+    // Filesystem initialization should have forced to use Blob instance for FNS-DFS
+    URL blobClientUrl = fs.getAbfsStore().getClient().getBaseUrl();
+    Assertions.assertThat(blobClientUrl.toString())
+        .contains(blobDomain);
+  }
+
   @Test
   public void testIsNonEmptyDirectory() throws IOException {
     testIsNonEmptyDirectoryInternal(EMPTY_STRING, true, EMPTY_STRING,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -843,19 +843,25 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     String scheme = "abfs";
     String dfsDomain = "dfs.core.windows.net";
     String blobDomain = "blob.core.windows.net";
-    String accountNameNoDns = getAccountName().substring(0,
-        getAccountName().indexOf(DOT));
+    Configuration conf = new Configuration(getRawConfiguration());
+    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, true);
+
+    String dfsUri = String.format("%s://%s@%s.%s/",
+            scheme, getFileSystemName(),
+            getAccountName().substring(0, getAccountName().indexOf(DOT)),
+            dfsDomain);
 
     // Initialize filesystem with DFS endpoint
-    String dfsUri = String.format("%s://%s@%s.%s/", scheme, getFileSystemName(),
-        accountNameNoDns, dfsDomain);
     AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
-        new java.net.URI(dfsUri), getRawConfiguration());
+        new URI(dfsUri), conf);
 
     // Filesystem initialization should have forced to use Blob instance for FNS-DFS
-    URL blobClientUrl = fs.getAbfsStore().getClient().getBaseUrl();
-    Assertions.assertThat(blobClientUrl.toString())
-        .contains(blobDomain);
+    AbfsClient abfsClient = fs.getAbfsStore().getClient();
+    Assertions.assertThat(abfsClient)
+            .as("abfsClient should be instance of AbfsBlobClient")
+            .isInstanceOf(AbfsBlobClient.class);
+    Assertions.assertThat(abfsClient.getBaseUrl().toString())
+            .contains(blobDomain);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,6 +32,8 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationValueException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -54,6 +58,7 @@ import org.apache.hadoop.fs.azurebfs.contracts.services.AppendRequestParameters;
 import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.http.HttpResponse;
+import org.apache.hadoop.fs.store.DataBlocks;
 
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
@@ -592,5 +597,110 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
           .as("Expected addCheckSumHeaderForWrite() to be called exactly once")
           .isEqualTo(1);
     }
+  }
+
+  /**
+   * Tests the selection logic for the DFS-to-Blob fallback handler in AbfsOutputStream.
+   * Verifies:
+   *   For FNS, fallback succeeds regardless of ingress service type.
+   *   For HNS with BLOB ingress, fallback fails with InvalidConfigurationValueException.
+   *   For HNS with DFS ingress, fallback succeeds.
+   */
+  @Test
+  public void testDFSToBlobFallbackHandlerSelection() throws Exception {
+    // Common mocks
+    DataBlocks.BlockFactory blockFactory = Mockito.mock(DataBlocks.BlockFactory.class);
+    AzureBlockManager blockManager = Mockito.mock(AzureBlockManager.class);
+    AbfsClientHandler clientHandler = Mockito.mock(AbfsClientHandler.class);
+    AbfsClient client = Mockito.mock(AbfsClient.class);
+
+    Mockito.when(clientHandler.getClient(Mockito.any())).thenReturn(client);
+
+    Method createNewHandler =
+            AbfsOutputStream.class.getDeclaredMethod(
+                    "createNewHandler",
+                    AbfsServiceType.class,
+                    DataBlocks.BlockFactory.class,
+                    int.class,
+                    boolean.class,
+                    AzureBlockManager.class);
+    createNewHandler.setAccessible(true);
+
+    Field fallbackField =
+            AbfsOutputStream.class.getDeclaredField("isDFSToBlobFallbackEnabled");
+    fallbackField.setAccessible(true);
+
+    Field serviceTypeField =
+            AbfsOutputStream.class.getDeclaredField("serviceTypeAtInit");
+    serviceTypeField.setAccessible(true);
+
+    Field clientHandlerField =
+            AbfsOutputStream.class.getDeclaredField("clientHandler");
+    clientHandlerField.setAccessible(true);
+
+    // FNS case: fallback should succeed regardless of ingress service type
+    // Only setting isDFSToBlobFallbackEnabled config is enough
+    Mockito.when(client.getIsNamespaceEnabled()).thenReturn(false);
+
+    AbfsOutputStream fnsStream =
+            Mockito.mock(AbfsOutputStream.class, Mockito.CALLS_REAL_METHODS);
+
+    fallbackField.set(fnsStream, true);
+    clientHandlerField.set(fnsStream, clientHandler);
+
+    Object fnsHandler =
+            createNewHandler.invoke(
+                    fnsStream,
+                    AbfsServiceType.BLOB,
+                    blockFactory,
+                    1024,
+                    false,
+                    blockManager);
+
+    Assertions.assertThat(fnsHandler)
+            .as("FNS: fallback should succeed regardless of ingress service type")
+            .isInstanceOf(AzureDfsToBlobIngressFallbackHandler.class);
+
+    // HNS case: if ingress service type is BLOB, fallback should fail
+    Mockito.when(client.getIsNamespaceEnabled()).thenReturn(true);
+
+    AbfsOutputStream hnsBlobStream =
+            Mockito.mock(AbfsOutputStream.class, Mockito.CALLS_REAL_METHODS);
+
+    fallbackField.set(hnsBlobStream, true);
+    serviceTypeField.set(hnsBlobStream, AbfsServiceType.BLOB);
+    clientHandlerField.set(hnsBlobStream, clientHandler);
+
+    Assertions.assertThatThrownBy(() ->
+                    createNewHandler.invoke(
+                            hnsBlobStream,
+                            AbfsServiceType.BLOB,
+                            blockFactory,
+                            1024,
+                            false,
+                            blockManager))
+            .as("HNS with BLOB ingress should not allow fallback")
+            .hasCauseInstanceOf(InvalidConfigurationValueException.class);
+
+    // HNS case: if ingress service type is DFS, fallback should succeed
+    AbfsOutputStream hnsDfsStream =
+            Mockito.mock(AbfsOutputStream.class, Mockito.CALLS_REAL_METHODS);
+
+    fallbackField.set(hnsDfsStream, true);
+    serviceTypeField.set(hnsDfsStream, AbfsServiceType.DFS);
+    clientHandlerField.set(hnsDfsStream, clientHandler);
+
+    Object hnsHandler =
+            createNewHandler.invoke(
+                    hnsDfsStream,
+                    AbfsServiceType.DFS,
+                    blockFactory,
+                    1024,
+                    false,
+                    blockManager);
+
+    Assertions.assertThat(hnsHandler)
+            .as("HNS with DFS ingress should allow fallback")
+            .isInstanceOf(AzureDfsToBlobIngressFallbackHandler.class);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRenameRetryRecovery.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRenameRetryRecovery.java
@@ -450,60 +450,6 @@ public class TestAbfsRenameRetryRecovery extends AbstractAbfsIntegrationTest {
   }
 
   /**
-   * Test that rename recovery remains unsupported for
-   * FNS configurations.
-   */
-  @Test
-  public void testRenameRecoveryUnsupportedForFlatNamespace() throws Exception {
-    // In DFS endpoint, renamePath is O(1) API call and idempotency issue can happen.
-    // For blob endpoint, client orchestrates the rename operation.
-    assumeDfsServiceType();
-    assumeHnsDisabled();
-    AzureBlobFileSystem fs = getFileSystem();
-    AzureBlobFileSystemStore abfsStore = fs.getAbfsStore();
-    TracingContext testTracingContext = getTestTracingContext(fs, false);
-
-    AbfsClient mockClient = getMockAbfsClient();
-
-    String base = "/" + getMethodName();
-    String path1 = base + "/dummyFile1";
-    String path2 = base + "/dummyFile2";
-
-    touch(new Path(path1));
-
-    setAbfsClient(abfsStore, mockClient);
-
-    // checking correct count in AbfsCounters
-    AbfsCounters counter = mockClient.getAbfsCounters();
-    IOStatistics ioStats = counter.getIOStatistics();
-
-    Long connMadeBeforeRename = lookupCounterStatistic(ioStats, CONNECTIONS_MADE.getStatName());
-    Long renamePathAttemptsBeforeRename = lookupCounterStatistic(ioStats, RENAME_PATH_ATTEMPTS.getStatName());
-
-    expectErrorCode(SOURCE_PATH_NOT_FOUND, intercept(AbfsRestOperationException.class, () ->
-            mockClient.renamePath(path1, path2, null,
-                testTracingContext, null,
-                false)));
-
-    // validating stat counters after rename
-
-    // only 2 calls should have happened in total for rename
-    // 1 -> original rename rest call, 2 -> first retry,
-    // no getPathStatus calls
-    // last getPathStatus call should be skipped
-    assertThatStatisticCounter(ioStats,
-            CONNECTIONS_MADE.getStatName())
-            .isEqualTo(2 + connMadeBeforeRename);
-
-    // the RENAME_PATH_ATTEMPTS stat should be incremented by 1
-    // retries happen internally within AbfsRestOperation execute()
-    // the stat for RENAME_PATH_ATTEMPTS is updated only once before execute() is called
-    assertThatStatisticCounter(ioStats,
-            RENAME_PATH_ATTEMPTS.getStatName())
-            .isEqualTo(1 + renamePathAttemptsBeforeRename);
-  }
-
-  /**
    * Test the resilient commit code works through fault injection, including
    * reporting recovery.
    */

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -42,6 +42,7 @@ public class TracingHeaderValidator implements Listener {
 
   private static final String GUID_PATTERN = "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$";
   private String ingressHandler = null;
+  private boolean FNSEndpointConverted = false;
   private String position = String.valueOf(0);
   private ReadType readType = ReadType.UNKNOWN_READ;
 
@@ -61,6 +62,7 @@ public class TracingHeaderValidator implements Listener {
         retryNum, streamID);
     tracingHeaderValidator.primaryRequestId = primaryRequestId;
     tracingHeaderValidator.ingressHandler = ingressHandler;
+    tracingHeaderValidator.FNSEndpointConverted = FNSEndpointConverted;
     tracingHeaderValidator.position = position;
     tracingHeaderValidator.readType = readType;
     tracingHeaderValidator.operatedBlobCount = operatedBlobCount;
@@ -194,6 +196,11 @@ public class TracingHeaderValidator implements Listener {
   @Override
   public void updateIngressHandler(String ingressHandler) {
     this.ingressHandler = ingressHandler;
+  }
+
+  @Override
+  public void updateFNSEndpointConverted() {
+    this.FNSEndpointConverted = true;
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -42,7 +42,7 @@ public class TracingHeaderValidator implements Listener {
 
   private static final String GUID_PATTERN = "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$";
   private String ingressHandler = null;
-  private boolean FNSEndpointConverted = false;
+  private boolean fnsEndpointConverted = false;
   private String position = String.valueOf(0);
   private ReadType readType = ReadType.UNKNOWN_READ;
 
@@ -62,7 +62,7 @@ public class TracingHeaderValidator implements Listener {
         retryNum, streamID);
     tracingHeaderValidator.primaryRequestId = primaryRequestId;
     tracingHeaderValidator.ingressHandler = ingressHandler;
-    tracingHeaderValidator.FNSEndpointConverted = FNSEndpointConverted;
+    tracingHeaderValidator.fnsEndpointConverted = fnsEndpointConverted;
     tracingHeaderValidator.position = position;
     tracingHeaderValidator.readType = readType;
     tracingHeaderValidator.operatedBlobCount = operatedBlobCount;
@@ -200,7 +200,7 @@ public class TracingHeaderValidator implements Listener {
 
   @Override
   public void updateFNSEndpointConverted() {
-    this.FNSEndpointConverted = true;
+    this.fnsEndpointConverted = true;
   }
 
   @Override


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19766
We have observed cases of ABFS driver being initialised with DFS for FNS accounts which is not a recommended endpoint by the service.  
To prevent this, we’re normalizing endpoint to Blob for FNS accounts even if they were initialized with DFS endpoint. We also shall restrict usage of a separate ingress service type for FNS accounts.

### How was this patch tested?
Test suite was run. Results of which are added in the comments below

