### PR TITLE
HADOOP-19764. Upgrade amazon-s3-encryption-client-java to 4.0.0+ due to Invisible Salamanders (CVE-2025-14763)

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -212,7 +212,7 @@
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.35.4</aws-java-sdk-v2.version>
-    <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
+    <amazon-s3-encryption-client-java.version>4.0.0</amazon-s3-encryption-client-java.version>
     <amazon-s3-analyticsaccelerator-s3.version>1.3.1</amazon-s3-analyticsaccelerator-s3.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/EncryptionS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/EncryptionS3ClientFactory.java
@@ -154,7 +154,7 @@ public class EncryptionS3ClientFactory extends DefaultS3ClientFactory {
         "S3ClientCreationParameters is not initialized");
 
     S3EncryptionClient.Builder s3EncryptionClientBuilder =
-        S3EncryptionClient.builder()
+        S3EncryptionClient.builderV4()
             .wrappedAsyncClient(s3AsyncClient)
             .wrappedClient(s3Client)
             // this is required for doing S3 ranged GET calls
@@ -239,7 +239,7 @@ public class EncryptionS3ClientFactory extends DefaultS3ClientFactory {
         "S3ClientCreationParameters is not initialized");
 
     S3AsyncEncryptionClient.Builder s3EncryptionAsyncClientBuilder =
-        S3AsyncEncryptionClient.builder()
+        S3AsyncEncryptionClient.builderV4()
             .wrappedClient(s3AsyncClient)
             // this is required for doing S3 ranged GET calls
             .enableLegacyUnauthenticatedModes(true)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

CVE-2025-14763

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

