### PR TITLE
HDFS-17871: Improve performance of findDeepest in RBF

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -633,6 +633,9 @@ public class MountTableResolver
       if (floorEntry != null && isParentEntry(path, floorEntry.getKey())) {
         return floorEntry.getValue();
       }
+      if ("".equals(path)) {
+        return null;
+      }
       MountTable mountTable;
       Path currentPath = new Path(path);
       while (true) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -629,14 +629,24 @@ public class MountTableResolver
   private MountTable findDeepest(final String path) {
     readLock.lock();
     try {
-      Entry<String, MountTable> entry = this.tree.floorEntry(path);
-      while (entry != null && !isParentEntry(path, entry.getKey())) {
-        entry = this.tree.lowerEntry(entry.getKey());
+      Entry<String, MountTable> floorEntry = this.tree.floorEntry(path);
+      if (floorEntry != null && isParentEntry(path, floorEntry.getKey())) {
+        return floorEntry.getValue();
       }
-      if (entry == null) {
-        return null;
+      MountTable mountTable;
+      Path currentPath = new Path(path);
+      while (true) {
+        mountTable = tree.getOrDefault(currentPath.toUri().getPath(), null);
+        if (mountTable != null) {
+          break;
+        }
+        if (currentPath.isRoot()) {
+          break;
+        } else {
+          currentPath = currentPath.getParent();
+        }
       }
-      return entry.getValue();
+      return mountTable;
     } finally {
       readLock.unlock();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
@@ -265,6 +265,9 @@ public class TestMountTableResolver {
 
     mtEntry = mountTable.getMountPoint("/user/a1");
     assertEquals("/user", mtEntry.getSourcePath());
+
+    mtEntry = mountTable.getMountPoint("");
+    assertNull(mtEntry);
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

https://issues.apache.org/jira/projects/HDFS/issues/HDFS-17871

The current implementation of `org.apache.hadoop.hdfs.server.federation.resolver.MountTableResolver#findDeepest` method in RBF has a performance issue: when the tree doesn't contain a parent path for the queried path, the `while` loop iterates through **all entries** in the TreeMap, resulting in `O(n)` time complexity instead of the expected `O(log n)`.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html