### PR TITLE
HADOOP-19784- ABFS: Update Unit Test for Client Header Changes

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -178,7 +178,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
               EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
 
       // The tracing context being used FS Initialization should have the endpoint conversion indicator set to 'T'
-      final int endpointConversionIndicatorIndex  = 15;
+      final int endpointConversionIndicatorIndex  = 14;
       String endpointConversionIndicator = captured.getHeader().split(COLON, SPLIT_NO_LIMIT)[endpointConversionIndicatorIndex ];
       Assertions.assertFalse(endpointConversionIndicator.isEmpty(), "Endpoint conversion indicator should be present");
       Assertions.assertEquals(endptConversionIndicatorInTc, endpointConversionIndicator, "Endpoint conversion indicator should be 'T'");


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19784
We have a unit test (testFNSEndptConvertedIndicatorInHeader) that validates the presence of a specific indicator within a field in the client request header. Recent changes to the client header structure have altered the expected index/position of this indicator, causing the test to fail.
This change updates the test to reflect the revised header format and corrects the assertion accordingly.

### How was this patch tested?
Test suite result added in comment below