### PR TITLE
HADOOP-19786. Bump org.owasp:dependency-check-maven plugin to 12.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <checkstyle.version>11.1.0</checkstyle.version>
-    <dependency-check-maven.version>12.2.0</dependency-check-maven.version>
+    <dependency-check-maven.version>12.2.2</dependency-check-maven.version>
     <spotbugs.version>4.9.7</spotbugs.version>
     <spotbugs-maven-plugin.version>4.9.7.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <checkstyle.version>11.1.0</checkstyle.version>
-    <dependency-check-maven.version>7.1.1</dependency-check-maven.version>
+    <dependency-check-maven.version>12.2.0</dependency-check-maven.version>
     <spotbugs.version>4.9.7</spotbugs.version>
     <spotbugs-maven-plugin.version>4.9.7.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>
@@ -526,6 +526,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>${dependency-check-maven.version}</version>
+          <configuration>
+            <!-- often misidentied native binaries as .net native binaries then looks for .Net tooling to scan them -->
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+            <!-- requires separate sonatype account and sometimes fails if not present -->
+            <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
### Description of PR
Owasp plugin doesn't work

### How was this patch tested?

:~/hadoop$ mvn  org.owasp:dependency-check-maven:check 
### For code changes:

- [ Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling
No ai was used

- [NA ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ NA] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html