### PR TITLE
HDFS-17863: CannotObtainBlockLengthException after DataNode restart

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaWaitingToBeRecovered.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaWaitingToBeRecovered.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.hdfs.server.protocol.ReplicaRecoveryInfo;
  * This class represents a replica that is waiting to be recovered.
  * After a datanode restart, any replica in "rbw" directory is loaded
  * as a replica waiting to be recovered.
- * A replica waiting to be recovered does not provision read nor
- * participates in any pipeline recovery. It will become outdated if its
- * client continues to write or be recovered as a result of
- * lease recovery.
+ * A replica waiting to be recovered provisions read access for the bytes
+ * validated on load, but does not participate in any pipeline recovery.
+ * It will become outdated if its client continues to write or be recovered
+ * as a result of lease recovery.
  */
 public class ReplicaWaitingToBeRecovered extends LocalReplica {
 
@@ -73,7 +73,7 @@ public class ReplicaWaitingToBeRecovered extends LocalReplica {
   
   @Override //ReplicaInfo
   public long getVisibleLength() {
-    return -1;  //no bytes are visible
+    return getNumBytes();  // all bytes are visible since validated on load
   }
   
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPersistBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPersistBlocks.java
@@ -363,4 +363,87 @@ public class TestPersistBlocks {
       cluster.shutdown();
     }
   }
+
+  /**
+   * Test that an under-construction file can be read after DataNode restart.
+   * This is a regression test for HDFS-17863: After hflush(), HDFS guarantees
+   * that written data becomes visible to readers, even while the file remains
+   * under construction. This guarantee must hold even after DataNode restart.
+   *
+   * The scenario is:
+   * 1. Client creates a file and writes data with hflush()
+   * 2. DataNode restarts (simulating failure/recovery)
+   * 3. A reader (new client) should be able to read the flushed data
+   *
+   * Before the fix, step 3 would fail with CannotObtainBlockLengthException
+   * because ReplicaWaitingToBeRecovered.getVisibleLength() returned -1.
+   */
+  @Test
+  public void testReadUnderConstructionFileAfterDataNodeRestart()
+      throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    conf.setInt(
+        CommonConfigurationKeysPublic.IPC_CLIENT_CONNECTION_MAXIDLETIME_KEY,
+        0);
+    MiniDFSCluster cluster = null;
+    FSDataOutputStream out = null;
+
+    try {
+      // Use replication factor of 1 to simplify the test
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+      cluster.waitActive();
+      FileSystem fs = cluster.getFileSystem();
+      Path testPath = new Path("/testReadAfterDNRestart");
+
+      // Create a file and write some data
+      byte[] testData = "Hello HDFS".getBytes();
+      out = fs.create(testPath, (short) 1);
+      out.write(testData);
+      out.hflush();
+
+      // Verify the file is readable before restart
+      FSDataInputStream in = fs.open(testPath);
+      byte[] readBuf = new byte[testData.length];
+      int bytesRead = in.read(readBuf);
+      assertEquals(testData.length, bytesRead,
+          "Should read all bytes before DN restart");
+      assertArrayEquals(testData, readBuf,
+          "Data should match before DN restart");
+      in.close();
+
+      // Restart the DataNode - this simulates a DataNode failure/recovery
+      // The block will be loaded as ReplicaWaitingToBeRecovered
+      cluster.restartDataNode(0);
+      cluster.waitActive();
+
+      // Wait for the DataNode to re-register with the NameNode
+      // and complete block report
+      cluster.waitFirstBRCompleted(0, 30000);
+
+      // Try to read the file again with a NEW file system instance
+      // This simulates a different client reading the file
+      // Before the fix, this would throw CannotObtainBlockLengthException
+      // because ReplicaWaitingToBeRecovered.getVisibleLength() returned -1
+      Configuration readerConf = new HdfsConfiguration();
+      FileSystem readerFs = FileSystem.newInstance(cluster.getURI(), readerConf);
+      try {
+        FSDataInputStream in2 = readerFs.open(testPath);
+        byte[] readBuf2 = new byte[testData.length];
+        int bytesRead2 = in2.read(readBuf2);
+        assertEquals(testData.length, bytesRead2,
+            "Should read all bytes after DN restart");
+        assertArrayEquals(testData, readBuf2,
+            "Data should match after DN restart");
+        in2.close();
+      } finally {
+        readerFs.close();
+      }
+    } finally {
+      // Close the output stream if it's still open
+      IOUtils.closeStream(out);
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR fixes [HDFS-17863](https://issues.apache.org/jira/browse/HDFS-17863).

The bug accurs where under-construction files become unreadable after DataNode restart, even though the data was successfully flushed with hflush(). This breaks HDFS's visibility guarantee for flushed data.

  When a DataNode restarts, under-construction block replicas in the "rbw" (replica being written) directory are loaded as ReplicaWaitingToBeRecovered (RWR state). The getVisibleLength() method in this class unconditionally returned -1:

```java
  // Before (ReplicaWaitingToBeRecovered.java:75-77)
  @Override
  public long getVisibleLength() {
    return -1;  //no bytes are visible
  }
```

  When a client tries to read the file:
  1. DFSInputStream calls readBlockLength() to determine the under-construction block length
  2. It contacts the DataNode via getReplicaVisibleLength()
  3. The DataNode returns -1 (from RWR replica)
  4. Client treats this as invalid and throws CannotObtainBlockLengthException

  This violates HDFS's hflush() contract which guarantees that flushed data remains visible to readers.

### Changes

  Changed ReplicaWaitingToBeRecovered.getVisibleLength() to return getNumBytes() instead of -1:
```java
  // After (ReplicaWaitingToBeRecovered.java:75-77)
  @Override
  public long getVisibleLength() {
    return getNumBytes();  // all bytes are visible since validated on load
  }
```

### Why This Fix Is Safe

  The fix is safe because the block length returned by getNumBytes() has already been validated against checksums when the replica is loaded from disk.

  In BlockPoolSlice.addReplicaToReplicasMap() (lines 693-700), RWR replicas are created with a validated length:
```java
  if (loadRwr) {
    ReplicaBuilder builder = new ReplicaBuilder(ReplicaState.RWR)
        .setBlockId(blockId)
        .setLength(validateIntegrityAndSetLength(file, genStamp))  // <-- Validated!
        .setGenerationStamp(genStamp)
        ...
  }
```

  The validateIntegrityAndSetLength() method (lines 871-920):
  1. Reads the checksum from the meta file
  2. Validates the last chunk of data against its checksum
  3. Returns only the length of data that passes checksum validation
  4. Truncates any corrupted trailing data

  Therefore, getNumBytes() returns a checksum-verified length that is safe to expose to readers. This is the same validation used for RBW replicas loaded with valid restart metadata.

A New test added:
  - TestPersistBlocks#testReadUnderConstructionFileAfterDataNodeRestart - Specifically reproduces the JIRA scenario

I also ran other tests related to this change:
  Regression tests - all pass (58 tests):
  - TestDatanodeRestart (2 tests)
  - TestLeaseRecovery2 (8 tests)
  - TestFileLengthOnClusterRestart (1 test)
  - TestReadWhileWriting (1 test)
  - TestTransferRbw (1 test)
  - TestWriteRead (3 tests)
  - TestWriteToReplica (6 tests)
  - TestBlockRecovery (17 tests)
  - TestBlockRecovery2 (5 tests)
  - TestBlockListAsLongs (7 tests)
  - TestPersistBlocks (7 tests)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html