### PR TITLE
HADOOP-19776: trunk pre-commits for native code still try to use Java 8

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -84,17 +84,24 @@ pipeline {
         stage ('setup sources') {
             steps {
 
-                dir("${WORKSPACE}/rockylinux-8") {
+                dir("${WORKSPACE}/debian-12") {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/rockylinux-8
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-12
                     '''
                 }
 
-                dir("${WORKSPACE}/debian-11") {
+                dir("${WORKSPACE}/debian-13") {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-11
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-13
+                    '''
+                }
+
+                dir("${WORKSPACE}/ubuntu-24") {
+                    sh '''#!/usr/bin/env bash
+
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/ubuntu-24
                     '''
                 }
 
@@ -111,12 +118,12 @@ pipeline {
         // C++/C++ build/platform.
         // This stage serves as a means of cross platform validation, which is
         // really needed to ensure that any C++ related/platform change doesn't
-        // break the Hadoop build on Rocky Linux 8.
-        stage ('precommit-run Rocky Linux 8') {
+        // break the Hadoop build on Debian 12.
+        stage ('precommit-run Debian 12') {
             environment {
-                SOURCEDIR = "${WORKSPACE}/rockylinux-8/src"
-                PATCHDIR = "${WORKSPACE}/rockylinux-8/out"
-                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_rockylinux_8"
+                SOURCEDIR = "${WORKSPACE}/debian-12/src"
+                PATCHDIR = "${WORKSPACE}/debian-12/out"
+                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_12"
                 IS_OPTIONAL = 1
             }
 
@@ -136,7 +143,7 @@ pipeline {
                 failure {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp "${WORKSPACE}/rockylinux-8/out" "${WORKSPACE}"
+                    cp -Rp "${WORKSPACE}/debian-12/out" "${WORKSPACE}"
                     '''
                     archiveArtifacts "out/**"
                 }
@@ -157,12 +164,12 @@ pipeline {
         // C++/C++ build/platform.
         // This stage serves as a means of cross platform validation, which is
         // really needed to ensure that any C++ related/platform change doesn't
-        // break the Hadoop build on Debian 11.
-        stage ('precommit-run Debian 11') {
+        // break the Hadoop build on Debian 13.
+        stage ('precommit-run Debian 13') {
             environment {
-                SOURCEDIR = "${WORKSPACE}/debian-11/src"
-                PATCHDIR = "${WORKSPACE}/debian-11/out"
-                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_11"
+                SOURCEDIR = "${WORKSPACE}/debian-13/src"
+                PATCHDIR = "${WORKSPACE}/debian-13/out"
+                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_13"
                 IS_OPTIONAL = 1
             }
 
@@ -182,7 +189,54 @@ pipeline {
                 failure {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp "${WORKSPACE}/debian-11/out" "${WORKSPACE}"
+                    cp -Rp "${WORKSPACE}/debian-13/out" "${WORKSPACE}"
+                    '''
+                    archiveArtifacts "out/**"
+                }
+
+                cleanup() {
+                    script {
+                        sh '''#!/usr/bin/env bash
+
+                        chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
+                        "${SOURCEDIR}/dev-support/jenkins.sh" cleanup_ci_proc
+                        '''
+                    }
+                }
+            }
+        }
+
+
+        // This is an optional stage which runs only when there's a change in
+        // C++/C++ build/platform.
+        // This stage serves as a means of cross platform validation, which is
+        // really needed to ensure that any C++ related/platform change doesn't
+        // break the Hadoop build on Ubuntu 24.
+        stage ('precommit-run Ubuntu 24') {
+            environment {
+                SOURCEDIR = "${WORKSPACE}/ubuntu-24/src"
+                PATCHDIR = "${WORKSPACE}/ubuntu-24/out"
+                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_ubuntu_24"
+                IS_OPTIONAL = 1
+            }
+
+            steps {
+                withCredentials(getGithubCreds()) {
+                    sh '''#!/usr/bin/env bash
+
+                    chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
+                    "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
+                    '''
+                }
+            }
+
+            post {
+                // Since this is an optional platform, we want to copy the artifacts
+                // and archive it only if the build fails, to help with debugging.
+                failure {
+                    sh '''#!/usr/bin/env bash
+
+                    cp -Rp "${WORKSPACE}/ubuntu-24/out" "${WORKSPACE}"
                     '''
                     archiveArtifacts "out/**"
                 }

--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -84,24 +84,17 @@ pipeline {
         stage ('setup sources') {
             steps {
 
-                dir("${WORKSPACE}/debian-12") {
+                dir("${WORKSPACE}/rockylinux-8") {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-12
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/rockylinux-8
                     '''
                 }
 
-                dir("${WORKSPACE}/debian-13") {
+                dir("${WORKSPACE}/debian-11") {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-13
-                    '''
-                }
-
-                dir("${WORKSPACE}/ubuntu-24") {
-                    sh '''#!/usr/bin/env bash
-
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/ubuntu-24
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-11
                     '''
                 }
 
@@ -118,12 +111,12 @@ pipeline {
         // C++/C++ build/platform.
         // This stage serves as a means of cross platform validation, which is
         // really needed to ensure that any C++ related/platform change doesn't
-        // break the Hadoop build on Debian 12.
-        stage ('precommit-run Debian 12') {
+        // break the Hadoop build on Rocky Linux 8.
+        stage ('precommit-run Rocky Linux 8') {
             environment {
-                SOURCEDIR = "${WORKSPACE}/debian-12/src"
-                PATCHDIR = "${WORKSPACE}/debian-12/out"
-                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_12"
+                SOURCEDIR = "${WORKSPACE}/rockylinux-8/src"
+                PATCHDIR = "${WORKSPACE}/rockylinux-8/out"
+                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_rockylinux_8"
                 IS_OPTIONAL = 1
             }
 
@@ -143,7 +136,7 @@ pipeline {
                 failure {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp "${WORKSPACE}/debian-12/out" "${WORKSPACE}"
+                    cp -Rp "${WORKSPACE}/rockylinux-8/out" "${WORKSPACE}"
                     '''
                     archiveArtifacts "out/**"
                 }
@@ -164,12 +157,12 @@ pipeline {
         // C++/C++ build/platform.
         // This stage serves as a means of cross platform validation, which is
         // really needed to ensure that any C++ related/platform change doesn't
-        // break the Hadoop build on Debian 13.
-        stage ('precommit-run Debian 13') {
+        // break the Hadoop build on Debian 11.
+        stage ('precommit-run Debian 11') {
             environment {
-                SOURCEDIR = "${WORKSPACE}/debian-13/src"
-                PATCHDIR = "${WORKSPACE}/debian-13/out"
-                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_13"
+                SOURCEDIR = "${WORKSPACE}/debian-11/src"
+                PATCHDIR = "${WORKSPACE}/debian-11/out"
+                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_11"
                 IS_OPTIONAL = 1
             }
 
@@ -189,54 +182,7 @@ pipeline {
                 failure {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp "${WORKSPACE}/debian-13/out" "${WORKSPACE}"
-                    '''
-                    archiveArtifacts "out/**"
-                }
-
-                cleanup() {
-                    script {
-                        sh '''#!/usr/bin/env bash
-
-                        chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
-                        "${SOURCEDIR}/dev-support/jenkins.sh" cleanup_ci_proc
-                        '''
-                    }
-                }
-            }
-        }
-
-
-        // This is an optional stage which runs only when there's a change in
-        // C++/C++ build/platform.
-        // This stage serves as a means of cross platform validation, which is
-        // really needed to ensure that any C++ related/platform change doesn't
-        // break the Hadoop build on Ubuntu 24.
-        stage ('precommit-run Ubuntu 24') {
-            environment {
-                SOURCEDIR = "${WORKSPACE}/ubuntu-24/src"
-                PATCHDIR = "${WORKSPACE}/ubuntu-24/out"
-                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_ubuntu_24"
-                IS_OPTIONAL = 1
-            }
-
-            steps {
-                withCredentials(getGithubCreds()) {
-                    sh '''#!/usr/bin/env bash
-
-                    chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
-                    "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
-                    '''
-                }
-            }
-
-            post {
-                // Since this is an optional platform, we want to copy the artifacts
-                // and archive it only if the build fails, to help with debugging.
-                failure {
-                    sh '''#!/usr/bin/env bash
-
-                    cp -Rp "${WORKSPACE}/ubuntu-24/out" "${WORKSPACE}"
+                    cp -Rp "${WORKSPACE}/debian-11/out" "${WORKSPACE}"
                     '''
                     archiveArtifacts "out/**"
                 }

--- a/dev-support/docker/Dockerfile_rockylinux_8
+++ b/dev-support/docker/Dockerfile_rockylinux_8
@@ -87,6 +87,12 @@ ENV INFOPATH="${GCC_HOME}/root/usr/share/info"
 ######
 ENV MAVEN_HOME=/opt/maven
 ENV PATH="${PATH}:${MAVEN_HOME}/bin"
+
+# jenkins.sh sets --java-home to a path with an "-amd64" suffix, which doesn't
+# exist on Rocky. Fake it with symlinks.
+RUN ln -s /usr/lib/jvm/java-17-openjdk /usr/lib/jvm/java-17-openjdk-amd64
+RUN ln -s /usr/lib/jvm/java-21-openjdk /usr/lib/jvm/java-21-openjdk-amd64
+
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 

--- a/dev-support/docker/Dockerfile_rockylinux_8
+++ b/dev-support/docker/Dockerfile_rockylinux_8
@@ -43,6 +43,8 @@ RUN yum update -y \
     && yum install -y python3 \
     && yum install -y $(pkg-resolver/resolve.py rockylinux:8)
 
+RUN update-alternatives --set java java-17-openjdk.x86_64
+
 RUN dnf --enablerepo=powertools install -y \
     doxygen \
     snappy-devel \
@@ -86,7 +88,7 @@ ENV INFOPATH="${GCC_HOME}/root/usr/share/info"
 ENV MAVEN_HOME=/opt/maven
 ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
 #######
 # Set env vars for SpotBugs

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -361,7 +361,8 @@
       "openjdk-25-jdk"
     ],
     "rockylinux:8": [
-      "java-17-openjdk-devel"
+        "java-17-openjdk-devel",
+        "java-21-openjdk-devel"
     ],
     "ubuntu:focal": [
       "temurin-25-jdk",

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -360,6 +360,9 @@
       "temurin-17-jdk",
       "openjdk-25-jdk"
     ],
+    "rockylinux:8": [
+      "java-17-openjdk-devel"
+    ],
     "ubuntu:focal": [
       "temurin-25-jdk",
       "openjdk-8-jdk",

--- a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
@@ -110,14 +110,17 @@ jthrowable newIOException(JNIEnv* env, const char *fmt, ...)
 
 const char* terror(int errnum)
 {
-// MT-Safe under Solaris or glibc >= 2.32 not supporting sys_errlist/sys_nerr
-#if defined(__sun)
-  #define USE_STR_ERROR
-#elif defined(__GLIBC_PREREQ)
-  #if __GLIBC_PREREQ(2, 32)
-    #define USE_STR_ERROR
+/* STD_ERROR is the new standard. Alpine musc does not want to be 'detected' it want to be pure and modern. Thus we detect the old glib and handle. */  
+#ifdef __GLIBC__
+  #if defined(__GLIBC_PREREQ)
+    #if __GLIBC_PREREQ(2, 32)
+      #define USE_STR_ERROR
+    #endif
   #endif
+#else
+  #define USE_STR_ERROR
 #endif
+
 
 #if defined(USE_STR_ERROR)
   return strerror(errnum); 


### PR DESCRIPTION
### Description of PR

Pre-commits contain some steps specifically triggered for native code patches to check cross-platform compatibility. These are still trying to run with Java 8 targets. (Example: #8151 .) This patch introduces Java 17 and 21 in the Rocky 8 image.

### How was this patch tested?

Relying on pre-submit results. I'm temporarily including the native code change from #8151 to try to trigger it. I won't include that when I commit this.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

