### PR TITLE
YARN-11924. Add zkManager.exists(path) check to ZKConfigurationStore:…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1007,6 +1007,16 @@ public class YarnConfiguration extends Configuration {
   public static final String DEFAULT_RM_SCHEDCONF_STORE_ZK_PARENT_PATH =
       "/confstore";
 
+  /** Read-retry period for the ZKConfigurationStore. */
+  @Private
+  @Unstable
+  public static final String RM_SCHEDCONF_STORE_ZK_READ_RETRY_SECS =
+      YARN_PREFIX + "scheduler.configuration.zk-store.read-retry-secs";
+  @Private
+  @Unstable
+  public static final int DEFAULT_RM_SCHEDCONF_STORE_ZK_READ_RETRY_SECS = 3;
+
+
   @Private
   @Unstable
   public static final String RM_SCHEDULER_MUTATION_ACL_POLICY_CLASS =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -4626,6 +4626,17 @@
 
   <property>
     <description>
+      ZK read-retry seconds when using zookeeper-based configuration store.
+      Should the ZK configuration store being formatted while one of the RM
+      is in the INIT state, allow retries using this interval in the hope that the store will be
+      re-populated with some data soon.
+    </description>
+    <name>yarn.scheduler.configuration.zk-store.read-retry-secs</name>
+    <value>3</value>
+  </property>
+
+  <property>
+    <description>
       Provides an option for client to load supported resource types from RM
       instead of depending on local resource-types.xml file.
     </description>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/ZKConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/ZKConfigurationStore.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Zookeeper-based implementation of {@link YarnConfigurationStore}.
@@ -265,8 +266,36 @@ public class ZKConfigurationStore extends YarnConfigurationStore {
 
   @VisibleForTesting
   protected byte[] getZkData(String path) throws Exception {
-    return zkManager.getData(path);
+    // If the 'yarn resourcemanager -format-conf-store' command is issued
+    // while one of the RMs is in a starting state, the RM may fail. This
+    // occurs because the /confstore/CONF_STORE path may not yet exist.
+    // Alternatively, if the confstore is in the process of being written,
+    // the getZkData method returns a null value, causing the crash.
+    //To prevent this, added a re-try mechanism before giving up.
+    int maxRetries = 6;
+    int attempt = 1;
+    int sleepBetweenRetries = conf.getInt(
+        YarnConfiguration.RM_SCHEDCONF_STORE_ZK_READ_RETRY_SECS,
+        YarnConfiguration.DEFAULT_RM_SCHEDCONF_STORE_ZK_READ_RETRY_SECS);
+
+    while (attempt < maxRetries) {
+      if(zkManager.exists(path)) {
+        LOG.debug("zkManager.exists(path) {} exists.", path);
+        byte[] zkData = zkManager.getData(path);
+        if (zkData != null && zkData.length > 0) {
+          LOG.debug("We are returning the zkData OK!");
+          return zkData;
+        }
+      }
+      LOG.warn("The ZK CONFSTORE path or the ZkData was null. Retrying in {} "
+              + "seconds... (Attempt {})", sleepBetweenRetries, attempt);
+      TimeUnit.SECONDS.sleep(sleepBetweenRetries);
+      attempt++;
+    }
+    LOG.error("The ZK CONFSTORE path or the ZkData was null. Giving up.");
+    return new byte[0];
   }
+
 
   @VisibleForTesting
   protected void setZkData(String path, byte[] data) throws Exception {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestZKConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestZKConfigurationStore.java
@@ -198,7 +198,28 @@ public class TestZKConfigurationStore extends
     prepareLogMutation("key1", "val1");
 
     data = ((ZKConfigurationStore) confStore).getZkData(logsPath);
-    assertNull(data, "Failed to Disable Audit Logs");
+    assertEquals(0, data.length, "Failed to Disable Audit Logs");
+  }
+
+  @Test
+  public void testZkData() throws Exception {
+    conf.setInt(YarnConfiguration.RM_SCHEDCONF_STORE_ZK_READ_RETRY_SECS, 0);
+    schedConf.set("key", "val");
+    confStore.initialize(conf, schedConf, rmContext);
+    String confStorePath = getZkPath("CONF_STORE");
+    byte[] data = ((ZKConfigurationStore) confStore).getZkData(confStorePath);
+    assertTrue(data.length > 0, "ConfStore data expected to be not null.");
+  }
+
+  @Test
+  public void testEmptyZkData() throws Exception {
+    conf.setInt(YarnConfiguration.RM_SCHEDCONF_STORE_ZK_READ_RETRY_SECS, 0);
+    schedConf.set("key", "val");
+    confStore.initialize(conf, schedConf, rmContext);
+    confStore.format();
+    String confStorePath = getZkPath("CONF_STORE");
+    byte[] data = ((ZKConfigurationStore) confStore).getZkData(confStorePath);
+    assertEquals(0, data.length, "ConfStore data expected to be empty.");
   }
 
   public Configuration createRMHAConf(String rmIds, String rmId,


### PR DESCRIPTION
…getZkData() and retry mechanism

Should a "yarn resourcemanager -format-state-store" command be issued while one of the RM is starting and in the INIT state (because of YARN-11551), there is a time period when the /confstore/CONF_STORE path does not exist, hence the getZkData method returns a null value, causing the RM to fail. To prevent this, add a check and re-try mechanism before giving up.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Rare race condition is addressed when "yarn resourcemanager -format-state-store" issued when an RM is in the INITING state (already initialized the confstore) right before reading it. This change avoids a null pointer exception.

### How was this patch tested?
Manually with locks introduced in the RM at the confstore format step with sleep, so while one of the RM is formatting the statestore, the other RM will be at the getZkData method trying to read the confstore in the INIT state.
Also with added unit tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html