### PR TITLE
HADOOP-19805. S3A: When creating a signer, if it is Configurable, set its config

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/SignerFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/SignerFactory.java
@@ -35,10 +35,12 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.impl.InstantiationIOException;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_CLASS_NAME;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.unavailable;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
@@ -100,15 +102,17 @@ public final class SignerFactory {
 
   /**
    * Create an instance of the given signer.
-   *
+   * If a signer is Configurable, call setConf on it with the passed in config.
    * @param signerType The signer type.
+   * @param conf configuration to init with
    * @param configKey Config key used to configure the signer.
    * @return The new signer instance.
    * @throws InstantiationIOException instantiation problems.
    * @throws IOException on any other problem.
    *
    */
-  public static Signer createSigner(String signerType, String configKey) throws IOException {
+  public static Signer createSigner(String signerType, final Configuration conf, String configKey)
+      throws IOException {
     if (S3_V2_SIGNER.equals(signerType)) {
       throw unavailable(null, null, configKey, S3_V2_SIGNER + " is no longer supported");
     }
@@ -124,7 +128,10 @@ public final class SignerFactory {
     Signer signer =
         S3AUtils.getInstanceFromReflection(className, null, null, Signer.class, "create",
             configKey);
-
+    requireNonNull(conf);
+    if (signer instanceof Configurable sc) {
+      sc.setConf(conf);
+    }
     return signer;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -132,7 +132,7 @@ public final class AWSClientConfig {
     if (!signer.isEmpty()) {
       LOG.debug("Signer override = {}", signer);
       overrideConfigBuilder.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
-          SignerFactory.createSigner(signer, SIGNING_ALGORITHM));
+          SignerFactory.createSigner(signer, conf, SIGNING_ALGORITHM));
     }
 
     initSigner(conf, overrideConfigBuilder, awsServiceIdentifier);
@@ -415,7 +415,7 @@ public final class AWSClientConfig {
       if (!signerOverride.isEmpty()) {
         LOG.debug("Signer override for {} = {}", awsServiceIdentifier, signerOverride);
         clientConfig.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
-            SignerFactory.createSigner(signerOverride, configKey));
+            SignerFactory.createSigner(signerOverride, conf, configKey));
       }
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileSystem;
@@ -205,6 +206,9 @@ public class ITestCustomSigner extends AbstractS3ATestBase {
           .as("Configuration TEST_KEY mismatch in %s", CustomSigner.description())
           .isEqualTo(identifier);
 
+      Assertions.assertThat(CustomSigner.getLastConfiguration())
+          .isSameAs(fs.getConf());
+
       // now do some more operations to make sure all is good.
       final Path subdir = new Path(finalPath, "year=1970/month=1/day=1");
       fs.mkdirs(subdir);
@@ -269,8 +273,8 @@ public class ITestCustomSigner extends AbstractS3ATestBase {
   }
 
   @Private
-  public static final class CustomSigner extends AbstractAwsS3V4Signer implements Signer {
-
+  public static final class CustomSigner extends AbstractAwsS3V4Signer implements Signer,
+      Configurable {
 
     private static final AtomicInteger INSTANTIATION_COUNT =
         new AtomicInteger(0);
@@ -279,9 +283,25 @@ public class ITestCustomSigner extends AbstractS3ATestBase {
 
     private static StoreValue lastStoreValue;
 
+    private static Configuration lastConfiguration;
+
     public CustomSigner() {
       int c = INSTANTIATION_COUNT.incrementAndGet();
       LOG.info("Creating Signer #{}", c);
+    }
+
+    @Override
+    public void setConf(final Configuration conf) {
+      lastConfiguration = conf;
+    }
+
+    @Override
+    public Configuration getConf() {
+      return lastConfiguration;
+    }
+
+    public static Configuration getLastConfiguration() {
+      return lastConfiguration;
     }
 
     /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestSignerManager.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestSignerManager.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -33,7 +34,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.s3a.auth.TestSignerManager.SignerInitializerForTest.StoreValue;
 import org.apache.hadoop.fs.s3a.auth.delegation.DelegationTokenProvider;
 import org.apache.hadoop.fs.s3a.impl.InstantiationIOException;
@@ -93,7 +96,7 @@ public class TestSignerManager extends AbstractHadoopTestBase {
     signerManager.initCustomSigners();
     // Simulate a call from the AWS SDK to create the signer.
     intercept(InstantiationIOException.class,
-        () -> SignerFactory.createSigner("testsignerUnregistered", null));
+        () -> SignerFactory.createSigner("testsignerUnregistered", config, null));
   }
 
   @Test
@@ -103,7 +106,11 @@ public class TestSignerManager extends AbstractHadoopTestBase {
     SignerManager signerManager = new SignerManager("dontcare", null, config,
         UserGroupInformation.getCurrentUser());
     signerManager.initCustomSigners();
-    Signer s1 = SignerFactory.createSigner("testsigner1", null);
+    Signer s1 = SignerFactory.createSigner("testsigner1", config, null);
+    Configurable cs1 = (Configurable) s1;
+    Assertions.assertThat(cs1.getConf())
+        .describedAs("Configuration of %s", s1)
+        .isSameAs(config);
     s1.sign(null, null);
     assertThat(SignerForTest1.initialized)
         .as(SignerForTest1.class.getName() + " not initialized")
@@ -119,13 +126,13 @@ public class TestSignerManager extends AbstractHadoopTestBase {
     SignerManager signerManager = new SignerManager("dontcare", null, config,
         UserGroupInformation.getCurrentUser());
     signerManager.initCustomSigners();
-    Signer s1 = SignerFactory.createSigner("testsigner1", null);
+    Signer s1 = SignerFactory.createSigner("testsigner1", config, null);
     s1.sign(null, null);
     assertThat(SignerForTest1.initialized)
         .as(SignerForTest1.class.getName() + " not initialized")
         .isEqualTo(true);
 
-    Signer s2 = SignerFactory.createSigner("testsigner2", null);
+    Signer s2 = SignerFactory.createSigner("testsigner2", config, null);
     s2.sign(null, null);
     assertThat(SignerForTest2.initialized)
         .as(SignerForTest2.class.getName() + " not initialized")
@@ -321,7 +328,7 @@ public class TestSignerManager extends AbstractHadoopTestBase {
    * SignerForTest1.
    */
   @Private
-  public static class SignerForTest1 implements Signer {
+  public static final class SignerForTest1 extends Configured implements Signer {
 
     private static boolean initialized = false;
 
@@ -586,13 +593,13 @@ public class TestSignerManager extends AbstractHadoopTestBase {
   @Test
   public void testV2SignerRejected() throws Throwable {
     intercept(InstantiationIOException.class, "no longer supported",
-        () -> SignerFactory.createSigner(S3_V2_SIGNER, "key"));
+        () -> SignerFactory.createSigner(S3_V2_SIGNER, new Configuration(), "key"));
   }
 
   @Test
   public void testUnknownSignerRejected() throws Throwable {
     intercept(InstantiationIOException.class, "unknownSigner",
-        () -> SignerFactory.createSigner("unknownSigner", "key"));
+        () -> SignerFactory.createSigner("unknownSigner", new Configuration(), "key"));
   }
 
 }


### PR DESCRIPTION


This makes it a lot easier to configure a signer, rather than the full AwsSignerInitializer interface, which is only applied when you have a chain of custom signers.


### How was this patch tested?

S3 london

* all tests have passed.
* this shows that branch-3.4 is lacking; there's one commit I will pull in and should have already #8118 ; dir marker and yarn stuff I'm going to neglect.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

no ai: humans shall be free!