### PR TITLE
YARN-11897: Make NMWebservices API backward-compatible after Jersey 2 upgrade.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/ContainerLogsInfoes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/ContainerLogsInfoes.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.yarn.server.webapp.dao;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/ContainerLogsInfoes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/ContainerLogsInfoes.java
@@ -1,0 +1,25 @@
+package org.apache.hadoop.yarn.server.webapp.dao;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement
+public class ContainerLogsInfoes {
+  private List<ContainerLogsInfo> containerLogsInfo;
+
+
+  public ContainerLogsInfoes(List<ContainerLogsInfo> containerLogsInfo) {
+    this.containerLogsInfo = containerLogsInfo;
+  }
+
+  public ContainerLogsInfoes() {
+  }
+
+  public List<ContainerLogsInfo> getContainerLogsInfo() {
+    return containerLogsInfo;
+  }
+
+  public void setContainerLogsInfo(List<ContainerLogsInfo> containerLogsInfo) {
+    this.containerLogsInfo = containerLogsInfo;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -225,6 +225,10 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jettison</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.moxy</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/api/deviceplugin/Device.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/api/deviceplugin/Device.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin;
 
 import java.io.Serializable;
 import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 
 /**
  * Represent one "device" resource.
  * */
+@XmlAccessorType(XmlAccessType.FIELD)
 public final class Device implements Serializable, Comparable {
 
   private static final long serialVersionUID = -7270474563684671656L;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/AssignedDevice.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/AssignedDevice.java
@@ -31,8 +31,11 @@ public class AssignedDevice implements Serializable, Comparable {
 
   private static final long serialVersionUID = -544285507952217366L;
 
-  private final Device device;
-  private final String containerId;
+  private Device device;
+  private String containerId;
+
+  public AssignedDevice() {
+  }
 
   public AssignedDevice(ContainerId cId, Device dev) {
     this.device = dev;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/JAXBContextResolver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/JAXBContextResolver.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Arrays;
-
-
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/JAXBContextResolver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/JAXBContextResolver.java
@@ -18,15 +18,19 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.webapp;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Arrays;
 
-import org.glassfish.jersey.jettison.JettisonJaxbContext;
+
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 import javax.xml.bind.JAXBContext;
+
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
 
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AppInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AppsInfo;
@@ -34,6 +38,7 @@ import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AuxiliaryServiceInfo
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AuxiliaryServicesInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.ContainersInfo;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMDeviceResourceInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NodeInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMResourceInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.NMGpuResourceInfo;
@@ -50,13 +55,15 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
   private final Class[] cTypes = {AppInfo.class, AppsInfo.class,
       AuxiliaryServicesInfo.class, AuxiliaryServiceInfo.class,
       ContainerInfo.class, ContainersInfo.class, NodeInfo.class,
-      RemoteExceptionData.class, NMGpuResourceInfo.class, NMResourceInfo.class};
+      RemoteExceptionData.class, NMGpuResourceInfo.class, NMResourceInfo.class,
+      NMDeviceResourceInfo.class};
 
   public JAXBContextResolver() throws Exception {
     this.types = new HashSet<>(Arrays.asList(cTypes));
     // sets the json configuration so that the json output looks like
     // the xml output
-    this.context = new JettisonJaxbContext(cTypes);
+    this.context = JAXBContextFactory.createContext(cTypes, Collections.singletonMap(
+        MarshallerProperties.JSON_INCLUDE_ROOT, false));
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NMWebServices.java
@@ -50,7 +50,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NMWebServices.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.ResourcePluginManager;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AuxiliaryServicesInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMResourceInfo;
+import org.apache.hadoop.yarn.server.webapp.dao.ContainerLogsInfoes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -330,9 +331,11 @@ public class NMWebServices {
         // Skip it and do nothing
         LOG.debug("{}", ex);
       }
-      GenericEntity<List<ContainerLogsInfo>> meta = new GenericEntity<List<
-          ContainerLogsInfo>>(containersLogsInfo){};
-      ResponseBuilder resp = Response.ok().entity(meta);
+      // Wrapping the response with ContainerLogsInfoes class is needed to provide
+      // backward-compatibility with the Jersey 1 JSON response format.
+      // Previously Jersey 1 returned JSON object type in case the returned list had
+      // a single element, and with a wrapper object we can achieve the same behaviour.
+      ResponseBuilder resp = Response.ok().entity(new ContainerLogsInfoes(containersLogsInfo));
       // Sending the X-Content-Type-Options response header with the value
       // nosniff will prevent Internet Explorer from MIME-sniffing a response
       // away from the declared content-type.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/WebServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/WebServer.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.yarn.server.nodemanager.webapp;
 
 import static org.apache.hadoop.yarn.util.StringHelper.pajoin;
+
+import org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider.NMJsonProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +43,6 @@ import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 
 import javax.servlet.Filter;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
-import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -69,12 +70,15 @@ public class WebServer extends AbstractService {
   }
 
   protected ResourceConfig configure() {
+    NMJsonProvider nmJsonProvider = new NMJsonProvider();
+
     ResourceConfig config = new ResourceConfig();
     config.packages("org.apache.hadoop.yarn.server.nodemanager.webapp");
     config.register(new JerseyBinder());
     config.register(NMWebServices.class);
     config.register(GenericExceptionHandler.class);
-    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    config.register(nmJsonProvider);
+    config.register(JAXBContextResolver.class);
     return config;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NMResourceInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NMResourceInfo.java
@@ -18,24 +18,15 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.webapp.dao;
 
+import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.NMGpuResourceInfo;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
+@XmlSeeAlso({NMGpuResourceInfo.class, NMDeviceResourceInfo.class})
 public class NMResourceInfo {
-
-  private long resourceValue;
-
-  public NMResourceInfo() {
-  } // JAXB needs this
-
-  public long getResourceValue() {
-    return resourceValue;
-  }
-
-  public void setResourceValue(long resourceValue) {
-    this.resourceValue = resourceValue;
-  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NMResourceInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NMResourceInfo.java
@@ -25,16 +25,15 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NMResourceInfo {
-    private long resourceValue;
+  private long resourceValue;
 
-    public NMResourceInfo() {
-    } // JAXB needs this
+  public NMResourceInfo() {} // JAXB needs this
 
-    public long getResourceValue() {
-        return resourceValue;
-    }
+  public long getResourceValue() {
+    return resourceValue;
+  }
 
-    public void setResourceValue(long resourceValue) {
-        this.resourceValue = resourceValue;
-    }
+  public void setResourceValue(long resourceValue) {
+    this.resourceValue = resourceValue;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NMResourceInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NMResourceInfo.java
@@ -18,15 +18,23 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.webapp.dao;
 
-import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.NMGpuResourceInfo;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlSeeAlso({NMGpuResourceInfo.class, NMDeviceResourceInfo.class})
 public class NMResourceInfo {
+    private long resourceValue;
+
+    public NMResourceInfo() {
+    } // JAXB needs this
+
+    public long getResourceValue() {
+        return resourceValue;
+    }
+
+    public void setResourceValue(long resourceValue) {
+        this.resourceValue = resourceValue;
+    }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/gpu/NMGpuResourceInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/gpu/NMGpuResourceInfo.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMResourceInfo;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
@@ -34,6 +35,7 @@ import java.util.List;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NMGpuResourceInfo")
 public class NMGpuResourceInfo extends NMResourceInfo {
   GpuDeviceInformation gpuDeviceInformation;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/NMJsonProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/NMJsonProvider.java
@@ -42,7 +42,7 @@ import java.lang.reflect.Type;
 @Consumes(MediaType.APPLICATION_JSON)
 public class NMJsonProvider extends MOXyJsonProvider {
 
-  private boolean isRootElementNeeded (Class<?> type) {
+  private boolean isRootElementNeeded(Class<?> type) {
     return !type.equals(ContainerLogsInfoes.class)
         && !type.equals(NMGpuResourceInfo.class)
         && !type.equals(NMDeviceResourceInfo.class);
@@ -63,6 +63,8 @@ public class NMJsonProvider extends MOXyJsonProvider {
       throws JAXBException {
     marshaller.setProperty(MarshallerProperties.JSON_MARSHAL_EMPTY_COLLECTIONS, false);
     marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, isRootElementNeeded(type));
-    marshaller.setProperty(MarshallerProperties.JSON_REDUCE_ANY_ARRAYS, type.equals(ContainerLogsInfoes.class));
+    marshaller.setProperty(
+            MarshallerProperties.JSON_REDUCE_ANY_ARRAYS, type.equals(ContainerLogsInfoes.class)
+    );
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/NMJsonProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/NMJsonProvider.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider;
 
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMDeviceResourceInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/NMJsonProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/NMJsonProvider.java
@@ -1,0 +1,68 @@
+package org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider;
+
+import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMDeviceResourceInfo;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.NMGpuResourceInfo;
+import org.apache.hadoop.yarn.server.webapp.dao.ContainerLogsInfoes;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.jaxb.rs.MOXyJsonProvider;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * MOXy JSON provider for NodeManager WebService.
+ *
+ * <p>This class configures a MOXy JSON provider for the NodeManager REST API endpoints.
+ * The endpoints should be able to provide two types of JSON responses:</p>
+ * <ul>
+ *   <li>
+ *     <b>Wrapped classes</b> – classes whose JSON representation includes a root wrapper element.
+ *   </li>
+ *   <li>
+ *     <b>Unwrapped classes</b> – classes whose JSON representation omits a root wrapper element.
+ *   </li>
+ * </ul>
+ *
+ * <p>This behaviour can be configured by the MarshallerProperties.JSON_INCLUDE_ROOT property.
+ *
+ * By default NodeManager REST API endpoints should include the root wrapper element in the
+ * responses, however there are some exceptions (e.g. ContainerLogsInfoes class) which
+ * was introduced to provide backward-compatibility with the Jersey 1 response format.</p>
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class NMJsonProvider extends MOXyJsonProvider {
+
+  private boolean isRootElementNeeded (Class<?> type) {
+    return !type.equals(ContainerLogsInfoes.class)
+        && !type.equals(NMGpuResourceInfo.class)
+        && !type.equals(NMDeviceResourceInfo.class);
+  }
+
+  @Override
+  protected void preReadFrom(Class<Object> type, Type genericType,
+                             Annotation[] annotations, MediaType mediaType,
+                             MultivaluedMap<String, String> httpHeaders,
+                             Unmarshaller unmarshaller) throws JAXBException {
+    unmarshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, isRootElementNeeded(type));
+  }
+
+  @Override
+  protected void preWriteTo(Object object, Class<?> type, Type genericType,
+                            Annotation[] annotations, MediaType mediaType,
+                            MultivaluedMap<String, Object> httpHeaders, Marshaller marshaller)
+      throws JAXBException {
+    marshaller.setProperty(MarshallerProperties.JSON_MARSHAL_EMPTY_COLLECTIONS, false);
+    marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, isRootElementNeeded(type));
+    marshaller.setProperty(MarshallerProperties.JSON_REDUCE_ANY_ARRAYS, type.equals(ContainerLogsInfoes.class));
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/package-info.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/jsonprovider/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider contains classes
+ * for handling json response format mostly to provide backward-compatibility with jersey1.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider;
+

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
@@ -19,8 +19,11 @@
 package org.apache.hadoop.yarn.server.nodemanager.webapp;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMDeviceResourceInfo;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider.NMJsonProvider;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
-import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.TestProperties;
 import org.apache.commons.io.FileUtils;
@@ -102,7 +105,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Iterator;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,11 +139,14 @@ public class TestNMWebServices extends JerseyTestBase {
 
   @Override
   protected Application configure() {
+    NMJsonProvider nmJsonProvider = new NMJsonProvider();
+
     ResourceConfig config = new ResourceConfig();
     config.register(new JerseyBinder());
     config.register(NMWebServices.class);
     config.register(GenericExceptionHandler.class);
-    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    config.register(nmJsonProvider);
+    config.register(JAXBContextResolver.class);
     forceSet(TestProperties.CONTAINER_PORT, JERSEY_RANDOM_PORT);
     return config;
   }
@@ -169,17 +174,17 @@ public class TestNMWebServices extends JerseyTestBase {
         @Override
         public long getVmemAllocatedForContainers() {
           // 15.5G in bytes
-          return new Long("16642998272");
+          return Long.parseLong("16642998272");
         }
 
         @Override
         public long getPmemAllocatedForContainers() {
           // 16G in bytes
-          return new Long("17179869184");
+          return Long.parseLong("17179869184");
         }
         @Override
         public long getVCoresAllocatedForContainers() {
-          return new Long("4000");
+          return Long.parseLong("4000");
         }
         @Override
         public boolean isVmemCheckEnabled() {
@@ -208,7 +213,6 @@ public class TestNMWebServices extends JerseyTestBase {
   private void setupMockPluginsWithNmResourceInfo() throws YarnException {
     ResourcePlugin mockPlugin1 = mock(ResourcePlugin.class);
     NMResourceInfo nmResourceInfo1 = new NMResourceInfo();
-    nmResourceInfo1.setResourceValue(NM_RESOURCE_VALUE);
 
     when(mockPlugin1.getNMResourceInfo()).thenReturn(nmResourceInfo1);
 
@@ -234,16 +238,29 @@ public class TestNMWebServices extends JerseyTestBase {
     List<AssignedGpuDevice> assignedGpuDevices = Arrays.asList(
         new AssignedGpuDevice(2, 2, createContainerId(1)),
         new AssignedGpuDevice(3, 3, createContainerId(2)));
+
     NMResourceInfo nmResourceInfo1 = new NMGpuResourceInfo(gpuDeviceInformation,
         totalGpuDevices,
         assignedGpuDevices);
     when(mockPlugin1.getNMResourceInfo()).thenReturn(nmResourceInfo1);
+
+    NMDeviceResourceInfo nmDeviceResourceInfo = new NMDeviceResourceInfo();
+    nmDeviceResourceInfo.setTotalDevices(Collections.singletonList(
+        Device.Builder.newInstance()
+            .setId(42)
+            .build()
+    ));
+    ResourcePlugin mockPlugin2 = mock(ResourcePlugin.class);
+    when(mockPlugin2.getNMResourceInfo()).thenReturn(nmDeviceResourceInfo);
+
+
 
     ResourcePluginManager pluginManager = createResourceManagerWithPlugins(
         ImmutableMap.<String, ResourcePlugin>builder()
             .put("resource-1", mockPlugin1)
             .put("yarn.io/resource-1", mockPlugin1)
             .put("resource-2", mock(ResourcePlugin.class))
+            .put("resource-3", mockPlugin2)
             .build()
     );
 
@@ -257,14 +274,9 @@ public class TestNMWebServices extends JerseyTestBase {
     return pluginManager;
   }
 
-  private void assertNMResourceInfoResponse(Response response, long value)
-      throws JSONException {
+  private void assertNMResourceInfoResponse(Response response) {
     assertEquals(MediaType.APPLICATION_JSON + ";" + JettyUtils.UTF_8,
-        response.getMediaType().toString(),
-        "MediaType of the response is not the expected!");
-    JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals(value, json.getJSONObject("nmResourceInfo").getLong("resourceValue"),
-        "Unexpected value in the json response!");
+        response.getMediaType().toString(), "MediaType of the response is not the expected!");
   }
 
   private void assertEmptyNMResourceInfo(Response response) throws JSONException {
@@ -523,23 +535,23 @@ public class TestNMWebServices extends JerseyTestBase {
 
   @Test
   public void testGetNMResourceInfoSuccessful()
-      throws YarnException, JSONException {
+      throws YarnException{
     setupMockPluginsWithNmResourceInfo();
 
     WebTarget r = targetWithJsonObject();
     Response response = getNMResourceResponse(r, "resource-1");
-    assertNMResourceInfoResponse(response, NM_RESOURCE_VALUE);
+    assertNMResourceInfoResponse(response);
   }
 
   @Test
   public void testGetNMResourceInfoEncodedIsSuccessful()
-      throws YarnException, JSONException {
+      throws YarnException{
     setupMockPluginsWithNmResourceInfo();
 
     //test encoded yarn.io/resource-1 path
     WebTarget r = targetWithJsonObject();
     Response response = getNMResourceResponse(r, "yarn.io%2Fresource-1");
-    assertNMResourceInfoResponse(response, NM_RESOURCE_VALUE);
+    assertNMResourceInfoResponse(response);
   }
 
   @Test
@@ -571,22 +583,37 @@ public class TestNMWebServices extends JerseyTestBase {
 
   @Test
   public void testGetYarnGpuResourceInfo()
-      throws YarnException, JSONException {
+          throws YarnException, JSONException {
     setupMockPluginsWithGpuResourceInfo();
-
     WebTarget r = targetWithJsonObject();
     Response response = getNMResourceResponse(r, "resource-1");
     assertEquals(MediaType.APPLICATION_JSON + ";" + JettyUtils.UTF_8,
-        response.getMediaType().toString(), "MediaType of the response is not the expected!");
-    JSONObject nmGpuResourceInfo = response.readEntity(JSONObject.class);
-    JSONObject json = nmGpuResourceInfo.getJSONObject("nmGpuResourceInfo");
+            response.getMediaType().toString(), "MediaType of the response is not the expected!");
+    JSONObject json = response.readEntity(JSONObject.class);
     assertEquals("1.2.3",
-        json.getJSONObject("gpuDeviceInformation").getString("driver_version"),
-        "Unexpected driverVersion in the json response!");
+            json.getJSONObject("gpuDeviceInformation").getString("driver_version"),
+            "Unexpected driverVersion in the json response!");
     assertEquals(3, json.getJSONArray("totalGpuDevices").length(),
-        "Unexpected totalGpuDevices in the json response!");
+            "Unexpected totalGpuDevices in the json response!");
     assertEquals(2, json.getJSONArray("assignedGpuDevices").length(),
-        "Unexpected assignedGpuDevices in the json response!");
+            "Unexpected assignedGpuDevices in the json response!");
+  }
+
+  @Test
+  public void testGetDeviceResourceInfo()
+          throws YarnException, JSONException {
+    setupMockPluginsWithGpuResourceInfo();
+
+    WebTarget r = targetWithJsonObject();
+    Response response = getNMResourceResponse(r, "resource-3");
+    assertEquals(MediaType.APPLICATION_JSON + ";" + JettyUtils.UTF_8,
+            response.getMediaType().toString(),
+            "MediaType of the response is not the expected!");
+    JSONObject json = response.readEntity(JSONObject.class);
+    assertEquals(42,
+            json.getJSONArray("totalDevices")
+                    .getJSONObject(0)
+                    .get("id"), "Check the first Device ID");
   }
 
   @SuppressWarnings("checkstyle:methodlength")
@@ -901,32 +928,15 @@ public class TestNMWebServices extends JerseyTestBase {
 
   private List<ContainerLogsInfo> readEntity(Response response) throws JSONException {
     JSONObject jsonObject = response.readEntity(JSONObject.class);
-    Iterator<String> keys = jsonObject.keys();
     List<ContainerLogsInfo> list = new ArrayList<>();
 
-    while (keys.hasNext()) {
-      String key = keys.next();
-      JSONObject subJsonObject = jsonObject.getJSONObject(key);
-      Iterator<String> subKeys = subJsonObject.keys();
-      while (subKeys.hasNext()) {
-        String subKeyItem = subKeys.next();
-        Object object = subJsonObject.get(subKeyItem);
+    JSONArray jsonArray = jsonObject.getJSONArray("containerLogsInfo");
 
-        if (object instanceof JSONObject) {
-          JSONObject subKeyItemValue = subJsonObject.getJSONObject(subKeyItem);
-          ContainerLogsInfo containerLogsInfo = parseContainerLogsInfo(subKeyItemValue);
-          list.add(containerLogsInfo);
-        }
+    for (int i = 0; i < jsonArray.length(); i++) {
+      JSONObject subKeyItem = jsonArray.getJSONObject(i);
 
-        if(object instanceof JSONArray) {
-          JSONArray jsonArray = subJsonObject.getJSONArray(subKeyItem);
-          for (int i = 0; i < jsonArray.length(); i++) {
-            JSONObject subKeyItemValue = jsonArray.getJSONObject(i);
-            ContainerLogsInfo containerLogsInfo = parseContainerLogsInfo(subKeyItemValue);
-            list.add(containerLogsInfo);
-          }
-        }
-      }
+      ContainerLogsInfo containerLogsInfo = parseContainerLogsInfo(subKeyItem);
+      list.add(containerLogsInfo);
     }
 
     return list;
@@ -939,15 +949,18 @@ public class TestNMWebServices extends JerseyTestBase {
     String containerId = subKeyItemValue.getString("containerId");
     String nodeId = subKeyItemValue.getString("nodeId");
 
-    JSONObject containerLogInfo = subKeyItemValue.getJSONObject("containerLogInfo");
-    String fileName = containerLogInfo.getString("fileName");
-    String fileSize = containerLogInfo.getString("fileSize");
-    String lastModifiedTime = containerLogInfo.getString("lastModifiedTime");
-
     ContainerLogMeta containerLogMeta = new ContainerLogMeta(containerId, nodeId);
-    containerLogMeta.addLogMeta(fileName, fileSize, lastModifiedTime);
-    ContainerLogsInfo containerLogsInfo =
-        new ContainerLogsInfo(containerLogMeta, logAggregationType);
-    return containerLogsInfo;
+
+    JSONArray containerLogInfo = subKeyItemValue.getJSONArray("containerLogInfo");
+    for (int i = 0; i < containerLogInfo.length(); i++) {
+      JSONObject logEntry = containerLogInfo.getJSONObject(i);
+      containerLogMeta.addLogMeta(
+              logEntry.getString("fileName"),
+              logEntry.getString("fileSize"),
+              logEntry.getString("lastModifiedTime")
+      );
+    }
+
+    return new ContainerLogsInfo(containerLogMeta, logAggregationType);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
@@ -930,7 +930,9 @@ public class TestNMWebServices extends JerseyTestBase {
     JSONObject jsonObject = response.readEntity(JSONObject.class);
     List<ContainerLogsInfo> list = new ArrayList<>();
 
-    JSONArray jsonArray = jsonObject.getJSONArray("containerLogsInfo");
+    JSONArray jsonArray = jsonObject
+            .getJSONObject("containerLogsInfo")
+            .getJSONArray("containerLogInfo");
 
     for (int i = 0; i < jsonArray.length(); i++) {
       JSONObject subKeyItem = jsonArray.getJSONObject(i);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
@@ -624,7 +624,8 @@ public class TestNMWebServices extends JerseyTestBase {
         .getApplicationAttemptId();
     final ApplicationId appId = appAttemptId.getApplicationId();
     final String appIdStr = appId.toString();
-    final String filename = "logfile1";
+    final String filename1 = "logfile1";
+    final String filename2 = "logfile2";
     nmContext.getApplications().put(appId, new ApplicationImpl(null, "user",
         appId, null, nmContext));
     
@@ -634,22 +635,32 @@ public class TestNMWebServices extends JerseyTestBase {
     nmContext.getContainers().put(containerId, container);
     
     // write out log file
-    Path path = dirsHandler.getLogPathForWrite(
+    Path path1 = dirsHandler.getLogPathForWrite(
         ContainerLaunch.getRelativeContainerLogDir(
-            appIdStr, containerIdStr) + "/" + filename, false);
-    
-    File logFile = new File(path.toUri().getPath());
-    logFile.deleteOnExit();
-    if (logFile.getParentFile().exists()) {
-      FileUtils.deleteDirectory(logFile.getParentFile());
+            appIdStr, containerIdStr) + "/" + filename1, false);
+
+    File logFile1 = new File(path1.toUri().getPath());
+    logFile1.deleteOnExit();
+    if (logFile1.getParentFile().exists()) {
+      FileUtils.deleteDirectory(logFile1.getParentFile());
     }
-    assertTrue(logFile.getParentFile().mkdirs(), "Failed to create log dir");
-    PrintWriter pw = new PrintWriter(logFile);
+    assertTrue(logFile1.getParentFile().mkdirs(), "Failed to create log dir");
+    PrintWriter pw = new PrintWriter(logFile1);
     pw.print(logMessage);
     pw.close();
 
+    Path path2 = dirsHandler.getLogPathForWrite(
+            ContainerLaunch.getRelativeContainerLogDir(
+                    appIdStr, containerIdStr) + "/" + filename2, false);
+
+    File logFile2 = new File(path2.toUri().getPath());
+    logFile2.deleteOnExit();
+    PrintWriter pw2 = new PrintWriter(logFile2);
+    pw2.print("This is a second log file to force JSON array serialization.");
+    pw2.close();
+
     // ask for it
-    Response response = target.path(filename)
+    Response response = target.path(filename1)
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     String responseText = response.readEntity(String.class);
     String responseLogMessage = getLogContext(responseText);
@@ -659,7 +670,7 @@ public class TestNMWebServices extends JerseyTestBase {
     // specify how many bytes we should get from logs
     // specify a position number, it would get the first n bytes from
     // container log
-    response = target.path(filename)
+    response = target.path(filename1)
         .queryParam("size", "5")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -672,7 +683,7 @@ public class TestNMWebServices extends JerseyTestBase {
 
     // specify the bytes which is larger than the actual file size,
     // we would get the full logs
-    response = target.path(filename)
+    response = target.path(filename1)
         .queryParam("size", "10000")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -682,7 +693,7 @@ public class TestNMWebServices extends JerseyTestBase {
 
     // specify a negative number, it would get the last n bytes from
     // container log
-    response = target.path(filename)
+    response = target.path(filename1)
         .queryParam("size", "-5")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -693,7 +704,7 @@ public class TestNMWebServices extends JerseyTestBase {
         responseLogMessage);
     assertTrue(fullTextSize >= responseLogMessage.getBytes().length);
 
-    response = target.path(filename)
+    response = target.path(filename1)
         .queryParam("size", "-10000")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -703,7 +714,7 @@ public class TestNMWebServices extends JerseyTestBase {
     assertEquals(logMessage, responseLogMessage);
 
     // ask and download it
-    response = target.path(filename)
+    response = target.path(filename1)
         .queryParam("format", "octet-stream")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -714,7 +725,7 @@ public class TestNMWebServices extends JerseyTestBase {
         response.getMediaType().toString());
 
     // specify a invalid format value
-    response = target.path(filename)
+    response = target.path(filename1)
         .queryParam("format", "123")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -743,14 +754,15 @@ public class TestNMWebServices extends JerseyTestBase {
         ContainerLogAggregationType.LOCAL.toString());
     List<ContainerLogFileInfo> logMeta = responseList.get(0)
         .getContainerLogsInfo();
-    assertEquals(1, logMeta.size());
-    assertThat(logMeta.get(0).getFileName()).isEqualTo(filename);
+    assertEquals(2, logMeta.size());
+    assertThat(logMeta.get(0).getFileName()).isEqualTo(filename1);
+    assertThat(logMeta.get(1).getFileName()).isEqualTo(filename2);
 
     // now create an aggregated log in Remote File system
     File tempLogDir = new File("target",
         TestNMWebServices.class.getSimpleName() + "temp-log-dir");
     try {
-      String aggregatedLogFile = filename + "-aggregated";
+      String aggregatedLogFile = filename1 + "-aggregated";
       String aggregatedLogMessage = "This is aggregated ;og.";
       TestContainerLogsUtils.createContainerLogFileInRemoteFS(
           nmContext.getConf(), FileSystem.get(nmContext.getConf()),
@@ -776,8 +788,9 @@ public class TestNMWebServices extends JerseyTestBase {
           assertEquals(logInfo.getLogType(),
               ContainerLogAggregationType.LOCAL.toString());
           List<ContainerLogFileInfo> meta = logInfo.getContainerLogsInfo();
-          assertEquals(1, meta.size());
-          assertThat(meta.get(0).getFileName()).isEqualTo(filename);
+          assertEquals(2, meta.size());
+          assertThat(meta.get(0).getFileName()).isEqualTo(filename1);
+          assertThat(meta.get(1).getFileName()).isEqualTo(filename2);
         }
       }
 
@@ -786,8 +799,8 @@ public class TestNMWebServices extends JerseyTestBase {
           nmContext.getConf(), FileSystem.get(nmContext.getConf()),
           tempLogDir.getAbsolutePath(), appId,
           Collections.singletonMap(containerId, aggregatedLogMessage),
-          nmContext.getNodeId(), filename, "user", true);
-      response = target.path(filename)
+          nmContext.getNodeId(), filename1, "user", true);
+      response = target.path(filename1)
           .request(MediaType.TEXT_PLAIN).get(Response.class);
       responseText = response.readEntity(String.class);
       assertTrue(responseText.contains("LogAggregationType: "
@@ -802,7 +815,7 @@ public class TestNMWebServices extends JerseyTestBase {
     // After container is completed, it is removed from nmContext
     nmContext.getContainers().remove(containerId);
     assertNull(nmContext.getContainers().get(containerId));
-    response = target.path(filename).request(MediaType.TEXT_PLAIN)
+    response = target.path(filename1).request(MediaType.TEXT_PLAIN)
         .get(Response.class);
     responseText = response.readEntity((String.class));
     assertTrue(responseText.contains(logMessage));
@@ -930,36 +943,46 @@ public class TestNMWebServices extends JerseyTestBase {
     JSONObject jsonObject = response.readEntity(JSONObject.class);
     List<ContainerLogsInfo> list = new ArrayList<>();
 
-    JSONArray jsonArray = jsonObject
-            .getJSONObject("containerLogsInfo")
-            .getJSONArray("containerLogInfo");
+    Object containerLogsTypeInfo = jsonObject.get("containerLogsInfo");
 
-    for (int i = 0; i < jsonArray.length(); i++) {
-      JSONObject subKeyItem = jsonArray.getJSONObject(i);
-
-      ContainerLogsInfo containerLogsInfo = parseContainerLogsInfo(subKeyItem);
-      list.add(containerLogsInfo);
+    if (containerLogsTypeInfo instanceof JSONArray) {
+      JSONArray containerLogsInfoArr = (JSONArray) containerLogsTypeInfo;
+      for (int i = 0; i < containerLogsInfoArr.length(); i++) {
+        list.add(parseContainerLogsInfo(containerLogsInfoArr.getJSONObject(i)));
+      }
+    } else if (containerLogsTypeInfo instanceof JSONObject) {
+      list.add(parseContainerLogsInfo((JSONObject) containerLogsTypeInfo));
     }
 
     return list;
   }
 
-  private ContainerLogsInfo parseContainerLogsInfo(JSONObject subKeyItemValue)
+  private ContainerLogsInfo parseContainerLogsInfo(JSONObject jsonLogsInfo)
       throws JSONException {
 
-    String logAggregationType = subKeyItemValue.getString("logAggregationType");
-    String containerId = subKeyItemValue.getString("containerId");
-    String nodeId = subKeyItemValue.getString("nodeId");
+    String logAggregationType = jsonLogsInfo.getString("logAggregationType");
+    String containerId = jsonLogsInfo.getString("containerId");
+    String nodeId = jsonLogsInfo.getString("nodeId");
 
     ContainerLogMeta containerLogMeta = new ContainerLogMeta(containerId, nodeId);
 
-    JSONArray containerLogInfo = subKeyItemValue.getJSONArray("containerLogInfo");
-    for (int i = 0; i < containerLogInfo.length(); i++) {
-      JSONObject logEntry = containerLogInfo.getJSONObject(i);
+    Object containerLogTypeInfo = jsonLogsInfo.get("containerLogInfo");
+    if (containerLogTypeInfo instanceof JSONArray) {
+      JSONArray containerLogInfoArr = (JSONArray) containerLogTypeInfo;
+      for (int i = 0; i < containerLogInfoArr.length(); i++) {
+        JSONObject logEntry = containerLogInfoArr.getJSONObject(i);
+        containerLogMeta.addLogMeta(
+                logEntry.getString("fileName"),
+                logEntry.getString("fileSize"),
+                logEntry.getString("lastModifiedTime")
+        );
+      }
+    } else if (containerLogTypeInfo instanceof JSONObject) {
+      JSONObject containerLogInfoObj = jsonLogsInfo.getJSONObject("containerLogInfo");
       containerLogMeta.addLogMeta(
-              logEntry.getString("fileName"),
-              logEntry.getString("fileSize"),
-              logEntry.getString("lastModifiedTime")
+              containerLogInfoObj.getString("fileName"),
+              containerLogInfoObj.getString("fileSize"),
+              containerLogInfoObj.getString("lastModifiedTime")
       );
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
@@ -624,8 +624,7 @@ public class TestNMWebServices extends JerseyTestBase {
         .getApplicationAttemptId();
     final ApplicationId appId = appAttemptId.getApplicationId();
     final String appIdStr = appId.toString();
-    final String filename1 = "logfile1";
-    final String filename2 = "logfile2";
+    final String filename = "logfile1";
     nmContext.getApplications().put(appId, new ApplicationImpl(null, "user",
         appId, null, nmContext));
     
@@ -637,7 +636,7 @@ public class TestNMWebServices extends JerseyTestBase {
     // write out log file
     Path path1 = dirsHandler.getLogPathForWrite(
         ContainerLaunch.getRelativeContainerLogDir(
-            appIdStr, containerIdStr) + "/" + filename1, false);
+            appIdStr, containerIdStr) + "/" + filename, false);
 
     File logFile1 = new File(path1.toUri().getPath());
     logFile1.deleteOnExit();
@@ -649,18 +648,8 @@ public class TestNMWebServices extends JerseyTestBase {
     pw.print(logMessage);
     pw.close();
 
-    Path path2 = dirsHandler.getLogPathForWrite(
-            ContainerLaunch.getRelativeContainerLogDir(
-                    appIdStr, containerIdStr) + "/" + filename2, false);
-
-    File logFile2 = new File(path2.toUri().getPath());
-    logFile2.deleteOnExit();
-    PrintWriter pw2 = new PrintWriter(logFile2);
-    pw2.print("This is a second log file to force JSON array serialization.");
-    pw2.close();
-
     // ask for it
-    Response response = target.path(filename1)
+    Response response = target.path(filename)
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     String responseText = response.readEntity(String.class);
     String responseLogMessage = getLogContext(responseText);
@@ -670,7 +659,7 @@ public class TestNMWebServices extends JerseyTestBase {
     // specify how many bytes we should get from logs
     // specify a position number, it would get the first n bytes from
     // container log
-    response = target.path(filename1)
+    response = target.path(filename)
         .queryParam("size", "5")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -683,7 +672,7 @@ public class TestNMWebServices extends JerseyTestBase {
 
     // specify the bytes which is larger than the actual file size,
     // we would get the full logs
-    response = target.path(filename1)
+    response = target.path(filename)
         .queryParam("size", "10000")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -693,7 +682,7 @@ public class TestNMWebServices extends JerseyTestBase {
 
     // specify a negative number, it would get the last n bytes from
     // container log
-    response = target.path(filename1)
+    response = target.path(filename)
         .queryParam("size", "-5")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -704,7 +693,7 @@ public class TestNMWebServices extends JerseyTestBase {
         responseLogMessage);
     assertTrue(fullTextSize >= responseLogMessage.getBytes().length);
 
-    response = target.path(filename1)
+    response = target.path(filename)
         .queryParam("size", "-10000")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -714,7 +703,7 @@ public class TestNMWebServices extends JerseyTestBase {
     assertEquals(logMessage, responseLogMessage);
 
     // ask and download it
-    response = target.path(filename1)
+    response = target.path(filename)
         .queryParam("format", "octet-stream")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -725,7 +714,7 @@ public class TestNMWebServices extends JerseyTestBase {
         response.getMediaType().toString());
 
     // specify a invalid format value
-    response = target.path(filename1)
+    response = target.path(filename)
         .queryParam("format", "123")
         .request(MediaType.TEXT_PLAIN).get(Response.class);
     responseText = response.readEntity(String.class);
@@ -753,21 +742,16 @@ public class TestNMWebServices extends JerseyTestBase {
     assertEquals(responseList.get(0).getLogType(),
         ContainerLogAggregationType.LOCAL.toString());
 
-    for (ContainerLogsInfo logInfo : responseList) {
-      assertEquals(logInfo.getLogType(),
-              ContainerLogAggregationType.LOCAL.toString());
-      List<ContainerLogFileInfo> logMeta = logInfo
-              .getContainerLogsInfo();
-      assertEquals(2, logMeta.size());
-      assertThat(logMeta.get(0).getFileName()).isEqualTo(filename1);
-      assertThat(logMeta.get(1).getFileName()).isEqualTo(filename2);
-    }
+    List<ContainerLogFileInfo> logMeta = responseList.get(0)
+            .getContainerLogsInfo();
+    assertEquals(1, logMeta.size());
+    assertThat(logMeta.get(0).getFileName()).isEqualTo(filename);
 
     // now create an aggregated log in Remote File system
     File tempLogDir = new File("target",
         TestNMWebServices.class.getSimpleName() + "temp-log-dir");
     try {
-      String aggregatedLogFile = filename1 + "-aggregated";
+      String aggregatedLogFile = filename + "-aggregated";
       String aggregatedLogMessage = "This is aggregated ;og.";
       TestContainerLogsUtils.createContainerLogFileInRemoteFS(
           nmContext.getConf(), FileSystem.get(nmContext.getConf()),
@@ -793,9 +777,8 @@ public class TestNMWebServices extends JerseyTestBase {
           assertEquals(logInfo.getLogType(),
               ContainerLogAggregationType.LOCAL.toString());
           List<ContainerLogFileInfo> meta = logInfo.getContainerLogsInfo();
-          assertEquals(2, meta.size());
-          assertThat(meta.get(0).getFileName()).isEqualTo(filename1);
-          assertThat(meta.get(1).getFileName()).isEqualTo(filename2);
+          assertEquals(1, meta.size());
+          assertThat(meta.get(0).getFileName()).isEqualTo(filename);
         }
       }
 
@@ -804,8 +787,8 @@ public class TestNMWebServices extends JerseyTestBase {
           nmContext.getConf(), FileSystem.get(nmContext.getConf()),
           tempLogDir.getAbsolutePath(), appId,
           Collections.singletonMap(containerId, aggregatedLogMessage),
-          nmContext.getNodeId(), filename1, "user", true);
-      response = target.path(filename1)
+          nmContext.getNodeId(), filename, "user", true);
+      response = target.path(filename)
           .request(MediaType.TEXT_PLAIN).get(Response.class);
       responseText = response.readEntity(String.class);
       assertTrue(responseText.contains("LogAggregationType: "
@@ -820,7 +803,7 @@ public class TestNMWebServices extends JerseyTestBase {
     // After container is completed, it is removed from nmContext
     nmContext.getContainers().remove(containerId);
     assertNull(nmContext.getContainers().get(containerId));
-    response = target.path(filename1).request(MediaType.TEXT_PLAIN)
+    response = target.path(filename).request(MediaType.TEXT_PLAIN)
         .get(Response.class);
     responseText = response.readEntity((String.class));
     assertTrue(responseText.contains(logMessage));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
@@ -752,11 +752,16 @@ public class TestNMWebServices extends JerseyTestBase {
     assertEquals(1, responseList.size());
     assertEquals(responseList.get(0).getLogType(),
         ContainerLogAggregationType.LOCAL.toString());
-    List<ContainerLogFileInfo> logMeta = responseList.get(0)
-        .getContainerLogsInfo();
-    assertEquals(2, logMeta.size());
-    assertThat(logMeta.get(0).getFileName()).isEqualTo(filename1);
-    assertThat(logMeta.get(1).getFileName()).isEqualTo(filename2);
+
+    for (ContainerLogsInfo logInfo : responseList) {
+      assertEquals(logInfo.getLogType(),
+              ContainerLogAggregationType.LOCAL.toString());
+      List<ContainerLogFileInfo> logMeta = logInfo
+              .getContainerLogsInfo();
+      assertEquals(2, logMeta.size());
+      assertThat(logMeta.get(0).getFileName()).isEqualTo(filename1);
+      assertThat(logMeta.get(1).getFileName()).isEqualTo(filename2);
+    }
 
     // now create an aggregated log in Remote File system
     File tempLogDir = new File("target",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AppsInfo;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider.NMJsonProvider;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
@@ -79,7 +80,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
-import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.TestProperties;
 
@@ -99,11 +99,14 @@ public class TestNMWebServicesApps extends JerseyTestBase {
 
   @Override
   protected javax.ws.rs.core.Application configure() {
+    NMJsonProvider nmJsonProvider = new NMJsonProvider();
+
     ResourceConfig config = new ResourceConfig();
     config.register(new JerseyBinder());
     config.register(NMWebServices.class);
     config.register(GenericExceptionHandler.class);
-    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    config.register(nmJsonProvider);
+    config.register(JAXBContextResolver.class);
     forceSet(TestProperties.CONTAINER_PORT, JERSEY_RANDOM_PORT);
     return config;
   }
@@ -127,18 +130,18 @@ public class TestNMWebServicesApps extends JerseyTestBase {
         @Override
         public long getVmemAllocatedForContainers() {
           // 15.5G in bytes
-          return new Long("16642998272");
+          return Long.parseLong("16642998272");
         }
 
         @Override
         public long getPmemAllocatedForContainers() {
           // 16G in bytes
-          return new Long("17179869184");
+          return Long.parseLong("17179869184");
         }
 
         @Override
         public long getVCoresAllocatedForContainers() {
-          return new Long("4000");
+          return Long.parseLong("4000");
         }
 
 
@@ -190,7 +193,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals(new JSONObject("{apps:\"\"}"), json, "apps is not empty");
+    assertEquals("{}", json.getString("apps"), "apps is not null");
   }
 
   private HashMap<String, String> addAppContainers(Application app) 
@@ -306,7 +309,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals(new JSONObject("{apps:\"\"}"), json, "apps is not empty");
+    assertEquals("{}", json.getString("apps"), "apps is not null");
   }
 
   @Test
@@ -387,7 +390,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
 
-    assertEquals(new JSONObject("{apps:\"\"}"), json, "apps is not empty");
+    assertEquals("{}", json.getString("apps"), "apps is not null");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.AuxServices;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceRecord;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider.NMJsonProvider;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
@@ -71,7 +72,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
-import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.TestProperties;
 
@@ -93,11 +93,14 @@ public class TestNMWebServicesAuxServices extends JerseyTestBase {
 
   @Override
   protected Application configure() {
+    NMJsonProvider nmJsonProvider = new NMJsonProvider();
+
     ResourceConfig config = new ResourceConfig();
     config.register(new JerseyBinder());
     config.register(NMWebServices.class);
     config.register(GenericExceptionHandler.class);
-    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    config.register(nmJsonProvider);
+    config.register(JAXBContextResolver.class);
     forceSet(TestProperties.CONTAINER_PORT, "9999");
     return config;
   }
@@ -110,18 +113,18 @@ public class TestNMWebServicesAuxServices extends JerseyTestBase {
         @Override
         public long getVmemAllocatedForContainers() {
           // 15.5G in bytes
-          return new Long("16642998272");
+          return Long.parseLong("16642998272");
         }
 
         @Override
         public long getPmemAllocatedForContainers() {
           // 16G in bytes
-          return new Long("17179869184");
+          return Long.parseLong("17179869184");
         }
 
         @Override
         public long getVCoresAllocatedForContainers() {
-          return new Long("4000");
+          return Long.parseLong("4000");
         }
 
         @Override
@@ -197,7 +200,7 @@ public class TestNMWebServicesAuxServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("{\"services\":\"\"}", json.toString(), "aux services isn't empty");
+    assertEquals("{}", json.getString("services"), "aux services isn't null");
   }
 
   private void addAuxServices(AuxServiceRecord... records) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
+import org.apache.hadoop.yarn.server.nodemanager.webapp.jsonprovider.NMJsonProvider;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
@@ -79,7 +80,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
-import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.TestProperties;
 
@@ -99,11 +99,14 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
 
   @Override
   protected javax.ws.rs.core.Application configure() {
+    NMJsonProvider nmJsonProvider = new NMJsonProvider();
+
     ResourceConfig config = new ResourceConfig();
     config.register(new JerseyBinder());
     config.register(NMWebServices.class);
     config.register(GenericExceptionHandler.class);
-    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    config.register(nmJsonProvider);
+    config.register(JAXBContextResolver.class);
     forceSet(TestProperties.CONTAINER_PORT, "9999");
     return config;
   }
@@ -116,18 +119,18 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
         @Override
         public long getVmemAllocatedForContainers() {
           // 15.5G in bytes
-          return new Long("16642998272");
+          return Long.parseLong("16642998272");
         }
 
         @Override
         public long getPmemAllocatedForContainers() {
           // 16G in bytes
-          return new Long("17179869184");
+          return Long.parseLong("17179869184");
         }
 
         @Override
         public long getVCoresAllocatedForContainers() {
-          return new Long("4000");
+          return Long.parseLong("4000");
         }
 
         @Override
@@ -202,7 +205,8 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("{\"containers\":\"\"}", json.toString(), "apps isn't empty");
+    assertEquals("{}", json.getString("containers"), "apps isn't null");
+
   }
 
   private HashMap<String, String> addAppContainers(Application app) 


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11897: Make NMWebservices API backward-compatible after Jersey 2 upgrade.


Retrieving the logs for a running application fails as the logs CLI expects a JSON object as a response when calling the NM REST API, and it provides a JSON Array

Actual response with Jersey 2:
```
[
  {
    "containerLogsInfo": {
      "containerLogInfo": [
        {
          "fileName": "stderr",
          "fileSize": "0",
          "lastModifiedTime": "Wed Nov 12 13:26:19 +0000 2025"
        },
        ...
      ],
      "logAggregationType": "LOCAL",
      "containerId": "container_e80_1762940127665_0015_01_000003",
      "nodeId": "ccycloud-2.native-moxy4.root.comops.site:8041"
    }
  }
]

```
Expected response with Jersey 1:
```
{
  "containerLogsInfo": [
    {
      "containerLogInfo": {
        "fileName": "logfile1",
        "fileSize": "12",
        "lastModifiedTime": "Thu Nov 13 13:11:14 +0100 2025"
      },
      "logAggregationType": "LOCAL",
      "containerId": "container_0_0000_00_000000",
      "nodeId": "testhost.foo.com:8042"
    },
    {
      "containerLogInfo": {
        "fileName": "logfile1-aggregated",
        "fileSize": "23",
        "lastModifiedTime": "Thu Nov 13 13:11:14 +0100 2025"
      },
      "logAggregationType": "AGGREGATED",
      "containerId": "container_0_0000_00_000000",
      "nodeId": "testhost.foo.com_8042"
    }
  ]
}
```

### How was this patch tested?
Tested on a cluster:

- Logs CLI works for running/finished applications
- UI v2 works when loading containers for a node

Response format for `/ws/v1/node/containers/{container-id}/logs` endpoint seems compatible with the Jersey 1 format comparing them with a nightly version:

**JSON**:
```
{
  "containerLogsInfo": [
    {
      "containerLogInfo": [
        {
          "fileName": "stderr",
          "fileSize": "0",
          "lastModifiedTime": "Wed Nov 19 08:40:57 +0000 2025"
        },
        {
          "fileName": "prelaunch.err",
          "fileSize": "0",
          "lastModifiedTime": "Wed Nov 19 08:40:57 +0000 2025"
        },
        {
          "fileName": "prelaunch.out",
          "fileSize": "70",
          "lastModifiedTime": "Wed Nov 19 08:40:57 +0000 2025"
        },
        {
          "fileName": "stdout",
          "fileSize": "0",
          "lastModifiedTime": "Wed Nov 19 08:40:57 +0000 2025"
        }
      ],
      "logAggregationType": "LOCAL",
      "containerId": "container_e87_1763463022925_0008_01_000003",
      "nodeId": "ccycloud-2.native-moxy4.root.comops.site:8041"
    }
  ]
}
```
**XML**:
```
<containerLogsInfoes>
   <containerLogsInfo>
      <containerLogInfo>
         <fileName>stderr</fileName>
         <fileSize>0</fileSize>
         <lastModifiedTime>Wed Nov 19 14:43:16 +0000 2025</lastModifiedTime>
      </containerLogInfo>
      <containerLogInfo>
         <fileName>prelaunch.err</fileName>
         <fileSize>0</fileSize>
         <lastModifiedTime>Wed Nov 19 14:43:16 +0000 2025</lastModifiedTime>
      </containerLogInfo>
      <containerLogInfo>
         <fileName>prelaunch.out</fileName>
         <fileSize>70</fileSize>
         <lastModifiedTime>Wed Nov 19 14:43:16 +0000 2025</lastModifiedTime>
      </containerLogInfo>
      <containerLogInfo>
         <fileName>stdout</fileName>
         <fileSize>0</fileSize>
         <lastModifiedTime>Wed Nov 19 14:43:16 +0000 2025</lastModifiedTime>
      </containerLogInfo>
      <logAggregationType>LOCAL</logAggregationType>
      <containerId>container_e88_1763555032540_0004_01_000003</containerId>
      <nodeId>ccycloud-2.native-moxy4.root.comops.site:8041</nodeId>
   </containerLogsInfo>
</containerLogsInfoes>
```


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html