### PR TITLE
HDFS-17880 TreeWalk should add element to the last position

### DIFF
--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreeWalk.java
@@ -77,7 +77,7 @@ public abstract class TreeWalk implements Iterable<TreePath> {
 
     protected void onAccept(TreePath p, long id) {
       for (TreePath k : getChildren(p, id, this)) {
-        pending.addFirst(k);
+        pending.addLast(k);
       }
     }
 


### PR DESCRIPTION

### Description of PR
The elements in FsDirectory are in  alphabetical order. The new element should add to the last of queue.

### How was this patch tested?
The existing testcases.
