### PR TITLE
HDFS-17874. Followup; move SampleStep to a hadoop package.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.hdfs.server.diskbalancer.planner;
 import java.io.IOException;
 
 import org.junit.Test;
-import sample.SampleStep;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolume;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.test.SampleStep;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +88,7 @@ public class TestNodePlan {
   private void assertNodePlanInvalid(final NodePlan nodePlan) throws Exception {
     LambdaTestUtils.intercept(
         IOException.class,
-        "Invalid @class value in NodePlan JSON: sample.SampleStep",
+        "Invalid @class value in NodePlan JSON",
         () -> NodePlan.parseJson(nodePlan.toJson()));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/test/SampleStep.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/test/SampleStep.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package sample;
+package org.apache.hadoop.test;
 
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolume;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.Step;


### PR DESCRIPTION

This is needed to keep cyclonedx happy.


### How was this patch tested?

manual build with
```
mvn -T 1C clean package -Pdist -DskipTests -Dmaven.javadoc.skip=true -Dtar
```
and output check to make sure cyclonedx was run

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html