### PR TITLE
YARN-11930: Newly released protobuf-maven-plugin incompatible with hadoop-yarn-csi build

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -159,6 +159,7 @@
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
+    <ascopes.protobuf-maven-plugin.version>4.1.3</ascopes.protobuf-maven-plugin.version>
     <maven-replacer-plugin.version>1.5.3</maven-replacer-plugin.version>
 
     <protobuf-compile.version>3.5.1</protobuf-compile.version>
@@ -2433,6 +2434,11 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>io.github.ascopes</groupId>
+          <artifactId>protobuf-maven-plugin</artifactId>
+          <version>${ascopes.protobuf-maven-plugin.version}</version>
         </plugin>
         <!-- Modify the generated source to use our shaded protobuf -->
         <plugin>


### PR DESCRIPTION
### Description of PR

[YARN-11921](https://issues.apache.org/jira/browse/YARN-11921) introduced use of io.github.ascopes:protobuf-maven-plugin in the hadoop-yarn-csi build. The version number of the plugin wasn't pinned. The plugin released a new 5.0.0 version this week, which is incompatible with our build. We can fix this by pinning the version back to 4.1.3.

There are some breaking changes in 5.0.0 that would require more changes for compatibility. We can look into that after the Hadoop 3.5.0 release.

### How was this patch tested?

On current trunk, `mvn clean install -DskipTests -DskipShade` fails with:

```
[ERROR] Failed to execute goal io.github.ascopes:protobuf-maven-plugin:5.0.0:generate (default) on project hadoop-yarn-csi: The parameters 'protoc' for goal io.github.ascopes:protobuf-maven-plugin:5.0.0:generate are missing or invalid -> [Help 1]
```

After applying this patch, the build is successful.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html