### PR TITLE
HDFS-17878. Reduce frequency of getDatanodeListForReport calls for metrics

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -2116,4 +2116,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
    */
   public static final String SUPPORTED_PACKAGES_CONFIG_NAME =
       "dfs.nodeplan.steps.supported.packages";
+
+  public static final String DFS_NAMENODE_DATANODE_LIST_CACHE_EXPIRATION_MS_KEY =
+      "dfs.namenode.datanode.list.cache.expiration.ms";
+  public static final long DFS_NAMENODE_DATANODE_LIST_CACHE_EXPIRATION_MS_DEFAULT = 0;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
 
+import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.thirdparty.com.google.common.net.InetAddresses;
 
@@ -70,6 +72,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -230,6 +233,9 @@ public class DatanodeManager {
 
   private final boolean randomNodeOrderEnabled;
 
+  /** Cached map of DatanodeReportType -> list of DatanodeDescriptor for metrics purposes. */
+  private Cache<DatanodeReportType, List<DatanodeDescriptor>> datanodeListSnapshots = null;
+
   DatanodeManager(final BlockManager blockManager, final Namesystem namesystem,
       final Configuration conf) throws IOException {
     this.namesystem = namesystem;
@@ -364,6 +370,17 @@ public class DatanodeManager {
     this.randomNodeOrderEnabled = conf.getBoolean(
         DFSConfigKeys.DFS_NAMENODE_RANDOM_NODE_ORDER_ENABLED,
         DFSConfigKeys.DFS_NAMENODE_RANDOM_NODE_ORDER_ENABLED_DEFAULT);
+
+    long datanodeListCacheExpirationMs =
+        conf.getLong(DFSConfigKeys.DFS_NAMENODE_DATANODE_LIST_CACHE_EXPIRATION_MS_KEY,
+            DFSConfigKeys.DFS_NAMENODE_DATANODE_LIST_CACHE_EXPIRATION_MS_DEFAULT);
+    if (datanodeListCacheExpirationMs > 0) {
+      LOG.info("Using cached DN list for metrics, expiration time = {} ms.",
+          datanodeListCacheExpirationMs);
+      datanodeListSnapshots = CacheBuilder.newBuilder()
+          .expireAfterWrite(datanodeListCacheExpirationMs, TimeUnit.MILLISECONDS)
+          .build();
+    }
   }
 
   /**
@@ -963,6 +980,11 @@ public class DatanodeManager {
     synchronized (this) {
       host2DatanodeMap.remove(datanodeMap.remove(key));
     }
+    Cache<DatanodeReportType, List<DatanodeDescriptor>> tmpDatanodeListSnapshots =
+        datanodeListSnapshots;
+    if (tmpDatanodeListSnapshots != null) {
+      tmpDatanodeListSnapshots.invalidateAll();
+    }
     if (LOG.isDebugEnabled()) {
       LOG.debug("{}.wipeDatanode({}): storage {} is removed from datanodeMap.",
           getClass().getSimpleName(), node, key);
@@ -1438,7 +1460,7 @@ public class DatanodeManager {
 
   /** @return the number of dead datanodes. */
   public int getNumDeadDataNodes() {
-    return getDatanodeListForReport(DatanodeReportType.DEAD).size();
+    return getDatanodeListForReportWithCache(DatanodeReportType.DEAD).size();
   }
 
   /** @return the number of datanodes. */
@@ -1453,12 +1475,12 @@ public class DatanodeManager {
     // There is no need to take namesystem reader lock as
     // getDatanodeListForReport will synchronize on datanodeMap
     // A decommissioning DN may be "alive" or "dead".
-    return getDatanodeListForReport(DatanodeReportType.DECOMMISSIONING);
+    return getDatanodeListForReportWithCache(DatanodeReportType.DECOMMISSIONING);
   }
 
   /** @return list of datanodes that are entering maintenance. */
   public List<DatanodeDescriptor> getEnteringMaintenanceNodes() {
-    return getDatanodeListForReport(DatanodeReportType.ENTERING_MAINTENANCE);
+    return getDatanodeListForReportWithCache(DatanodeReportType.ENTERING_MAINTENANCE);
   }
 
   /* Getter and Setter for stale DataNodes related attributes */
@@ -1532,17 +1554,35 @@ public class DatanodeManager {
     this.numStaleStorages = numStaleStorages;
   }
 
-  /** Fetch live and dead datanodes. */
-  public void fetchDatanodes(final List<DatanodeDescriptor> live, 
+  public void fetchDatanodes(final List<DatanodeDescriptor> live,
       final List<DatanodeDescriptor> dead, final boolean removeDecommissionNode) {
+    fetchDatanodes(live, dead, removeDecommissionNode, false);
+  }
+
+  /**
+   * Fetches live and dead datanodes via cache maps. Generates and caches results
+   * on cache miss.
+   */
+  public void fetchDatanodesWithCache(final List<DatanodeDescriptor> live,
+      final List<DatanodeDescriptor> dead, final boolean removeDecommissionNode) {
+    fetchDatanodes(live, dead, removeDecommissionNode, true);
+  }
+
+  /** Fetch live and dead datanodes. */
+  private void fetchDatanodes(final List<DatanodeDescriptor> live,
+      final List<DatanodeDescriptor> dead, final boolean removeDecommissionNode, boolean useCache) {
     if (live == null && dead == null) {
       throw new HadoopIllegalArgumentException("Both live and dead lists are null");
     }
 
-    // There is no need to take namesystem reader lock as
-    // getDatanodeListForReport will synchronize on datanodeMap
-    final List<DatanodeDescriptor> results =
-        getDatanodeListForReport(DatanodeReportType.ALL);
+    List<DatanodeDescriptor> results;
+    if (useCache) {
+      results = getDatanodeListForReportWithCache(DatanodeReportType.ALL);
+    } else {
+      // There is no need to take namesystem reader lock as
+      // getDatanodeListForReport will synchronize on datanodeMap
+      results = getDatanodeListForReport(DatanodeReportType.ALL);
+    }
     for(DatanodeDescriptor node : results) {
       if (isDatanodeDead(node)) {
         if (dead != null) {
@@ -1633,6 +1673,25 @@ public class DatanodeManager {
           DFSConfigKeys.DFS_DATANODE_IPC_DEFAULT_PORT);
     }
     return dnId;
+  }
+
+  /**
+   * Low impact version of {@link #getDatanodeListForReport} with possible stale
+   * data for low impact usage (metrics).
+   */
+  public List<DatanodeDescriptor> getDatanodeListForReportWithCache(
+      final DatanodeReportType type) {
+    Cache<DatanodeReportType, List<DatanodeDescriptor>> tmpDatanodeListSnapshots =
+        datanodeListSnapshots;
+    if (tmpDatanodeListSnapshots == null) {
+      return getDatanodeListForReport(type);
+    }
+    try {
+      return tmpDatanodeListSnapshots.get(type, () -> getDatanodeListForReport(type));
+    } catch (ExecutionException e) {
+      // Fallback if cache fails
+      return getDatanodeListForReport(type);
+    }
   }
 
   /** For generating datanode reports */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5789,8 +5789,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"NumDecomLiveDataNodes",
       "Number of datanodes which have been decommissioned and are now live"})
   public int getNumDecomLiveDataNodes() {
-    final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(live, null, false);
+    final List<DatanodeDescriptor> live = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(live, null, false);
     int liveDecommissioned = 0;
     for (DatanodeDescriptor node : live) {
       liveDecommissioned += node.isDecommissioned() ? 1 : 0;
@@ -5802,8 +5802,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"NumDecomDeadDataNodes",
       "Number of datanodes which have been decommissioned and are now dead"})
   public int getNumDecomDeadDataNodes() {
-    final List<DatanodeDescriptor> dead = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(null, dead, false);
+    final List<DatanodeDescriptor> dead = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(null, dead, false);
     int deadDecommissioned = 0;
     for (DatanodeDescriptor node : dead) {
       deadDecommissioned += node.isDecommissioned() ? 1 : 0;
@@ -5815,8 +5815,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"NumInServiceLiveDataNodes",
       "Number of live datanodes which are currently in service"})
   public int getNumInServiceLiveDataNodes() {
-    final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(live, null, true);
+    final List<DatanodeDescriptor> live = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(live, null, true);
     int liveInService = live.size();
     for (DatanodeDescriptor node : live) {
       liveInService -= node.isInMaintenance() ? 1 : 0;
@@ -5828,8 +5828,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"VolumeFailuresTotal",
       "Total number of volume failures across all Datanodes"})
   public int getVolumeFailuresTotal() {
-    List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(live, null, false);
+    List<DatanodeDescriptor> live = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(live, null, false);
     int volumeFailuresTotal = 0;
     for (DatanodeDescriptor node: live) {
       volumeFailuresTotal += node.getVolumeFailures();
@@ -5841,8 +5841,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"EstimatedCapacityLostTotal",
       "An estimate of the total capacity lost due to volume failures"})
   public long getEstimatedCapacityLostTotal() {
-    List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(live, null, false);
+    List<DatanodeDescriptor> live = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(live, null, false);
     long estimatedCapacityLostTotal = 0;
     for (DatanodeDescriptor node: live) {
       VolumeFailureSummary volumeFailureSummary = node.getVolumeFailureSummary();
@@ -6731,10 +6731,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   @Override // NameNodeMXBean
   public String getLiveNodes() {
-    final Map<String, Map<String,Object>> info = 
-      new HashMap<String, Map<String,Object>>();
-    final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    blockManager.getDatanodeManager().fetchDatanodes(live, null, false);
+    final Map<String, Map<String, Object>> info = new HashMap<>();
+    final List<DatanodeDescriptor> live = new ArrayList<>();
+    blockManager.getDatanodeManager().fetchDatanodesWithCache(live, null, false);
     for (DatanodeDescriptor node : live) {
       ImmutableMap.Builder<String, Object> innerinfo =
           ImmutableMap.<String,Object>builder();
@@ -6786,10 +6785,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   @Override // NameNodeMXBean
   public String getDeadNodes() {
-    final Map<String, Map<String, Object>> info = 
-      new HashMap<String, Map<String, Object>>();
-    final List<DatanodeDescriptor> dead = new ArrayList<DatanodeDescriptor>();
-    blockManager.getDatanodeManager().fetchDatanodes(null, dead, false);
+    final Map<String, Map<String, Object>> info = new HashMap<>();
+    final List<DatanodeDescriptor> dead = new ArrayList<>();
+    blockManager.getDatanodeManager().fetchDatanodesWithCache(null, dead, false);
     for (DatanodeDescriptor node : dead) {
       Map<String, Object> innerinfo = ImmutableMap.<String, Object>builder()
           .put("lastContact", getLastContact(node))
@@ -6917,10 +6915,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     float min = 0;
     float dev = 0;
 
-    final Map<String, Map<String,Object>> info =
-        new HashMap<String, Map<String,Object>>();
-    final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    blockManager.getDatanodeManager().fetchDatanodes(live, null, true);
+    final Map<String, Map<String, Object>> info = new HashMap<>();
+    final List<DatanodeDescriptor> live = new ArrayList<>();
+    blockManager.getDatanodeManager().fetchDatanodesWithCache(live, null, true);
     for (Iterator<DatanodeDescriptor> it = live.iterator(); it.hasNext();) {
       DatanodeDescriptor node = it.next();
       if (!node.isInService()) {
@@ -9095,8 +9092,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"NumInMaintenanceLiveDataNodes",
       "Number of live Datanodes which are in maintenance state"})
   public int getNumInMaintenanceLiveDataNodes() {
-    final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(live, null, true);
+    final List<DatanodeDescriptor> live = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(live, null, true);
     int liveInMaintenance = 0;
     for (DatanodeDescriptor node : live) {
       liveInMaintenance += node.isInMaintenance() ? 1 : 0;
@@ -9108,8 +9105,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   @Metric({"NumInMaintenanceDeadDataNodes",
       "Number of dead Datanodes which are in maintenance state"})
   public int getNumInMaintenanceDeadDataNodes() {
-    final List<DatanodeDescriptor> dead = new ArrayList<DatanodeDescriptor>();
-    getBlockManager().getDatanodeManager().fetchDatanodes(null, dead, true);
+    final List<DatanodeDescriptor> dead = new ArrayList<>();
+    getBlockManager().getDatanodeManager().fetchDatanodesWithCache(null, dead, true);
     int deadInMaintenance = 0;
     for (DatanodeDescriptor node : dead) {
       deadInMaintenance += node.isInMaintenance() ? 1 : 0;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6720,4 +6720,14 @@
       If you have more than one package, separate the packages using commas.
     </description>
   </property>
+  <property>
+    <name>dfs.namenode.datanode.list.cache.expiration.ms</name>
+    <value>0</value>
+    <description>
+      Set to a positive number to cache values for DatanodeManager.getDatanodeListForReport for
+      performance purpose. Milliseconds for cache expiration from insertion. 0 or negative value
+      to disable this cache.
+      Non metrics usage will bypass this cache (fsck, datanodeReport, etc.)
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -1226,4 +1226,31 @@ public class TestDatanodeManager {
       assertTrue(numECReconstructedTasks >= 0);
     }
   }
+
+  @Test
+  public void testGetDatanodeListForReportWithCache() throws IOException {
+    FSNamesystem fsn = Mockito.mock(FSNamesystem.class);
+    Configuration conf = new Configuration();
+    // Just need a huge number so the cache doesn't time out
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_DATANODE_LIST_CACHE_EXPIRATION_MS_KEY, 9000000000L);
+    DatanodeManager dm = Mockito.spy(mockDatanodeManager(fsn, conf));
+    dm.registerDatanode(new DatanodeRegistration(
+        new DatanodeID("127.0.0.1", "localhost", "storageid", 9000, 0, 0, 0), null, null,
+        "version"));
+
+    // First call will proc the live report
+    dm.getDatanodeListForReportWithCache(HdfsConstants.DatanodeReportType.LIVE);
+    // Second will bypass the live report and hit the cache
+    dm.getDatanodeListForReportWithCache(HdfsConstants.DatanodeReportType.LIVE);
+    Mockito.verify(dm, Mockito.times(1))
+        .getDatanodeListForReport(HdfsConstants.DatanodeReportType.LIVE);
+    // Third call will still bypass the live report and hit the cache again
+    dm.getDatanodeListForReportWithCache(HdfsConstants.DatanodeReportType.LIVE);
+    Mockito.verify(dm, Mockito.times(1))
+        .getDatanodeListForReport(HdfsConstants.DatanodeReportType.LIVE);
+    // Make a call that will never hit the cache and the total number of live calls should increase
+    dm.getDatanodeStorageReport(HdfsConstants.DatanodeReportType.LIVE);
+    Mockito.verify(dm, Mockito.times(2))
+        .getDatanodeListForReport(HdfsConstants.DatanodeReportType.LIVE);
+  }
 }


### PR DESCRIPTION
### Description of PR

`getDatanodeListForReport` is called by a lot of metrics method while holding synchronized lock, interfering with more critical ops like datanodeReport while not having critical data (metrics). Best to reduce the frequency of calls to this method. This patch added a configurable cache that is force-wiped when there is a change in DNs, else expires using the configured expiration period.

### How was this patch tested?

Product cluster + local UT benchmark