### PR TITLE
HADOOP-19794: create-release version parsing incompatible with Java 17

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -214,7 +214,7 @@ function set_defaults
   # the docker container comes up...
   JVM_VERSION=$(grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" \
     | head -1 \
-    | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||' -e 's|..||')
+    | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||')
 
   GIT=$(command -v git)
 


### PR DESCRIPTION
### Description of PR

Remove the last step of the `sed` parsing logic that attempted to break apart the older X.Y versioning convention (e.g. 1.8) and choose just the Y component (e.g. 8). This is no longer relevant for the newer versioning convention, e.g. Java 17.

### How was this patch tested?

I did a successful dry run of creating a 3.5.0 release after applying this patch.

Here is a transcript of how the chain of `sed` operations works on branch-3.4 vs. trunk. Notice that on trunk, the final step returns an empty result, which is why we need to remove it.

```
branch-3.4:
> grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" | head -1 | sed  -e 's|^ *<javac.version>||'
1.8</javac.version>

> grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" | head -1 | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||'
1.8

> grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" | head -1 | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||' -e 's|..||'
8

trunk:
> grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" | head -1 | sed  -e 's|^ *<javac.version>||'
17</javac.version>

> grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" | head -1 | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||'
17

> grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" | head -1 | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||' -e 's|..||'

```


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html