### PR TITLE
HADOOP-19779: Use enforcer to fail fast if building with Java <17

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -160,17 +160,6 @@
     <grpc.version>1.10.0</grpc.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
 
-    <!-- define the Java language version used by the compiler -->
-    <javac.version>1.8</javac.version>
-
-    <!-- The java version enforced by the maven enforcer -->
-    <!-- more complex patterns can be used here, such as
-       [${javac.version})
-    for an open-ended enforcement
-    -->
-    <enforced.java.version>[${javac.version},)</enforced.java.version>
-    <enforced.maven.version>[3.3.0,)</enforced.maven.version>
-
     <!-- keep this list sync with
          hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh#hadoop_finalize_jpms_opts
     -->

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
      running all unit tests before the it.test option is picked up.
     -->
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+
+    <!-- define the Java language version used by the compiler -->
+    <javac.version>17</javac.version>
+
+    <!-- The java version enforced by the maven enforcer -->
+    <!-- more complex patterns can be used here, such as
+       [${javac.version})
+    for an open-ended enforcement
+    -->
+    <enforced.java.version>[${javac.version},)</enforced.java.version>
+    <enforced.maven.version>[3.3.0,)</enforced.maven.version>
   </properties>
 
   <modules>
@@ -176,10 +187,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <configuration>
             <rules>
               <requireMavenVersion>
-                <version>[3.0.2,)</version>
+                <version>${enforced.maven.version}</version>
               </requireMavenVersion>
               <requireJavaVersion>
-                <version>[1.8,)</version>
+                <version>${enforced.java.version}</version>
               </requireJavaVersion>
             </rules>
           </configuration>


### PR DESCRIPTION
### Description of PR

1. Pull up the properties controlling Java version from hadoop-project/pom.xml to the root pom.xml. This is so that the same properties for Java version can be controlled across the whole project, even at points where we aren't getting inheritance from hadoop-project/pom.xml.
1. Update the Java compiler target version and enforced range to be 17+.

### How was this patch tested?

```
mvn clean package -DskipTests -DskipShade
```

On Java 17, it succeeds. On Java 8, it fails fast with this error message:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (clean) on project hadoop-main: 
[ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK version 1.8.0-472 (JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.472.b08-1.el8.x86_64/jre) is not in the allowed range [17,).
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html