### PR TITLE
HADOOP-19812. Reduce boost source code download size

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -88,8 +88,8 @@ Refer to  dev-support/docker/Dockerfile_ubuntu_20):
   $ cmake --build build --parallel $(nproc)
   $ sudo cmake --install build
 * Boost
-  $ curl -L https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download > boost_1_86_0.tar.bz2
-  $ tar --bzip2 -xf boost_1_86_0.tar.bz2 && cd boost_1_86_0
+  $ curl -L https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-b2-nodocs.tar.gz > boost-1.86.0.tar.gz
+  $ tar -zxf boost-1.86.0.tar.gz && cd boost-1.86.0
   $ ./bootstrap.sh --prefix=/usr/
   $ ./b2 --without-python
   $ sudo ./b2 --without-python install
@@ -551,9 +551,9 @@ Building on Rocky Linux 8
   $ sudo make install
 
 * Install boost.
-  $ curl -L -o boost_1_86_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download
-  $ tar xjf boost_1_86_0.tar.bz2
-  $ cd boost_1_86_0
+  $ curl -L -o boost-1.86.0.tar.gz https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-b2-nodocs.tar.gz
+  $ tar -xzf boost-1.86.0.tar.gz
+  $ cd boost-1.86.0
   $ ./bootstrap.sh --prefix=/usr/local
   $ ./b2
   $ sudo ./b2 install

--- a/dev-support/docker/pkg-resolver/install-boost.sh
+++ b/dev-support/docker/pkg-resolver/install-boost.sh
@@ -41,11 +41,11 @@ fi
 if [ "$version_to_install" == "1.86.0" ]; then
   # hadolint ignore=DL3003
   mkdir -p /opt/boost-library &&
-    curl -L https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download >boost_1_86_0.tar.bz2 &&
-    mv boost_1_86_0.tar.bz2 /opt/boost-library &&
+    curl -L https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-b2-nodocs.tar.gz > boost-1.86.0.tar.gz &&
+    mv boost-1.86.0.tar.gz /opt/boost-library &&
     cd /opt/boost-library &&
-    tar --bzip2 -xf boost_1_86_0.tar.bz2 &&
-    cd /opt/boost-library/boost_1_86_0 &&
+    tar -xzf boost-1.86.0.tar.gz &&
+    cd /opt/boost-library/boost-1.86.0 &&
     ./bootstrap.sh --prefix=/usr/ &&
     ./b2 --without-python install &&
     cd /root &&


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Reduce boost source code download size by switching from https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download (120M) to https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-b2-nodocs.tar.gz (61M)

I see relatively frequent failure in downloading boost source code from sourceforge.net, not sure if it's my own network issue ... but it's always good to reduce the download size

```
 => ERROR [11/17] RUN pkg-resolver/install-boost.sh ubuntu:noble                                                                                                       641.0s
------
 > [11/17] RUN pkg-resolver/install-boost.sh ubuntu:noble:
0.193   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
0.193                                  Dload  Upload   Total   Spent    Left  Speed
100   623  100   623    0     0   1142      0 --:--:-- --:--:-- --:--:--  1141
100   365  100   365    0     0    336      0  0:00:01  0:00:01 --:--:--   336
  1  120M    1 2063k    0     0   3300      0 10:37:28  0:10:40 10:26:48  4187
640.5 curl: (18) transfer closed with 124107374 bytes remaining to read
------

--------------------
  91 |     RUN pkg-resolver/install-maven.sh ubuntu:noble
  92 |     RUN pkg-resolver/install-spotbugs.sh ubuntu:noble
  93 | >>> RUN pkg-resolver/install-boost.sh ubuntu:noble
  94 |     RUN pkg-resolver/install-protobuf.sh ubuntu:noble
  95 |     RUN pkg-resolver/install-hadolint.sh ubuntu:noble
--------------------
ERROR: failed to build: failed to solve: process "/bin/bash -o pipefail -c pkg-resolver/install-boost.sh ubuntu:noble" did not complete successfully: exit code: 18
```

### How was this patch tested?

Tested on both arm and x86_64 platforms

```
$ ./start-build-env.sh
...
 _   _           _                    ______
| | | |         | |                   |  _  \
| |_| | __ _  __| | ___   ___  _ __   | | | |_____   __
|  _  |/ _` |/ _` |/ _ \ / _ \| '_ \  | | | / _ \ \ / /
| | | | (_| | (_| | (_) | (_) | |_) | | |/ /  __/\ V /
\_| |_/\__,_|\__,_|\___/ \___/| .__/  |___/ \___| \_(_)
                              | |
                              |_|

This is the standard Hadoop Developer build environment.
This has all the right tools installed required to build
Hadoop from source.

chengpan@9de8c3965a2f:~/hadoop$ ./mvnw install -DskipTests -DskipShade -Pnative
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:30 min
[INFO] Finished at: 2026-02-10T07:41:22Z
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19812)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.