### PR TITLE
YARN-11921. Replace unsupported org.xolstice.maven.plugins in hadoop-yarn-csi

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <grpc.version>1.69.0</grpc.version>
         <animal-sniffer.version>1.24</animal-sniffer.version>
+        <genrpc.version>1.53.0</genrpc.version>
+        <protoc.version>3.17.3</protoc.version>
     </properties>
 
     <dependencies>
@@ -194,19 +196,22 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
+                <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>${protobuf-maven-plugin.version}</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${hadoop.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <protocVersion>${protoc.version}</protocVersion>
+                    <binaryMavenPlugins>
+                        <binaryMavenPlugin>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>protoc-gen-grpc-java</artifactId>
+                            <version>${genrpc.version}</version>
+                        </binaryMavenPlugin>
+                    </binaryMavenPlugins>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>compile</goal>
-                            <goal>compile-custom</goal>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION

### Description of PR
xolstice plugin is unsupported thus causing you to pull old out of date binaries from maven. This replaces the plugin with a different one that is supported.

### How was this patch tested?

Completed the build even on alpine linux as well as locally on fedora 42.



