### PR TITLE
HADOOP-19181. S3A: IAMCredentialsProvider throttling results in auth failures (#8118)

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/IAMInstanceCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/IAMInstanceCredentialsProvider.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a.auth;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Duration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,12 @@ public class IAMInstanceCredentialsProvider
 
   private static final Logger LOG =
       LoggerFactory.getLogger(IAMInstanceCredentialsProvider.class);
+
+  /**
+   * How far in advance of credential expiry must IAM credentials be refreshed.
+   * See HADOOP-19181. S3A: IAMCredentialsProvider throttling results in AWS auth failures
+   */
+  public static final Duration TIME_BEFORE_EXPIRY = Duration.ofMinutes(5);
 
   /**
    * The credentials provider.
@@ -130,8 +137,12 @@ public class IAMInstanceCredentialsProvider
         // close it to shut down any thread
         iamCredentialsProvider.close();
         isContainerCredentialsProvider = false;
+
+        // create an async credentials provider with a safe credential
+        // expiry time.
         iamCredentialsProvider = InstanceProfileCredentialsProvider.builder()
                 .asyncCredentialUpdateEnabled(true)
+                .staleTime(TIME_BEFORE_EXPIRY)
                 .build();
         return iamCredentialsProvider.resolveCredentials();
       } else {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
@@ -55,11 +55,13 @@ import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider;
 import org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory;
 import org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider;
 import org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException;
+import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
 import org.apache.hadoop.fs.s3a.auth.ProfileAWSCredentialsProvider;
 import org.apache.hadoop.fs.s3a.auth.delegation.CountInvocationsProvider;
 import org.apache.hadoop.fs.s3a.impl.InstantiationIOException;
 import org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils;
 import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.test.HadoopTestBase;
 import org.apache.hadoop.util.Sets;
 
 import static org.apache.hadoop.fs.s3a.Constants.ASSUMED_ROLE_CREDENTIALS_PROVIDER;
@@ -79,7 +81,7 @@ import static org.apache.hadoop.util.StringUtils.STRING_COLLECTION_SPLIT_EQUALS_
 /**
  * Unit tests for {@link Constants#AWS_CREDENTIALS_PROVIDER} logic.
  */
-public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
+public class TestS3AAWSCredentialsProvider extends HadoopTestBase {
 
   /**
    * URI of the test file: this must be anonymously accessible.
@@ -911,4 +913,19 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
     }
   }
 
+  @Test
+  public void testIAMInstanceCredentialsProvider() throws Throwable {
+
+    final Configuration conf =
+        createProviderConfiguration(IAMInstanceCredentialsProvider.class);
+    Path testFile = getExternalData(conf);
+    try (AWSCredentialProviderList list = createAWSCredentialProviderList(testFile.toUri(), conf)) {
+      try {
+        list.resolveCredentials();
+      } catch (NoAwsCredentialsException e) {
+        ///  this is OK.
+      }
+
+    }
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -100,6 +100,8 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
   private static final Statement STATEMENT_ALL_BUCKET_READ_ACCESS
       = statement(true, S3_ALL_BUCKETS, S3_BUCKET_READ_OPERATIONS);
 
+  public static final String MALFORMED_POLICY_DOCUMENT = "MalformedPolicyDocument";
+
   /**
    * test URI, built in setup.
    */
@@ -240,13 +242,13 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
 
   @Test
   public void testAssumeRoleFSBadPolicy() throws Exception {
-    describe("Attemnpt to create the FS with malformed JSON");
+    describe("Attempt to create the FS with malformed JSON");
     Configuration conf = createAssumedRoleConfig();
     // add some malformed JSON
     conf.set(ASSUMED_ROLE_POLICY,  "}");
     expectFileSystemCreateFailure(conf,
         AWSBadRequestException.class,
-        "JSON");
+        MALFORMED_POLICY_DOCUMENT);
   }
 
   @Test
@@ -257,7 +259,7 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     conf.set(ASSUMED_ROLE_POLICY, "{'json':'but not what AWS wants}");
     expectFileSystemCreateFailure(conf,
         AWSBadRequestException.class,
-        "Syntax errors in policy");
+        MALFORMED_POLICY_DOCUMENT);
   }
 
   @Test


### PR DESCRIPTION

Hard-code a 15 minute  advance time for credential renewal, so even if a large number of processes simultaneously trying to renew their tokens through IAM requests may trigger throttling, the asynchronous refresh thread has minutes of backoff and retry before the existing credentials become invalid.

+ Add a test case to explicitly instantiate the class and ask for credentials doesn't care about whether credentials are returned (EC2 runs) or if NoAwsCredentialsException is returned -any other exception is raised as a failure.
+ Make test suite subclass of HadoopTestBase to avoid instantiating s3a fs.

Contains HADOOP-19748: S3A: ITestAssumeRole tests failing now STS returns detailed
 error messages


(This is a backport which I thought I'd already applied; will merge once yetus is happy)


### How was this patch tested?

s3 london; fixes all the assume role test failures


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html