### PR TITLE
HADOOP-19807. Enable cross-platform support for dev container

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -29,7 +29,17 @@ This requires a recent version of docker (1.4.1 and higher are known to work).
 On Linux / Mac:
     Install Docker and run this command:
 
-    $ ./start-build-env.sh [OS platform]
+    $ [CPU_ARCH=<arch>] ./start-build-env.sh [OS platform]
+
+   - [CPU_ARCH=<arch>] One of [x86_64, amd64, aarch64, arm64].
+        Default is output of 'uname -m'. Set to 'x86_64' on arm machine
+        (e.g. Apple M1) to create an x86_64 container.
+        Note:
+          CPU arch emulation may have significant performance overhead.
+          To enable cross-platform container support, run this command first:
+          $ docker run --rm --privileged tonistiigi/binfmt --install amd64,arm64
+          To run an x86_64 container on arm machine, use this command:
+          $ CPU_ARCH=x86_64 ./start-build-env.sh ubuntu_24
 
    - [OS Platform] One of [rockylinux_8, debian_11, debian_12, debian_13, ubuntu_20, ubuntu_24, windows_10].
         Default is 'ubuntu_24'.

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -25,6 +25,7 @@ OS_PLATFORM="${1:-}"
 DEFAULT_OS_PLATFORM="ubuntu_24"
 
 OS_PLATFORM_SUFFIX=""
+DOCKER_PLATFORM_ARGS=""
 
 if [[ -n ${OS_PLATFORM} ]]; then
   OS_PLATFORM_SUFFIX="_${OS_PLATFORM}"
@@ -35,9 +36,12 @@ fi
 DOCKER_DIR=dev-support/docker
 DOCKER_FILE="${DOCKER_DIR}/Dockerfile${OS_PLATFORM_SUFFIX}"
 
-CPU_ARCH=$(echo "$MACHTYPE" | cut -d- -f1)
-if [[ "$CPU_ARCH" == "aarch64" || "$CPU_ARCH" == "arm64" ]]; then
+CPU_ARCH=${CPU_ARCH:-$(uname -m)}
+if [[ "$CPU_ARCH" == "x86_64" || "$CPU_ARCH" == "amd64" ]]; then
+  DOCKER_PLATFORM_ARGS="--platform linux/amd64"
+elif [[ "$CPU_ARCH" == "aarch64" || "$CPU_ARCH" == "arm64" ]]; then
   DOCKER_FILE="${DOCKER_DIR}/Dockerfile${OS_PLATFORM_SUFFIX}_aarch64"
+  DOCKER_PLATFORM_ARGS="--platform linux/arm64"
 fi
 
 if [ ! -e "${DOCKER_FILE}" ] ; then
@@ -45,7 +49,7 @@ if [ ! -e "${DOCKER_FILE}" ] ; then
   exit 1
 fi
 
-docker build -t hadoop-build -f $DOCKER_FILE $DOCKER_DIR
+docker build ${DOCKER_PLATFORM_ARGS} -t hadoop-build -f $DOCKER_FILE $DOCKER_DIR
 
 USER_NAME=${SUDO_USER:=$USER}
 USER_ID=$(id -u "${USER_NAME}")
@@ -87,7 +91,7 @@ fi
 # Set the home directory in the Docker container.
 DOCKER_HOME_DIR=${DOCKER_HOME_DIR:-/home/${USER_NAME}}
 
-docker build -t "hadoop-build${OS_PLATFORM_SUFFIX}-${USER_ID}" - <<UserSpecificDocker
+docker build ${DOCKER_PLATFORM_ARGS} -t "hadoop-build${OS_PLATFORM_SUFFIX}-${USER_ID}" - <<UserSpecificDocker
 FROM hadoop-build
 RUN rm -f /var/log/faillog /var/log/lastlog
 RUN userdel -r \$(getent passwd ${USER_ID} | cut -d: -f1) 2>/dev/null || :
@@ -106,7 +110,7 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
-docker run --rm=true $DOCKER_INTERACTIVE_RUN \
+docker run ${DOCKER_PLATFORM_ARGS} --rm=true ${DOCKER_INTERACTIVE_RUN} \
   -v "${PWD}:${DOCKER_HOME_DIR}/hadoop${V_OPTS:-}" \
   -w "${DOCKER_HOME_DIR}/hadoop" \
   -v "${HOME}/.m2:${DOCKER_HOME_DIR}/.m2${V_OPTS:-}" \

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -49,6 +49,7 @@ if [ ! -e "${DOCKER_FILE}" ] ; then
   exit 1
 fi
 
+# shellcheck disable=SC2086
 docker build ${DOCKER_PLATFORM_ARGS} -t hadoop-build -f "${DOCKER_FILE}" "${DOCKER_DIR}"
 
 USER_NAME=${SUDO_USER:=$USER}
@@ -91,6 +92,7 @@ fi
 # Set the home directory in the Docker container.
 DOCKER_HOME_DIR=${DOCKER_HOME_DIR:-/home/${USER_NAME}}
 
+# shellcheck disable=SC2086
 docker build ${DOCKER_PLATFORM_ARGS} -t "hadoop-build${OS_PLATFORM_SUFFIX}-${USER_ID}" - <<UserSpecificDocker
 FROM hadoop-build
 RUN rm -f /var/log/faillog /var/log/lastlog
@@ -110,6 +112,7 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
+# shellcheck disable=SC2086
 docker run ${DOCKER_PLATFORM_ARGS} --rm=true ${DOCKER_INTERACTIVE_RUN} \
   -v "${PWD}:${DOCKER_HOME_DIR}/hadoop${V_OPTS:-}" \
   -w "${DOCKER_HOME_DIR}/hadoop" \

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -49,7 +49,7 @@ if [ ! -e "${DOCKER_FILE}" ] ; then
   exit 1
 fi
 
-docker build ${DOCKER_PLATFORM_ARGS} -t hadoop-build -f $DOCKER_FILE $DOCKER_DIR
+docker build ${DOCKER_PLATFORM_ARGS} -t hadoop-build -f "${DOCKER_FILE}" "${DOCKER_DIR}"
 
 USER_NAME=${SUDO_USER:=$USER}
 USER_ID=$(id -u "${USER_NAME}")
@@ -102,7 +102,7 @@ ENV HOME="${DOCKER_HOME_DIR}"
 
 UserSpecificDocker
 
-#If this env varible is empty, docker will be started
+# If this env variable is empty, docker will be started
 # in non interactive mode
 DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -110,6 +110,7 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
+# shellcheck disable=SC2086
 docker run "${DOCKER_PLATFORM_ARGS[@]}" --rm=true ${DOCKER_INTERACTIVE_RUN} \
   -v "${PWD}:${DOCKER_HOME_DIR}/hadoop${V_OPTS:-}" \
   -w "${DOCKER_HOME_DIR}/hadoop" \

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -25,7 +25,7 @@ OS_PLATFORM="${1:-}"
 DEFAULT_OS_PLATFORM="ubuntu_24"
 
 OS_PLATFORM_SUFFIX=""
-DOCKER_PLATFORM_ARGS=""
+DOCKER_PLATFORM_ARGS=()
 
 if [[ -n ${OS_PLATFORM} ]]; then
   OS_PLATFORM_SUFFIX="_${OS_PLATFORM}"
@@ -38,10 +38,10 @@ DOCKER_FILE="${DOCKER_DIR}/Dockerfile${OS_PLATFORM_SUFFIX}"
 
 CPU_ARCH=${CPU_ARCH:-$(uname -m)}
 if [[ "$CPU_ARCH" == "x86_64" || "$CPU_ARCH" == "amd64" ]]; then
-  DOCKER_PLATFORM_ARGS="--platform linux/amd64"
+  DOCKER_PLATFORM_ARGS=("--platform" "linux/amd64")
 elif [[ "$CPU_ARCH" == "aarch64" || "$CPU_ARCH" == "arm64" ]]; then
   DOCKER_FILE="${DOCKER_DIR}/Dockerfile${OS_PLATFORM_SUFFIX}_aarch64"
-  DOCKER_PLATFORM_ARGS="--platform linux/arm64"
+  DOCKER_PLATFORM_ARGS=("--platform" "linux/arm64")
 fi
 
 if [ ! -e "${DOCKER_FILE}" ] ; then
@@ -49,8 +49,7 @@ if [ ! -e "${DOCKER_FILE}" ] ; then
   exit 1
 fi
 
-# shellcheck disable=SC2086
-docker build ${DOCKER_PLATFORM_ARGS} -t hadoop-build -f "${DOCKER_FILE}" "${DOCKER_DIR}"
+docker build "${DOCKER_PLATFORM_ARGS[@]}" -t hadoop-build -f "${DOCKER_FILE}" "${DOCKER_DIR}"
 
 USER_NAME=${SUDO_USER:=$USER}
 USER_ID=$(id -u "${USER_NAME}")
@@ -92,8 +91,7 @@ fi
 # Set the home directory in the Docker container.
 DOCKER_HOME_DIR=${DOCKER_HOME_DIR:-/home/${USER_NAME}}
 
-# shellcheck disable=SC2086
-docker build ${DOCKER_PLATFORM_ARGS} -t "hadoop-build${OS_PLATFORM_SUFFIX}-${USER_ID}" - <<UserSpecificDocker
+docker build "${DOCKER_PLATFORM_ARGS[@]}" -t "hadoop-build${OS_PLATFORM_SUFFIX}-${USER_ID}" - <<UserSpecificDocker
 FROM hadoop-build
 RUN rm -f /var/log/faillog /var/log/lastlog
 RUN userdel -r \$(getent passwd ${USER_ID} | cut -d: -f1) 2>/dev/null || :
@@ -112,8 +110,7 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
-# shellcheck disable=SC2086
-docker run ${DOCKER_PLATFORM_ARGS} --rm=true ${DOCKER_INTERACTIVE_RUN} \
+docker run "${DOCKER_PLATFORM_ARGS[@]}" --rm=true ${DOCKER_INTERACTIVE_RUN} \
   -v "${PWD}:${DOCKER_HOME_DIR}/hadoop${V_OPTS:-}" \
   -w "${DOCKER_HOME_DIR}/hadoop" \
   -v "${HOME}/.m2:${DOCKER_HOME_DIR}/.m2${V_OPTS:-}" \


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR enables cross-platform support for the dev container, the most useful case: allow running an x86_64 container on the Apple M1 platform.

### How was this patch tested?

To enable cross-platform container support, run this command first:
```
$ docker run --rm --privileged tonistiigi/binfmt --install amd64,arm64
```

Test the cross-platform container capability
```
$ docker run --rm -it --platform linux/amd64 busybox uname -m
x86_64
$ docker run --rm -it --platform linux/arm64 busybox uname -m
aarch64
```

Test launch an x86_64 dev container on M1 Mac
```
$ CPU_ARCH=x86_64 ./start-build-env.sh ubuntu_24
...
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

I write it by hand, no AI usage.