### PR TITLE
YARN-11921. [Addendum] Use consistent hadoop.protobuf.version for protoc

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -29,7 +29,6 @@
         <grpc.version>1.69.0</grpc.version>
         <animal-sniffer.version>1.24</animal-sniffer.version>
         <genrpc.version>1.53.0</genrpc.version>
-        <protoc.version>3.17.3</protoc.version>
     </properties>
 
     <dependencies>
@@ -199,7 +198,7 @@
                 <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocVersion>${protoc.version}</protocVersion>
+                    <protocVersion>${hadoop.protobuf.version}</protocVersion>
                     <binaryMavenPlugins>
                         <binaryMavenPlugin>
                             <groupId>io.grpc</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11921. [Addendum] Use consistent hadoop.protobuf.version for protoc

In PR #8156 (YARN-11921), the hadoop-yarn-csi/pom.xml defines `protoc.version=3.17.3` explicitly for the protobuf-maven-plugin.

However, the Hadoop trunk project has upgraded to `hadoop.protobuf.version=3.25.5` globally (via HADOOP-19605 and related changes), which is the current recommended protobuf version for better security (fixes CVE-2024-7254 etc.) and compatibility.

This follow-up PR removes the hardcoded `protoc.version=3.17.3` and switches to `${hadoop.protobuf.version}` to:
- Ensure version consistency across the project
- Avoid potential mismatches in generated code or runtime behavior
- Align with the latest protobuf upgrades


### How was this patch tested?

Verified locally: build succeeds with protobuf sources generated correctly using 3.25.5.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html