### PR TITLE
HADOOP-19800. hadoop-aws, hadoop-azure &c not in binary distribution

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -338,10 +338,6 @@ Controlling the redistribution of the protobuf-2.5 dependency
     hadoop-common dependency, and included in the share/hadoop/common/lib/
     directory of any Hadoop distribution built.
 
-    Note that protobuf-java-2.5.0.jar is still placed in
-    share/hadoop/yarn/timelineservice/lib; this is needed by the hbase client
-    library.
-
 ----------------------------------------------------------------------------------
 Building components separately
 
@@ -413,7 +409,7 @@ with the relevant profile of ${module}-package alongside the -Pdist profile.
 For example, a build with the hadoop-aws and hadoop-azure-datalake dependencies,
 run with
 
- mvn package -Pdist -DskipTests -Dhadoop-aws-package -Dhadoop-azure-datalake-package
+ mvn package -Pdist -DskipTests -Dtar -Dhadoop-aws-package -Dhadoop-azure-datalake-package
 
 Available package profiles:
   hadoop-aliyun-package

--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -586,6 +586,15 @@ function makearelease
 
   # Stage BIN tarball
   run cd "${BASEDIR}"
+
+  # look for hadoop-aws in dir
+  echo "scanning binary dir tree for hadoop-aws"
+  run find "${BASEDIR}/hadoop-dist/target/hadoop-${HADOOP_VERSION}" -name "hadoop-aws*" -print
+
+  # look for hadoop-aws in tar.gz
+  echo "scanning hadoop-dist/target/for hadoop-aws"
+  run tar --list -zf "${BASEDIR}/hadoop-dist/target/hadoop-${HADOOP_VERSION}.tar.gz" | grep hadoop-aws
+
   run mv \
     "${BASEDIR}/hadoop-dist/target/hadoop-${HADOOP_VERSION}.tar.gz" \
     "${ARTIFACTS_DIR}/hadoop-${HADOOP_VERSION}${RC_LABEL}.tar.gz"
@@ -645,6 +654,10 @@ function makearelease
   run cp -r "${BASEDIR}/target/r${HADOOP_VERSION}"/* "hadoop-${HADOOP_VERSION}/share/doc/hadoop/"
   run tar -czpf "hadoop-${HADOOP_VERSION}${RC_LABEL}.tar.gz" "hadoop-${HADOOP_VERSION}"
   run rm -rf "hadoop-${HADOOP_VERSION}"
+
+  # look for hadoop-aws in tar.gz
+  echo "scanning final tar for hadoop-aws"
+  run tar --list -zf "hadoop-${HADOOP_VERSION}${RC_LABEL}.tar.gz"  | grep hadoop-aws
 
 }
 

--- a/hadoop-cloud-storage-project/hadoop-cloud-storage-dist/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-cloud-storage-dist/pom.xml
@@ -152,53 +152,38 @@ mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true \
         <configuration>
         </configuration>
       </plugin>
+      <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-assembly-plugin</artifactId>
+         <dependencies>
+           <dependency>
+             <groupId>org.apache.hadoop</groupId>
+             <artifactId>hadoop-assemblies</artifactId>
+             <version>${project.version}</version>
+           </dependency>
+         </dependencies>
+         <executions>
+           <execution>
+             <id>dist</id>
+             <phase>prepare-package</phase>
+             <goals>
+               <goal>single</goal>
+             </goals>
+             <configuration>
+               <appendAssemblyId>false</appendAssemblyId>
+               <attach>false</attach>
+               <finalName>${project.artifactId}-${project.version}</finalName>
+               <descriptorRefs>
+                 <descriptorRef>hadoop-cloud-storage</descriptorRef>
+               </descriptorRefs>
+             </configuration>
+           </execution>
+         </executions>
+       </plugin>
     </plugins>
   </build>
 
   <profiles>
-
-    <!-- distribution profile builds the artifacts. -->
-    <profile>
-      <id>dist</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>tar</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-assemblies</artifactId>
-                <version>${project.version}</version>
-              </dependency>
-            </dependencies>
-            <executions>
-              <execution>
-                <id>dist</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-                <configuration>
-                  <appendAssemblyId>false</appendAssemblyId>
-                  <attach>false</attach>
-                  <finalName>${project.artifactId}-${project.version}</finalName>
-                  <descriptorRefs>
-                    <descriptorRef>hadoop-cloud-storage</descriptorRef>
-                  </descriptorRefs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
     <!-- Pull in aliyun -->
     <profile>

--- a/hadoop-cloud-storage-project/hadoop-cloud-storage-dist/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-cloud-storage-dist/pom.xml
@@ -162,6 +162,9 @@ mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true \
       <id>dist</id>
       <activation>
         <activeByDefault>false</activeByDefault>
+        <property>
+          <name>tar</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/hadoop-cloud-storage-project/pom.xml
+++ b/hadoop-cloud-storage-project/pom.xml
@@ -33,6 +33,7 @@
     <module>hadoop-cloud-storage</module>
     <module>hadoop-cos</module>
     <module>hadoop-huaweicloud</module>
+    <module>hadoop-cloud-storage-dist</module>
   </modules>
   <build>
     <plugins>
@@ -50,18 +51,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-     <profile>
-       <id>dist</id>
-       <activation>
-         <activeByDefault>false</activeByDefault>
-         <property>
-           <name>tar</name>
-         </property>
-       </activation>
-       <modules>
-         <module>hadoop-cloud-storage-dist</module>
-       </modules>
-     </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
### How was this patch tested?

local test in progress

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html