### PR TITLE
Revert "YARN-11726: Add logging statements for successful and unsucce…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -533,14 +533,10 @@ public class WebAppUtils {
       char[] passchars = conf.getPassword(alias);
       if (passchars != null) {
         password = new String(passchars);
-        LOG.debug("Successful password retrival for alias: {}", alias);
-      } else {
-        LOG.warn("Password retrieval failed, no password found for alias: {}", alias);
       }
     }
     catch (IOException ioe) {
       password = null;
-      LOG.error("Unable to retrieve password for alias: {}", alias, ioe);
     }
     return password;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/util/TestWebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/util/TestWebAppUtils.java
@@ -110,16 +110,6 @@ public class TestWebAppUtils {
   }
 
   @Test
-  void testGetPasswordIOException() throws Exception {
-    Configuration mockConf = Mockito.mock(Configuration.class);
-
-    Mockito.when(mockConf.getPassword("error-alias"))
-            .thenThrow(new IOException("Simulated IO error"));
-
-    assertNull(WebAppUtils.getPassword(mockConf, "error-alias"));
-  }
-
-  @Test
   void testLoadSslConfiguration() throws Exception {
     Configuration conf = provisionCredentialsForSSL();
     TestBuilder builder = (TestBuilder) new TestBuilder();


### PR DESCRIPTION
…ssful pa…"

This reverts commit c902faaef8b003843485350e330188a0ea32768a.

Upon further checking the jira and the creator, the intent behind these jiras are questionable: https://issues.apache.org/jira/issues/?jql=creator%20in%20(loggingresearch). Reverting until proper explanation behind this ticket.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html