### PR TITLE
MAPREDUCE-7525. Improve TestDFSIO to support different InputFormat

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -537,7 +537,9 @@ public class TestDFSIO implements Tool {
     JobConf job = new JobConf(config, TestDFSIO.class);
 
     FileInputFormat.setInputPaths(job, getControlDir(config));
-    job.setInputFormat(SequenceFileInputFormat.class);
+    if (null == job.getClass("mapred.input.format.class", null)) {
+        job.setInputFormat(SequenceFileInputFormat.class);
+    }
 
     job.setMapperClass(mapperClass);
     job.setReducerClass(AccumulatingReducer.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -538,7 +538,7 @@ public class TestDFSIO implements Tool {
 
     FileInputFormat.setInputPaths(job, getControlDir(config));
     if (null == job.getClass("mapred.input.format.class", null)) {
-        job.setInputFormat(SequenceFileInputFormat.class);
+      job.setInputFormat(SequenceFileInputFormat.class);
     }
 
     job.setMapperClass(mapperClass);


### PR DESCRIPTION

### Description of PR

Currently, the TestDFSIO benchmark hardcodes the InputFormat to SequenceFileInputFormat.class in the runIOTest method. This limits flexibility for users who want to test different InputFormat implementations' performance, particularly CombineSequenceFileInputFormat which is essential for handling small file scenarios efficiently.
