### PR TITLE
HDFS-17876: NameNode.stop() missing null check for tracer.close() can cause NPE during shutdown

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1257,7 +1257,9 @@ public class NameNode extends ReconfigurableBase implements
       }
     }
     started.set(false);
-    tracer.close();
+    if (tracer != null) {
+      tracer.close();
+    }
   }
 
   synchronized boolean isStopRequested() {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR fix [HDFS-17876](https://issues.apache.org/jira/browse/HDFS-17876)

### Summary of the change:

  - File: hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java:1260
  - Issue: tracer.close() was called without a null check, inconsistent with all other resources in the stop() method
  - Fix: Added a defensive null check: if (tracer != null) { tracer.close(); }

  This prevents a NullPointerException during shutdown if:
  1. An exception occurs in the parent constructor before tracer is initialized
  2. The stopAtException() method calls stop() early during initialization failures
  3. Any future refactoring introduces paths where tracer isn't set before stop() is called


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html