### PR TITLE
HDFS-17875. AtomicFileOutputStream should override FilterOutputStream batch write API

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/AtomicFileOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/AtomicFileOutputStream.java
@@ -62,6 +62,11 @@ public class AtomicFileOutputStream extends FilterOutputStream {
   }
 
   @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    out.write(b, off, len);
+  }
+
+  @Override
   public void close() throws IOException {
     boolean triedToClose = false, success = false;
     try {


### PR DESCRIPTION
### Description of PR

We found that AtomicFileOutputStream write is slow because the `write(byte b[], int off, int len)` uses FilterOutputStream implementation which calls write(byte b) for each byte. 
 
We should override this API and forward it to the underlying OutputStream instead.

### How was this patch tested?

Existing CI

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html