### PR TITLE
HADOOP-19710. [ABFS] Read Buffer Manager V2 should not be allowed untill implemented

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -184,13 +184,11 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
      * If none of the V1 and V2 are enabled, then no read ahead will be done.
      */
     if (readAheadV2Enabled) {
-      ReadBufferManagerV2.setReadBufferManagerConfigs(
-          readAheadBlockSize, client.getAbfsConfiguration());
-      readBufferManager = ReadBufferManagerV2.getBufferManager();
-    } else {
-      ReadBufferManagerV1.setReadBufferManagerConfigs(readAheadBlockSize);
-      readBufferManager = ReadBufferManagerV1.getBufferManager();
+      LOG.debug("ReadBufferManagerV2 not yet implemented, defaulting to ReadBufferManagerV1");
     }
+    ReadBufferManagerV1.setReadBufferManagerConfigs(readAheadBlockSize);
+    readBufferManager = ReadBufferManagerV1.getBufferManager();
+
     if (streamStatistics != null) {
       ioStatistics = streamStatistics.getIOStatistics();
     }


### PR DESCRIPTION
Read Buffer Manager V2 is a Work in progress and not yet fully ready to be used.
This is to stop any user explicitly enabling the config to enable RBMV2.

JIRA: https://issues.apache.org/jira/browse/HADOOP-19710