### PR TITLE
HADOOP-19773. [JDK17] Use JDK17 as default in precommit Docker image.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get -q update \
     && apt-get -q update \
     && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal) \
     && apt-get clean \
-    && update-java-alternatives -s java-1.8.0-openjdk-amd64 \
+    && update-java-alternatives -s java-1.17.0-openjdk-amd64 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8
@@ -64,7 +64,7 @@ ENV PYTHONIOENCODING=utf-8
 ENV MAVEN_HOME=/opt/maven
 ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
 #######
 # Set env vars for SpotBugs 4.2.2

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -52,7 +52,7 @@ RUN apt-get -q update \
     && apt-get -q update \
     && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal::arch64) \
     && apt-get clean \
-    && update-java-alternatives -s java-1.8.0-openjdk-arm64 \
+    && update-java-alternatives -s java-1.17.0-openjdk-arm64 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8
@@ -65,7 +65,7 @@ ENV PYTHONIOENCODING=utf-8
 ENV MAVEN_HOME=/opt/maven
 ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-arm64
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-arm64
 
 #######
 # Set env vars for SpotBugs 4.2.2


### PR DESCRIPTION
### Description of PR
HADOOP-19773 [JDK17] Use JDK17 as default in precommit Docker image

The precommit Docker image currently defaults to Java 8, so CI logs for trunk PRs show JDK 8. For example, [PR-8151 ](https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-8151/1/artifact/out/console.txt)console output reports:
`Default Java | Red Hat, Inc.-1.8.0_472-b08 `
Update the Java configuration in the Dockerfile and switch the default Java version for the main precommit stage to JDK 17.

### For code changes:
No production code changes; CI/build environment only (Dockerfile/Jenkinsfile update).
