### PR TITLE
HDFS-17883. dfs.net.topology.impl should be respected when dfs.use.dfs.network.topology=true

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/NetworkTopologyFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/NetworkTopologyFactory.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.net;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.net.NetworkTopology;
+
+/**
+ * Factory for creating a {@link NetworkTopology} instance based on
+ * the {@code dfs.use.dfs.network.topology} configuration.
+ */
+public final class NetworkTopologyFactory {
+
+  private NetworkTopologyFactory() {}
+
+  /**
+   * Creates a {@link NetworkTopology} instance.
+   * If {@code dfs.use.dfs.network.topology} is enabled, returns a
+   * {@link DFSNetworkTopology}; otherwise, returns a plain
+   * {@link NetworkTopology}.
+   */
+  public static NetworkTopology create(Configuration conf) {
+    boolean useDfsNetworkTopology = conf.getBoolean(
+        DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_KEY,
+        DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_DEFAULT);
+    if (useDfsNetworkTopology) {
+      return DFSNetworkTopology.getInstance(conf);
+    } else {
+      return NetworkTopology.getInstance(conf);
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.hdfs.DFSUtilClient;
-import org.apache.hadoop.net.NetworkTopology;
+import org.apache.hadoop.hdfs.net.NetworkTopologyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.HadoopIllegalArgumentException;
@@ -261,7 +261,7 @@ public class Balancer implements BalancerMXBean {
   private static void checkReplicationPolicyCompatibility(Configuration conf
       ) throws UnsupportedActionException {
     BlockPlacementPolicies placementPolicies =
-        new BlockPlacementPolicies(conf, null, NetworkTopology.getInstance(conf), null);
+        new BlockPlacementPolicies(conf, null, NetworkTopologyFactory.create(conf), null);
     if (!(placementPolicies.getPolicy(CONTIGUOUS) instanceof
         BlockPlacementPolicyDefault)) {
       throw new UnsupportedActionException(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Dispatcher.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Dispatcher.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtilClient;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.apache.hadoop.hdfs.net.NetworkTopologyFactory;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
@@ -1090,7 +1091,7 @@ public class Dispatcher {
     this.includedNodes = includedNodes;
     this.movedBlocks = new MovedBlocks<StorageGroup>(movedWinWidth);
 
-    this.cluster = NetworkTopology.getInstance(conf);
+    this.cluster = NetworkTopologyFactory.create(conf);
 
     this.dispatchExecutor = dispatcherThreads == 0? null
         : Executors.newFixedThreadPool(dispatcherThreads);
@@ -1415,7 +1416,7 @@ public class Dispatcher {
 
   /** Reset all fields in order to prepare for the next iteration */
   void reset(Configuration conf) {
-    cluster = NetworkTopology.getInstance(conf);
+    cluster = NetworkTopologyFactory.create(conf);
     storageGroupMap.clear();
     sources.clear();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.hdfs.net.DFSNetworkTopology;
+import org.apache.hadoop.hdfs.net.NetworkTopologyFactory;
 import org.apache.hadoop.hdfs.protocol.*;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo.DatanodeInfoBuilder;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
@@ -201,10 +201,6 @@ public class DatanodeManager {
    */
   private final boolean dataNodeDiskStatsEnabled;
 
-  /**
-   * If we use DfsNetworkTopology to choose nodes for placing replicas.
-   */
-  private final boolean useDfsNetworkTopology;
 
   private static final String IP_PORT_SEPARATOR = ":";
 
@@ -235,14 +231,7 @@ public class DatanodeManager {
     this.namesystem = namesystem;
     this.blockManager = blockManager;
 
-    this.useDfsNetworkTopology = conf.getBoolean(
-        DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_KEY,
-        DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_DEFAULT);
-    if (useDfsNetworkTopology) {
-      networktopology = DFSNetworkTopology.getInstance(conf);
-    } else {
-      networktopology = NetworkTopology.getInstance(conf);
-    }
+    networktopology = NetworkTopologyFactory.create(conf);
     this.heartbeatManager = new HeartbeatManager(namesystem,
         blockManager, conf);
     this.datanodeAdminManager = new DatanodeAdminManager(namesystem,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/sps/ExternalSPSContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/sps/ExternalSPSContext.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSUtilClient;
+import org.apache.hadoop.hdfs.net.NetworkTopologyFactory;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
@@ -95,7 +96,7 @@ public class ExternalSPSContext implements Context {
   @Override
   public NetworkTopology getNetworkTopology(DatanodeMap datanodeMap) {
     // create network topology.
-    NetworkTopology cluster = NetworkTopology.getInstance(service.getConf());
+    NetworkTopology cluster = NetworkTopologyFactory.create(service.getConf());
     List<DatanodeWithStorage> targets = datanodeMap.getTargets();
     for (DatanodeWithStorage node : targets) {
       cluster.add(node.getDatanodeInfo());


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

https://issues.apache.org/jira/browse/HDFS-17883

If `dfs.use.dfs.network.topology` is true,  `dfs.net.topology.impl` should be used, not `net.topology.impl` on Balancer.java, Dispatcher.java or else.

I cannot run balancer when `dfs.use.dfs.network.topology` is true and `net.topology.impl` is not the same as `dfs.net.topology.impl` even though `net.topology.impl` is not necessary.


### How was this patch tested?

Manually tested


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html