### PR TITLE
HADOOP-19791: Upgraded GCS to remediate CVE-2025-55163

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -473,6 +473,7 @@ leveldb v1.13
 com.google.auth:google-auth-library-credentials:1.33.1
 com.google.auth:google-auth-library-oauth2-http:1.33.1
 com.google.protobuf:protobuf-java:2.5.0
+com.google.protobuf:protobuf-java:3.25.5
 com.google.protobuf:protobuf-java:3.25.8
 com.google.re2j:re2j:1.1
 com.jcraft:jsch:0.1.55

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -240,10 +240,10 @@ com.google.api-client:google-api-client:2.7.2
 com.google.api:gax:2.64.2
 com.google.api:gax-grpc:2.64.2
 com.google.api:gax-httpjson:2.64.2
-com.google.api.grpc:gapic-google-cloud-storage-v2:2.52.0
-com.google.api.grpc:grpc-google-cloud-storage-v2:2.52.0
+com.google.api.grpc:gapic-google-cloud-storage-v2:2.62.0
+com.google.api.grpc:grpc-google-cloud-storage-v2:2.62.0
 com.google.api.grpc:proto-google-cloud-monitoring-v3:3.52.0
-com.google.api.grpc:proto-google-cloud-storage-v2:2.52.0
+com.google.api.grpc:proto-google-cloud-storage-v2:2.62.0
 com.google.api.grpc:proto-google-common-protos:2.55.2
 com.google.api.grpc:proto-google-iam-v1:1.50.2
 com.google.apis:google-api-services-storage:v1-rev20250420-2.0.0
@@ -264,6 +264,7 @@ com.google.json-simple:json-simple:1.1.1
 com.google.guava:failureaccess:1.0
 com.google.guava:failureaccess:1.0.2
 com.google.guava:guava:33.4.8-jre
+com.google.guava:guava:33.5.0-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.http-client:google-http-client-apache-v2:1.46.3
 com.google.http-client:google-http-client-appengine:1.46.3
@@ -300,7 +301,7 @@ io.grpc:grpc-googleapis:1.70.0
 io.grpc:grpc-grpclb:1.70.0
 io.grpc:grpc-inprocess:1.70.0
 io.grpc:grpc-netty:1.69.0
-io.grpc:grpc-netty-shaded:1.70.0
+io.grpc:grpc-netty-shaded:1.76.2
 io.grpc:grpc-opentelemetry:1.70.0
 io.grpc:grpc-protobuf:1.69.0
 io.grpc:grpc-protobuf:1.70.0
@@ -472,7 +473,7 @@ leveldb v1.13
 com.google.auth:google-auth-library-credentials:1.33.1
 com.google.auth:google-auth-library-oauth2-http:1.33.1
 com.google.protobuf:protobuf-java:2.5.0
-com.google.protobuf:protobuf-java:3.25.5
+com.google.protobuf:protobuf-java:3.25.8
 com.google.re2j:re2j:1.1
 com.jcraft:jsch:0.1.55
 com.thoughtworks.paranamer:paranamer:2.3

--- a/hadoop-cloud-storage-project/hadoop-gcp/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-gcp/pom.xml
@@ -462,12 +462,12 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.4.0-jre</version>
+        <version>33.5.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.25.5</version>
+        <version>3.25.8</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2209,7 +2209,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage</artifactId>
-        <version>2.52.0</version>
+        <version>2.62.0</version>
     </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Description of PR
Upgraded GCS from 2.52.0 to 2.62.0 to remediate https://github.com/advisories/GHSA-prj3-ccx8-p6x4
Upgraded Guava and Protobuf Java to avoid conflict

### How was this patch tested?
Local build

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

N/A