### PR TITLE
HADOOP-19798. (Followup) Fix rat license check failures

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
@@ -75,9 +75,13 @@
             <exclude>src/main/webapp/jsconfig.json</exclude>
             <exclude>src/main/webapp/bower.json</exclude>
             <exclude>src/main/webapp/bower-shrinkwrap.json</exclude>
+            <exclude>src/main/webapp/bower_components/**</exclude>
+            <exclude>src/main/webapp/dist/**</exclude>
+            <exclude>src/main/webapp/node_modules/**</exclude>
             <exclude>src/main/webapp/package.json</exclude>
             <exclude>src/main/webapp/yarn.lock</exclude>
             <exclude>src/main/webapp/testem.json</exclude>
+            <exclude>src/main/webapp/testem.log</exclude>
             <exclude>src/main/webapp/public/assets/images/**/*</exclude>
             <exclude>src/main/webapp/public/assets/images/*</exclude>
             <exclude>src/main/webapp/public/robots.txt</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -613,6 +613,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
             <exclude>.idea/**</exclude>
             <exclude>.mvn/*.config</exclude>
             <exclude>**/build/**</exclude>
+            <exclude>**/dependency-reduced-pom.xml</exclude>
             <exclude>**/patchprocess/**</exclude>
             <exclude>**/*.js</exclude>
             <exclude>licenses/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
             <exclude>.git/**</exclude>
             <exclude>.github/pull_request_template.md</exclude>
             <exclude>.idea/**</exclude>
+            <exclude>.mvn/*.config</exclude>
             <exclude>**/build/**</exclude>
             <exclude>**/patchprocess/**</exclude>
             <exclude>**/*.js</exclude>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Exclude `.mvn/*.config` (`maven.config`, `jvm.config`) from rat check list.

https://maven.apache.org/configure.html

---
Update: exclude some other build output to pass the rat license check.

### How was this patch tested?

```
$ ./mvnw apache-rat:check
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.852 s
[INFO] Finished at: 2026-02-07T19:49:26+08:00
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No usage.