### PR TITLE
YARN-11923: YARN web proxy AmIpFilter allows TRACE, bypassing sparkUI TRACE block

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmIpFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmIpFilter.java
@@ -143,7 +143,7 @@ public class AmIpFilter implements Filter {
         method.equalsIgnoreCase("TRACK"))) {
       httpResp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
       return;
-    }      
+    }
 
     LOG.debug("Remote address for request is: {}", httpReq.getRemoteAddr());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmIpFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmIpFilter.java
@@ -138,6 +138,12 @@ public class AmIpFilter implements Filter {
     HttpServletRequest httpReq = (HttpServletRequest)req;
     HttpServletResponse httpResp = (HttpServletResponse)resp;
 
+    if (httpReq.getMethod().equalsIgnoreCase("TRACE") ||
+        httpReq.getMethod().equalsIgnoreCase("TRACK")) {
+      httpResp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+      return;
+    }      
+
     LOG.debug("Remote address for request is: {}", httpReq.getRemoteAddr());
 
     if (!getProxyAddresses().contains(httpReq.getRemoteAddr())) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmIpFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmIpFilter.java
@@ -138,8 +138,9 @@ public class AmIpFilter implements Filter {
     HttpServletRequest httpReq = (HttpServletRequest)req;
     HttpServletResponse httpResp = (HttpServletResponse)resp;
 
-    if (httpReq.getMethod().equalsIgnoreCase("TRACE") ||
-        httpReq.getMethod().equalsIgnoreCase("TRACK")) {
+    String method = httpReq.getMethod();
+    if (method != null && (method.equalsIgnoreCase("TRACE") ||
+        method.equalsIgnoreCase("TRACK"))) {
       httpResp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
       return;
     }      

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilter.java
@@ -309,6 +309,46 @@ public class TestAmFilter {
 
   }
 
+  @Test
+  @Timeout(5000)
+  void testTraceAndTrackBlocked() throws Exception {
+    Map<String, String> params = new HashMap<String, String>();
+    params.put(AmIpFilter.PROXY_HOST, proxyHost);
+    params.put(AmIpFilter.PROXY_URI_BASE, proxyUri);
+    FilterConfig config = new DummyFilterConfig(params);
+
+    AmIpFilter testFilter = new AmIpFilter();
+    testFilter.init(config);
+
+    final AtomicBoolean chainCalled = new AtomicBoolean(false);
+    FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest servletRequest,
+          ServletResponse servletResponse) throws IOException, ServletException {
+        chainCalled.set(true);
+      }
+    };
+
+    HttpServletResponseForTest response = new HttpServletResponseForTest();
+
+    HttpServletRequest traceRequest = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(traceRequest.getMethod()).thenReturn("TRACE");
+    Mockito.when(traceRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+    testFilter.doFilter(traceRequest, response, chain);
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED, response.status);
+    assertFalse(chainCalled.get());
+
+    response.status = 0;
+    chainCalled.set(false);
+
+    HttpServletRequest trackRequest = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(trackRequest.getMethod()).thenReturn("TRACK");
+    Mockito.when(trackRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+    testFilter.doFilter(trackRequest, response, chain);
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED, response.status);
+    assertFalse(chainCalled.get());
+  }
+
   private class HttpServletResponseForTest implements HttpServletResponse {
     String redirectLocation = "";
     int status;
@@ -368,12 +408,12 @@ public class TestAmFilter {
 
     @Override
     public void sendError(int sc, String msg) throws IOException {
-
+      this.status = sc;
     }
 
     @Override
     public void sendError(int sc) throws IOException {
-
+      this.status = sc;
     }
 
     @Override


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html