### PR TITLE
HADOOP-19808. Jenkins switch from Debian 11 to Debian 13

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -91,10 +91,10 @@ pipeline {
                     '''
                 }
 
-                dir("${WORKSPACE}/debian-11") {
+                dir("${WORKSPACE}/debian-13") {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-11
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/debian-13
                     '''
                 }
 
@@ -157,12 +157,12 @@ pipeline {
         // C++/C++ build/platform.
         // This stage serves as a means of cross platform validation, which is
         // really needed to ensure that any C++ related/platform change doesn't
-        // break the Hadoop build on Debian 11.
-        stage ('precommit-run Debian 11') {
+        // break the Hadoop build on Debian 13.
+        stage ('precommit-run Debian 13') {
             environment {
-                SOURCEDIR = "${WORKSPACE}/debian-11/src"
-                PATCHDIR = "${WORKSPACE}/debian-11/out"
-                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_11"
+                SOURCEDIR = "${WORKSPACE}/debian-13/src"
+                PATCHDIR = "${WORKSPACE}/debian-13/out"
+                DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile_debian_13"
                 IS_OPTIONAL = 1
             }
 
@@ -182,7 +182,7 @@ pipeline {
                 failure {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp "${WORKSPACE}/debian-11/out" "${WORKSPACE}"
+                    cp -Rp "${WORKSPACE}/debian-13/out" "${WORKSPACE}"
                     '''
                     archiveArtifacts "out/**"
                 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Debian 11 is going to be EOLed at Aug 2026, move to latest Debian 13.

https://endoflife.date/debian

### How was this patch tested?

Wait for CI reports.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used: No.