### PR TITLE
HDFS-17870: ArrayIndexOutOfBoundsException when DataNode was restarted without storageCapacities

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -1877,7 +1877,11 @@ public class MiniDFSCluster implements AutoCloseable {
       final DataNode curDn,
       long[][] storageCapacities) throws IOException {
 
-    if (storageCapacities == null || storageCapacities.length == 0) {
+    // Check for null/empty array AND ensure index is within bounds.
+    // DataNodes added without explicit storageCapacities won't have
+    // an entry in the storageCap list.
+    if (storageCapacities == null || storageCapacities.length == 0
+        || curDnIdx >= storageCapacities.length) {
       return;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMiniDFSCluster.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdfs;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
@@ -414,6 +415,42 @@ public class TestMiniDFSCluster {
           miniDfsCluster.getDataNode(ipcPorts[1]).getIpcPort());
       assertEquals(ipcPorts[2],
           miniDfsCluster.getDataNode(ipcPorts[2]).getIpcPort());
+    }
+  }
+
+  /**
+   * Test that restarting a DataNode that was added without explicit
+   * storage capacities does not throw ArrayIndexOutOfBoundsException.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/HDFS-17870">HDFS-17870</a>
+   */
+  @Test
+  @Timeout(value = 100)
+  public void testRestartDataNodeWithoutStorageCapacities() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    final long[] capacities = new long[] {1024 * 1024 * 100, 1024 * 1024 * 100};
+
+    // Create cluster with 1 DataNode and explicit storage capacities
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storageCapacities(capacities)
+        .storageTypes(new StorageType[]{StorageType.DISK, StorageType.DISK})
+        .storagesPerDatanode(2)
+        .build()) {
+      cluster.waitActive();
+
+      // Add another DataNode without specifying storage capacities
+      cluster.startDataNodes(conf, 1, true, null, null);
+      cluster.waitActive();
+
+      assertEquals(2, cluster.getDataNodes().size());
+
+      // Restart the second DataNode - this should not throw
+      // ArrayIndexOutOfBoundsException
+      assertTrue(cluster.restartDataNode(1));
+      cluster.waitActive();
+
+      assertEquals(2, cluster.getDataNodes().size());
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fix for [HDFS-17870](https://issues.apache.org/jira/browse/HDFS-17870)
 
MiniDFSCluster.restartDataNode() throws ArrayIndexOutOfBoundsException when attempting to restart a DataNode that was added to the cluster without specifying storage capacities.
This bug is because MiniDFSCluster.setDataNodeStorageCapacities() did not validate that the DataNode index is within the bounds of the storageCapacities array before accessing it.

### How was this patch tested?
In hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMiniDFSCluster.java add a new test method testRestartDataNodeWithoutStorageCapacities().
This test method will throw ArrayIndexOutOfBoundsException without the fix and pass with the fix.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html