### PR TITLE
HADOOP-19787. Remove unneeded deps from Hadoop-NFS

### DIFF
--- a/hadoop-common-project/hadoop-nfs/pom.xml
+++ b/hadoop-common-project/hadoop-nfs/pom.xml
@@ -79,18 +79,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsTime.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsTime.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.nfs;
 
 import org.junit.jupiter.api.Assertions;
 
-import org.apache.hadoop.nfs.NfsTime;
 import org.apache.hadoop.oncrpc.XDR;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
### Description of PR
dependency scan had issues with netty-memcache. pom mentions netty-all in compile scope, but it is not needed here.

### How was this patch tested?

mvn test
### For code changes:

- [ Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling
No ai was used
- [NA ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [NA ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html