### PR TITLE
HADOOP-19800: hadoop-aws, hadoop-azure and other cloud connectors don't get into common/lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,11 +138,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <module>hadoop-yarn-project</module>
     <module>hadoop-mapreduce-project</module>
     <module>hadoop-tools</module>
-    <module>hadoop-dist</module>
     <module>hadoop-minicluster</module>
     <module>hadoop-client-modules</module>
     <module>hadoop-build-tools</module>
     <module>hadoop-cloud-storage-project</module>
+    <module>hadoop-dist</module>
   </modules>
 
   <build>


### PR DESCRIPTION
### Description of PR

This is a backport of a tiny piece of HADOOP-19762 (#8147). Reorder the module list in the top-level pom.xml so that hadoop-dist is always last. Otherwise, hadoop-dist runs the dist-layout-stitching script before hadoop-cloud-storage-dist has run its assembly, so the final distribution tarball doesn't have the expected cloud storage library contents in `share/hadoop/common/lib`.

### How was this patch tested?

```
mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true  -Dhadoop-aliyun-package  -Dhadoop-aws-package  -Dhadoop-azure-datalake-package  -Dhadoop-cos-package  -Dhadoop-huaweicloud-package
```

The resulting distribution tarball contains the cloud storage jars in `share/hadoop/common/lib`.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html