### PR TITLE
HDFS-17874. (Followup) Fix package issue by moving SampleStep to a hadoop package

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.hdfs.server.diskbalancer.planner;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
-import sample.SampleStep;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolume;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.test.SampleStep;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +88,7 @@ public class TestNodePlan {
   private void assertNodePlanInvalid(final NodePlan nodePlan) throws Exception {
     LambdaTestUtils.intercept(
         IOException.class,
-        "Invalid @class value in NodePlan JSON: sample.SampleStep",
+        "Invalid @class value in NodePlan JSON",
         () -> NodePlan.parseJson(nodePlan.toJson()));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/test/SampleStep.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/test/SampleStep.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package sample;
+package org.apache.hadoop.test;
 
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolume;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.Step;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This forwardports https://github.com/apache/hadoop/pull/8242 (3.4, authored by @steveloughran) to trunk to recover the Jenkins

### How was this patch tested?

```
$ ./mvnw -T 1C clean package -Pdist -DskipTests -Dmaven.javadoc.skip=true -Dtar
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:53 min (Wall Clock)
[INFO] Finished at: 2026-02-11T02:38:47Z
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HDFS-17874)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No.