### PR TITLE
YARN-11922. ResourceManager not update SecretManager keysize immediately if recovery is on

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
@@ -184,9 +184,9 @@ public abstract class SecretManager<T extends TokenIdentifier> {
   }
 
   /**
-   * Validate the secretKey length is equal to the selected config
+   * Validate the secretKey length is equal to the selected config.
    * @param secretKey secretKey
-   * @return true if the length is equal
+   * @return true if the secretKey length is equal to the currently configured length
    */
   protected boolean validateSecretKeyLength(byte[] secretKey) {
     return secretKey.length * 8 == selectedLength;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
@@ -184,6 +184,15 @@ public abstract class SecretManager<T extends TokenIdentifier> {
   }
 
   /**
+   * Validate the secretKey length is equal to the selected config
+   * @param secretKey secretKey
+   * @return true if the length is equal
+   */
+  protected boolean validateSecretKeyLength(byte[] secretKey) {
+    return secretKey.length * 8 == selectedLength;
+  }
+
+  /**
    * Compute HMAC of the identifier using the secret key and return the 
    * output as password
    * @param identifier the bytes of the identifier

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/AMRMTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/AMRMTokenSecretManager.java
@@ -324,17 +324,16 @@ public class AMRMTokenSecretManager extends
   }
 
   public void recover(RMState state) {
-    if (state.getAMRMTokenSecretManagerState() != null) {
+    AMRMTokenSecretManagerState tokenState = getTokenState(state);
+    if (tokenState != null) {
       // recover the current master key
-      MasterKey currentKey =
-          state.getAMRMTokenSecretManagerState().getCurrentMasterKey();
+      MasterKey currentKey = tokenState.getCurrentMasterKey();
       this.currentMasterKey =
           new MasterKeyData(currentKey, createSecretKey(currentKey.getBytes()
             .array()));
 
       // recover the next master key if not null
-      MasterKey nextKey =
-          state.getAMRMTokenSecretManagerState().getNextMasterKey();
+      MasterKey nextKey = tokenState.getNextMasterKey();
       if (nextKey != null) {
         this.nextMasterKey =
             new MasterKeyData(nextKey, createSecretKey(nextKey.getBytes()
@@ -342,5 +341,35 @@ public class AMRMTokenSecretManager extends
         this.timer.schedule(new NextKeyActivator(), this.activationDelay);
       }
     }
+  }
+
+  private AMRMTokenSecretManagerState getTokenState(RMState state) {
+    AMRMTokenSecretManagerState result = state.getAMRMTokenSecretManagerState();
+    if (result != null) {
+      result = validateAndUpdateState(result);
+    }
+    return result;
+  }
+
+  private AMRMTokenSecretManagerState validateAndUpdateState(AMRMTokenSecretManagerState state) {
+    MasterKey currentKey = state.getCurrentMasterKey();
+    MasterKey nextKey = state.getNextMasterKey();
+    boolean updateRequired = false;
+    if (!validateMasterKey(currentKey)) {
+      state.setCurrentMasterKey(createNewMasterKey().getMasterKey());
+      updateRequired = true;
+    }
+    if (!validateMasterKey(nextKey)) {
+      state.setNextMasterKey(createNewMasterKey().getMasterKey());
+      updateRequired = true;
+    }
+    if (updateRequired) {
+      rmContext.getStateStore().storeOrUpdateAMRMTokenSecretManager(state, true);
+    }
+    return state;
+  }
+
+  private boolean validateMasterKey(MasterKey masterKey) {
+    return masterKey == null || validateSecretKeyLength(masterKey.getBytes().array());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/AMRMTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/AMRMTokenSecretManager.java
@@ -345,10 +345,7 @@ public class AMRMTokenSecretManager extends
 
   private AMRMTokenSecretManagerState getTokenState(RMState state) {
     AMRMTokenSecretManagerState result = state.getAMRMTokenSecretManagerState();
-    if (result != null) {
-      result = validateAndUpdateState(result);
-    }
-    return result;
+    return result == null ? null : validateAndUpdateState(result);
   }
 
   private AMRMTokenSecretManagerState validateAndUpdateState(AMRMTokenSecretManagerState state) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStoreTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStoreTestBase.java
@@ -41,8 +41,10 @@ import javax.crypto.SecretKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.CallerContext;
+import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -778,6 +780,27 @@ public class RMStateStoreTestBase {
       secondMasterKeyData.getSecretKey());
 
     store.close();
+  }
+
+  public void testAMRMTokenSecretManagerStateStoreKeyLengthChange(
+      RMStateStoreHelper stateStoreHelper) throws Exception {
+    RMState rmState = stateStoreHelper.getRMStateStore().loadState();
+    AMRMTokenSecretManagerState state = rmState.getAMRMTokenSecretManagerState();
+    assertEquals(
+        CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_DEFAULT,
+        state.getCurrentMasterKey().getBytes().array().length * 8
+    );
+    Configuration configuration = new Configuration();
+    configuration.setInt(
+        CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_KEY, 256);
+    SecretManager.update(configuration);
+    RMContext rmContext = mock(RMContext.class);
+    when(rmContext.getStateStore()).thenReturn(stateStoreHelper.getRMStateStore());
+    Configuration conf = new YarnConfiguration();
+    AMRMTokenSecretManager appTokenMgr = new AMRMTokenSecretManager(conf, rmContext);
+    appTokenMgr.recover(rmState);
+    assertEquals(256,  rmState.getAMRMTokenSecretManagerState()
+        .getCurrentMasterKey().getBytes().array().length * 8);
   }
 
   public void testReservationStateStore(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestFSRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestFSRMStateStore.java
@@ -215,6 +215,7 @@ public class TestFSRMStateStore extends RMStateStoreTestBase {
       testAMRMTokenSecretManagerStateStore(fsTester);
       testReservationStateStore(fsTester);
       testProxyCA(fsTester);
+      testAMRMTokenSecretManagerStateStoreKeyLengthChange(fsTester);
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestZKRMStateStore.java
@@ -298,6 +298,7 @@ public class TestZKRMStateStore extends RMStateStoreTestBase {
     ((TestZKRMStateStoreTester.TestZKRMStateStoreInternal)
         zkTester.getRMStateStore()).testRetryingCreateRootDir();
     testProxyCA(zkTester);
+    testAMRMTokenSecretManagerStateStoreKeyLengthChange(zkTester);
   }
 
   @Test


### PR DESCRIPTION
### Description of PR

Problem Statement:
I have a scenario where I need to migrate a YARN cluster to a FIPS 140-3–compatible environment. For this, the AMRMTokenSecretManager must use secrets that are at least 112 bits long. By default, the secret length is 64 bits. When I modify the key size and restart the cluster with recovery enabled, the state store reloads the old secret, which has a default lifetime of 24 hours. As a result, even though the cluster is configured to operate in FIPS 140-3–compatible mode, it continues to use a non-compliant secret.

Solution:
When the ResourceManager recovers, it should validate the secret size stored in the state store. If the stored secret size differs from the configured value, the secret should be forcibly regenerated and updated.

### How was this patch tested?

- Through manual testing, I verified that HIVE applications can run successfully both before and after the configuration change.
- UT was created.

### AI Tooling

ChatGPT to check grammar in the commit message