### PR TITLE
HDFS-17873. Use DFSUtil.getPassword in HikariDataSourceConnectionFactory and MySQLStateStoreHikariDataSourceConnectionFactory

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/HikariDataSourceConnectionFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/HikariDataSourceConnectionFactory.java
@@ -22,6 +22,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.security.token.delegation.SQLDelegationTokenSecretManager;
 
 import java.sql.Connection;
@@ -40,7 +41,7 @@ class HikariDataSourceConnectionFactory implements SQLConnectionFactory {
     Properties properties = new Properties();
     properties.setProperty("jdbcUrl", conf.get(CONNECTION_URL));
     properties.setProperty("username", conf.get(CONNECTION_USERNAME));
-    properties.setProperty("password", conf.get(CONNECTION_PASSWORD));
+    properties.setProperty("password", DFSUtil.getPassword(conf, CONNECTION_PASSWORD));
     properties.setProperty("driverClassName", conf.get(CONNECTION_DRIVER));
 
     // Include hikari connection properties

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreMySQLImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreMySQLImpl.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.server.federation.metrics.StateStoreMetrics;
 import org.apache.hadoop.hdfs.server.federation.router.security.token.SQLConnectionFactory;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreUtils;
@@ -407,7 +408,8 @@ public class StateStoreMySQLImpl extends StateStoreSerializableImpl {
       Properties properties = new Properties();
       properties.setProperty("jdbcUrl", conf.get(StateStoreMySQLImpl.CONNECTION_URL));
       properties.setProperty("username", conf.get(StateStoreMySQLImpl.CONNECTION_USERNAME));
-      properties.setProperty("password", conf.get(StateStoreMySQLImpl.CONNECTION_PASSWORD));
+      properties.setProperty("password",
+          DFSUtil.getPassword(conf, StateStoreMySQLImpl.CONNECTION_PASSWORD));
       properties.setProperty("driverClassName", conf.get(StateStoreMySQLImpl.CONNECTION_DRIVER));
 
       // Include hikari connection properties

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -1643,7 +1643,7 @@ public class DFSUtil {
    * @param alias name of the credential to retreive
    * @return String credential value or null
    */
-  static String getPassword(Configuration conf, String alias) {
+  public static String getPassword(Configuration conf, String alias) {
     String password = null;
     try {
       char[] passchars = conf.getPassword(alias);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Fix for [HDFS-17873](https://issues.apache.org/jira/browse/HDFS-17873)
Enable credential providers for HikariDataSourceConnectionFactory and MySQLStateStoreHikariDataSourceConnectionFactory.

### How was this patch tested?

Pass TestStateStoreMySQL, TestSQLDelegationTokenSecretManagerImpl, TestDFSUtil on local

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html