### PR TITLE
YARN-11920 flexible directory permissions

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
@@ -80,6 +80,7 @@
 #endif
 
 static const int DEFAULT_MIN_USERID = 1000;
+static const char* DEFAULT_CONTAINER_GROUP_MODE = "0770";
 
 static const char* DEFAULT_BANNED_USERS[] = {"yarn", "mapred", "hdfs", "bin", 0};
 
@@ -820,8 +821,7 @@ static int create_container_directories(const char* user, const char *app_id,
   } else {
     sprintf(combined_name, "%s/%s", app_id, container_id);
     char* const* log_dir_ptr;
-    // Log dirs need 750 access
-    const mode_t logdir_perms = S_IRWXU | S_IRGRP | S_IXGRP;
+    const mode_t logdir_perms = get_container_group_mode();
 
     for(log_dir_ptr = log_dir; *log_dir_ptr != NULL; ++log_dir_ptr) {
       char *container_log_dir = get_app_log_directory(*log_dir_ptr, combined_name);
@@ -1073,16 +1073,35 @@ static int change_owner(const char* path, uid_t user, gid_t group) {
   }
 }
 
+mode_t get_container_group_mode(){
+  char *permission_string = get_section_value(CONTAINER_GROUP_MODE_KEY, &executor_cfg);
+  char *default_mode = DEFAULT_CONTAINER_GROUP_MODE;
+  char *endptr;
+  mode_t mode_val;
+  if (permission_string != NULL){
+    mode_val = (mode_t) strtol(permission_string, &endptr, 8);
+    if (*endptr != '\0'){
+      fprintf(LOGFILE, "Illegal value of %s for %s in configuration\n",
+        permission_string, CONTAINER_GROUP_MODE_KEY);
+      exit(1);
+    }
+    free(permission_string);
+  } else {
+    mode_val = (mode_t) strtol(default_mode, &endptr, 8);
+  }
+  return mode_val;
+}
+
+
 /**
  * Create a top level directory for the user.
  * It assumes that the parent directory is *not* writable by the user.
- * It creates directories with 02750 permissions owned by the user
+ * It creates directories with get_container_group_mode() permissions owned by the user
  * and with the group set to the node manager group.
  * return non-0 on failure
  */
 int create_directory_for_user(const char* path) {
-  // set 750 permissions and setgid bit
-  mode_t permissions = S_IRWXU | S_IRGRP | S_IXGRP | S_ISGID;
+  mode_t permissions = get_container_group_mode() | S_ISGID;
   uid_t user = geteuid();
   gid_t group = getegid();
   uid_t root = 0;
@@ -1370,34 +1389,74 @@ int create_container_log_dirs(const char *container_id, const char *app_id,
   return 0;
 }
 
-/**
- * Function to create the application directories.
- * Returns pointer to primary_app_dir or NULL if it fails.
- */
-static char *create_app_dirs(const char *user,
+char* concat(const char *s1, const char *s2) {
+    size_t len1 = strlen(s1);
+    size_t len2 = strlen(s2);
+    char *result = malloc(len1 + len2 + 1);
+    if (result == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    memcpy(result, s1, len1);
+    memcpy(result + len1, s2, len2 + 1);
+    return result;
+}
+
+void maybe_create_appcache(const char *appcache, mode_t permissions){
+  //fprintf(LOGFILE, "Going to create %s\n", appcache);
+  struct stat exists;
+  int stat_res = stat(appcache, &exists);
+  if (stat_res == -1){
+    int mk_res = mkdir(appcache, permissions);
+    fprintf(LOGFILE, "Creating appcache %s result %d\n", appcache, mk_res);
+  }
+}
+
+char *create_app_dirs(const char *user,
                              const char *app_id,
-                             char* const* local_dirs)
-{
+                             char* const* local_dirs) {
   // 750
   mode_t permissions = S_IRWXU | S_IRGRP | S_IXGRP;
   char* const* nm_root;
   char *primary_app_dir = NULL;
-  for(nm_root=local_dirs; *nm_root != NULL; ++nm_root) {
+  for(nm_root = local_dirs; *nm_root != NULL; ++nm_root) {
     char *app_dir = get_app_directory(*nm_root, user, app_id);
-    if (app_dir == NULL) {
-      // try the next one
-    } else if (strstr(app_dir, "..") != 0) {
+    fprintf(LOGFILE, "Appdir %s\n", app_dir);
+    if (app_dir == NULL){
+      free(app_dir);
+      continue;
+    }
+    //implementation node: Could be more thought put in do this detection
+    if (strstr(app_dir, "..") != 0) {
       fprintf(LOGFILE, "Unsupported app directory path detected.\n");
       free(app_dir);
-    } else if (mkdirs(app_dir, permissions) != 0) {
-      free(app_dir);
-    } else if (primary_app_dir == NULL) {
-      primary_app_dir = app_dir;
-    } else {
-      free(app_dir);
+      continue;
     }
-  }
+    char *user_root = get_user_directory(*nm_root, user);
+    char *appcache = concat(user_root, "/appcache");
+    maybe_create_appcache(appcache, permissions);
+    free(user_root);
+    free(appcache);
 
+    struct stat exists;
+    int stat_res = stat(app_dir, &exists);
+    if (stat_res == 0){
+      if (primary_app_dir == NULL) {
+        primary_app_dir = strdup(app_dir);
+      }
+    } else if (stat_res == -1){
+      int mk_res = mkdir(app_dir, permissions);
+      if (mk_res == 0){
+        if (primary_app_dir == NULL) {
+          primary_app_dir = strdup(app_dir);
+        }
+      } else {
+        fprintf(LOGFILE, "Attempted to create appdir %s but failed with %d\n", app_dir, mk_res);
+      }
+    } else {
+      fprintf(LOGFILE, "Unable to stat %s \n", app_dir);
+    }
+    free(app_dir);
+  }
   if (primary_app_dir == NULL) {
     fprintf(LOGFILE, "Did not create any app directories\n");
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
@@ -79,9 +79,13 @@ enum operations {
 #define ROOT_TMP_DIR "private_slash_tmp"
 #define ROOT_VAR_TMP_DIR "private_var_slash_tmp"
 #define COMMAND_FILE_SECTION "command-execution"
+#define CONTAINER_GROUP_MODE_KEY "container.group.mode"
 
 extern struct passwd *user_detail;
 extern struct section executor_cfg;
+
+// a group mode that dictates how some folders will be created
+mode_t get_container_group_mode();
 
 //function used to load the configurations present in the secure config
 void read_executor_config(const char* file_name);
@@ -241,6 +245,23 @@ int mkdirs(const char* path, mode_t perm);
  * Function to initialize the user directories of a user.
  */
 int initialize_user(const char *user, char* const* local_dirs);
+
+/**
+ * This function creates app directories. For each node
+ * manager local director (local_dir) it attempts to create an .
+ * the method will succeed if it successful in creating at
+ * lest one.
+ * Implementation note: It returns the first success
+ * as the primary. It would be better if we randomized the
+ * list to more evenly distribute the directories.
+ * It would also be better if we returned all the directories
+ * created instead of only the first, as application has
+ * no way of knowing the state of all the directories.
+ * Returns pointer to primary_app_dir or NULL on failure.
+ */
+char *create_app_dirs(const char *user,
+                             const char *app_id,
+                             char* const* local_dirs);
 
 /**
  * Create a top level directory for the user.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/test/test-container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/test/test-container-executor.c
@@ -200,6 +200,34 @@ void test_get_app_directory() {
   free(app_dir);
 }
 
+/*
+In the directory structure:
+  /yarn-root/nm-local-dir/usercache/auser/appcache
+Where nodemanager is running:
+ user: yarn group: hadoop
+We require group +w permission as "auser" is owned auser.
+Otherwise nodemanager will not be able to create appcache
++*/
+void test_create_app_dirs(){
+  //precondition the user directory has been created
+  char * us = "bob";
+  char *user_dir = TEST_ROOT "/local-9/usercache/bob";
+  mkdirs(user_dir, 0770);
+  char* str_list[] = { TEST_ROOT "/local-9", NULL };
+  char* const* dirs_ptr = str_list;
+  char *app_dir = (char *) get_app_directory(TEST_ROOT "/local-9", us, "app_200906101234_0002");
+  char *created = create_app_dirs(us, "app_200906101234_0002", dirs_ptr);
+  ///tmp/test-container-executor/local-9/usercache/bob/appcache/app_200906101234_0002
+  printf("created %s", created);
+  struct stat exists;
+  int stat_res = stat(created, &exists);
+  if (stat_res !=0){
+    printf("Fail test_create_app_dir expected %s to exist but code: %d\n",
+               created, stat_res);
+  }
+}
+
+
 void test_get_container_work_directory() {
   char *expected_file = TEST_ROOT "/usercache/user/appcache/app_1/container_1";
   char *work_dir = get_container_work_directory(TEST_ROOT, "user", "app_1",
@@ -545,7 +573,7 @@ void test_yarn_sysfs() {
   char* const* local_dir_ptr;
   for (local_dir_ptr = local_dirs; *local_dir_ptr != 0; ++local_dir_ptr) {
     char *user_dir = make_string("%s/usercache/%s", *local_dir_ptr, username);
-    if (mkdirs(user_dir, 0750) != 0) {
+    if (mkdirs(user_dir, 0770) != 0) {
       printf("Can not make user directories: %s\n", user_dir);
       exit(1);
     }
@@ -1662,7 +1690,7 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
-  printf("\nOur executable is %s\n",get_executable(argv[0]));
+  printf("\nOur executable is %s\n", get_executable(argv[0]));
 
   local_dirs = split(strdup(NM_LOCAL_DIRS));
   log_dirs = split(strdup(NM_LOG_DIRS));
@@ -1726,6 +1754,9 @@ int main(int argc, char **argv) {
 
   printf("\nTesting exec_container()\n");
   test_exec_container();
+
+  printf("\nTest test_create_app_dirs()\n");
+  test_create_app_dirs();
 
   test_check_user(0);
 


### PR DESCRIPTION
### Description of PR

1. Container executor creates directories incorrectly. yarn is unable to create appdir
2. code is incorrectly freeing memory in method create_app_dirs a pointer to app_dir is created, then a primary_app_dir is set to app_dir, then appdir is free()ed. This results in undefined behavior.
3. No unit test was calling create_app_dirs (one was added)  
4. better comments were added explaing the different partial failures possible in the function

### How was this patch tested?
Unit tests pass. Unit tests were added. Docker build running end to end scenario (running wordcount) fully works.

### For code changes:

- [ Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

This PR was made by hand the 'old school way'
If an AI tool was used:

- [ NA ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ NA ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html