### PR TITLE
YARN-11925. Fix the configurability of RM webservice class

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1522,7 +1522,7 @@ public class ResourceManager extends CompositeService
 
     try {
       RMWebApp rmWebApp = new RMWebApp(this);
-      builder.withResourceConfig(rmWebApp.resourceConfig());
+      builder.withResourceConfig(rmWebApp.resourceConfig(conf));
       webApp = builder.start(rmWebApp, uiWebAppContext, schedulerUiWebAppContext);
     } catch (WebAppException e) {
       webApp = e.getWebApp();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebApp.java
@@ -61,9 +61,7 @@ public class RMWebApp extends WebApp implements YarnWebParams {
     Class webService = config.getClass(YarnConfiguration.YARN_WEBAPP_CUSTOM_WEBSERVICE_CLASS,
         RMWebServices.class);
     resourceConfig.register(webService);
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Registered webservice class is {}", webService.getName());
-    }
+    LOG.debug("Registered webservice class is {}", webService.getName());
 
     resourceConfig.register(GenericExceptionHandler.class);
     resourceConfig.register(JsonProviderFeature.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebApp.java
@@ -54,11 +54,18 @@ public class RMWebApp extends WebApp implements YarnWebParams {
     this.rm = rm;
   }
 
-  public ResourceConfig resourceConfig() {
+  public ResourceConfig resourceConfig(Configuration yarnConfiguration) {
     ResourceConfig config = new ResourceConfig();
-    config.packages("org.apache.hadoop.yarn.server.resourcemanager.webapp");
     config.register(new JerseyBinder());
-    config.register(RMWebServices.class);
+
+    Class webService = yarnConfiguration.getClass(
+        YarnConfiguration.YARN_WEBAPP_CUSTOM_WEBSERVICE_CLASS,
+        RMWebServices.class);
+    config.register(webService);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Registered webservice class is {}", webService.getName());
+    }
+
     config.register(GenericExceptionHandler.class);
     config.register(JsonProviderFeature.class);
     config.register(JAXBContextResolver.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebApp.java
@@ -54,22 +54,21 @@ public class RMWebApp extends WebApp implements YarnWebParams {
     this.rm = rm;
   }
 
-  public ResourceConfig resourceConfig(Configuration yarnConfiguration) {
-    ResourceConfig config = new ResourceConfig();
-    config.register(new JerseyBinder());
+  public ResourceConfig resourceConfig(Configuration config) {
+    ResourceConfig resourceConfig = new ResourceConfig();
+    resourceConfig.register(new JerseyBinder());
 
-    Class webService = yarnConfiguration.getClass(
-        YarnConfiguration.YARN_WEBAPP_CUSTOM_WEBSERVICE_CLASS,
+    Class webService = config.getClass(YarnConfiguration.YARN_WEBAPP_CUSTOM_WEBSERVICE_CLASS,
         RMWebServices.class);
-    config.register(webService);
+    resourceConfig.register(webService);
     if (LOG.isDebugEnabled()) {
       LOG.debug("Registered webservice class is {}", webService.getName());
     }
 
-    config.register(GenericExceptionHandler.class);
-    config.register(JsonProviderFeature.class);
-    config.register(JAXBContextResolver.class);
-    return config;
+    resourceConfig.register(GenericExceptionHandler.class);
+    resourceConfig.register(JsonProviderFeature.class);
+    resourceConfig.register(JAXBContextResolver.class);
+    return resourceConfig;
   }
 
   private class JerseyBinder extends AbstractBinder {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebApp.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 import static org.apache.hadoop.yarn.server.resourcemanager.MockNodes.newResource;
 import static org.apache.hadoop.yarn.webapp.Params.TITLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,6 +72,7 @@ import org.apache.hadoop.yarn.util.StringHelper;
 import org.apache.hadoop.yarn.webapp.WebApps;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
+import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
@@ -416,5 +418,24 @@ public class TestRMWebApp {
         start(new RMWebApp(mockRm(2500, 8, 8, 8*GiB))).joinThread();
     WebApps.$for("yarn", new TestRMWebApp()).at(8888).inDevMode().
         start(new RMWebApp(mockFifoRm(10, 1, 4, 8*GiB))).joinThread();
+  }
+
+  @Test
+  public void testCustomWebServiceClass() {
+    RMWebApp rmWebApp = new RMWebApp(mock(ResourceManager.class));
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.YARN_WEBAPP_CUSTOM_WEBSERVICE_CLASS,
+        "org.apache.hadoop.yarn.server.resourcemanager.webapp.TestRMWebApp$CustomRMWebServices");
+
+    ResourceConfig rc = rmWebApp.resourceConfig(conf);
+
+    assertTrue(rc.isRegistered(CustomRMWebServices.class));
+    assertFalse(rc.isRegistered(RMWebServices.class));
+  }
+
+  private class CustomRMWebServices extends RMWebServices {
+    public CustomRMWebServices(ResourceManager rm, Configuration conf) {
+      super(rm, conf);
+    }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebApp.java
@@ -427,10 +427,10 @@ public class TestRMWebApp {
     conf.set(YarnConfiguration.YARN_WEBAPP_CUSTOM_WEBSERVICE_CLASS,
         "org.apache.hadoop.yarn.server.resourcemanager.webapp.TestRMWebApp$CustomRMWebServices");
 
-    ResourceConfig rc = rmWebApp.resourceConfig(conf);
+    ResourceConfig resourceConfig = rmWebApp.resourceConfig(conf);
 
-    assertTrue(rc.isRegistered(CustomRMWebServices.class));
-    assertFalse(rc.isRegistered(RMWebServices.class));
+    assertTrue(resourceConfig.isRegistered(CustomRMWebServices.class));
+    assertFalse(resourceConfig.isRegistered(RMWebServices.class));
   }
 
   private class CustomRMWebServices extends RMWebServices {


### PR DESCRIPTION
Change-Id: I108120c5407ed103adfcfcb469c44c7ed3de9999

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
RM webservice class is not configurable in trunk with the "yarn.webapp.custom.webservice.class" property since the upgrade to Jersey 2. The patch

- registers webservice class that is configured in the above property
- removes package scan on "org.apache.hadoop.yarn.server.resourcemanager.webapp" to avoid registering RMWebServices class at the same time

### How was this patch tested?
Tested on a cluster with custom webservice class

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html