### PR TITLE
HADOOP-19799: Ubuntu 24 images cannot build full release docs

### DIFF
--- a/dev-support/docker/Dockerfile_ubuntu_24
+++ b/dev-support/docker/Dockerfile_ubuntu_24
@@ -45,7 +45,7 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends wget apt-transport-https gpg gpg-agent gawk ca-certificates \
-    && apt-get -q install -y --no-install-recommends python3 \
+    && apt-get -q install -y --no-install-recommends python3 pylint python3-dateutil \
     && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" > /etc/apt/sources.list.d/adoptium.list \
     && wget -q -O - https://packages.adoptium.net/artifactory/api/gpg/key/public > /etc/apt/trusted.gpg.d/adoptium.asc  \
     && apt-get -q update \

--- a/dev-support/docker/Dockerfile_ubuntu_24_aarch64
+++ b/dev-support/docker/Dockerfile_ubuntu_24_aarch64
@@ -45,7 +45,7 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends wget apt-transport-https gpg gpg-agent gawk ca-certificates \
-    && apt-get -q install -y --no-install-recommends python3 \
+    && apt-get -q install -y --no-install-recommends python3 pylint python3-dateutil \
     && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" > /etc/apt/sources.list.d/adoptium.list \
     && wget -q -O - https://packages.adoptium.net/artifactory/api/gpg/key/public > /etc/apt/trusted.gpg.d/adoptium.asc  \
     && apt-get -q update \


### PR DESCRIPTION
### Description of PR

The full release docs have Python dependencies on pylint and dateutil. These packages are not currently included in the Ubuntu 24 images.

```
mvn install site site:stage -DskipTests -DskipShade -Pdist,src -Preleasedocs,docs

[INFO] --- exec:1.3.1:exec (releasedocs) @ hadoop-common ---
ERROR:root:This script requires python-dateutil module to be installed. You can install it using:
	 pip install python-dateutil
```

Older images included these via dev-support/docker/pkg-resolver/install-common-pkgs.sh, which uses pip. This won't work for Ubuntu 24, which enforces that Python packages are managed with apt. We can simply include them in the apt commands.

### How was this patch tested?

I successfully built full release docs in both the x86 and ARM images.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html