### PR TITLE
HDFS-17874. Followup: Fix java8 and a typo in the test case

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/NodePlan.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/NodePlan.java
@@ -251,5 +251,5 @@ public class NodePlan {
         .map(String::trim)
         .filter(s -> !s.isEmpty())
         .collect(Collectors.toList());
- }
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/NodePlan.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/NodePlan.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.SUPPORTED_PACKAGES_CONFIG_NAME;
 
@@ -194,7 +195,7 @@ public class NodePlan {
         Map.Entry<String, JsonNode> entry = fieldsIterator.next();
         if ("@class".equals(entry.getKey())) {
           String textValue = entry.getValue().asText();
-          if (textValue != null && !textValue.isBlank() && !stepClassIsAllowed(textValue)) {
+          if (textValue != null && !textValue.isEmpty() && !stepClassIsAllowed(textValue)) {
             throw new IOException("Invalid @class value in NodePlan JSON: " + textValue);
           }
         }
@@ -249,6 +250,6 @@ public class NodePlan {
         .stream()
         .map(String::trim)
         .filter(s -> !s.isEmpty())
-        .toList();
-  }
+        .collect(Collectors.toList());
+ }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
@@ -18,7 +18,7 @@ package org.apache.hadoop.hdfs.server.diskbalancer.planner;
 
 import java.io.IOException;
 
-timport org.junit.Test;
+import org.junit.Test;
 import sample.SampleStep;
 
 import com.fasterxml.jackson.annotation.JsonProperty;


### PR DESCRIPTION

Each of these broke the branch-3.4 build

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html