### PR TITLE
HADOOP-19780. Fix website build in GitHub workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: apache/hadoop
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v3


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Use JDK17 to fix website build.

HADOOP-19780

### How was this patch tested?

Not tested. It will be verified by precommit job.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

AI tools is not used