### PR TITLE
YARN-11926: hadoop-yarn-server-resourcemanager: TestRMWebServicesReservation fails due to outdated timestamps

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/update-reservation.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/update-reservation.json
@@ -3,8 +3,8 @@
     {
       "reservation-id" : "reservation_12341234_1",
       "reservation-definition" : {
-         "arrival" : 1765541532000,
-         "deadline" : 1765542252000,
+         "arrival" : 1923221532000,
+         "deadline" : 1923222252000,
          "reservation-name" : "res_1",
          "reservation-requests" : {
             "reservation-request-interpreter" : 0,


### PR DESCRIPTION
### Description of PR

Push timestamps in test JSON forward for 5 years. This is a quick fix to get the test passing. A more complete solution to be implemented later could dynamically choose future values based on a delta from current time.

### How was this patch tested?

mvn clean test -Dtest=TestRMWebServicesReservation

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html