### PR TITLE
HADOOP-10579. Add match expressions to find command

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Atime.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Atime.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -atime expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Atime extends NumberExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Atime.class, "-atime");
+    factory.addClass(Amin.class, "-amin");
+  }
+
+  private static final String[] USAGE = {"-atime n", "-amin n"};
+  private static final String[] HELP = {"Evaluates as true if the file access time subtracted from",
+      "the start time is n days (or minutes if -amin is used)."};
+
+  /**
+   * Constructs an Atime expression with a parameter size of 1 day.
+   */
+  Atime() {
+    this(DAY_IN_MILLISECONDS);
+  }
+
+  /**
+   * Constructs an Atime expression using the specified units for the parameter.
+   *
+   * @param units expression parameter size in milliseconds
+   */
+  private Atime(long units) {
+    super(units);
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    return applyNumber(getOptions().getStartTime() - getFileStatus(item, depth).getAccessTime());
+  }
+
+  /**
+   * Implement -amin expression (similar to -atime but in minutes rather than days).
+   */
+  final static class Amin extends FilterExpression {
+    Amin() {
+      super(new Atime(MINUTE_IN_MILLISECONDS));
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Blocksize.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Blocksize.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -blocksize expression for the
+ * {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Blocksize extends NumberExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Blocksize.class, "-blocksize");
+  }
+
+  private static final String[] USAGE = {"-blocksize n"};
+  private static final String[] HELP = {"Evaluates to true if the block size of the file is n."};
+
+  Blocksize() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    return applyNumber(getFileStatus(item, depth).getBlockSize());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Empty.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Empty.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -empty expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Empty extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Empty.class, "-empty");
+  }
+
+  private static final String[] USAGE = {"-empty"};
+  private static final String[] HELP =
+      {"Evaluates as true if the file is empty or directory has no", "contents."};
+
+  Empty() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    FileStatus fileStatus = getFileStatus(item, depth);
+    if (fileStatus.isDirectory()) {
+      if (getFileSystem(item).listStatus(getPath(item)).length == 0) {
+        return Result.PASS;
+      }
+      return Result.FAIL;
+    }
+    if (fileStatus.getLen() == 0L) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java
@@ -81,7 +81,21 @@ public class Find extends FsCommand {
 
     // Navigation Expressions
     // Matcher Expressions
+    addExpression(Atime.class);
+    addExpression(Blocksize.class);
+    addExpression(Empty.class);
+    addExpression(Group.class);
+    addExpression(Mtime.class);
     addExpression(Name.class);
+    addExpression(Newer.class);
+    addExpression(Nogroup.class);
+    addExpression(Nouser.class);
+    addExpression(Perm.class);
+    addExpression(Regex.class);
+    addExpression(Replicas.class);
+    addExpression(Size.class);
+    addExpression(Type.class);
+    addExpression(User.class);
 
     DESCRIPTION = buildDescription(ExpressionFactory.getExpressionFactory());
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Group.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Group.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Deque;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -group expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Group extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Group.class, "-group");
+  }
+
+  private static final String[] USAGE = {"-group groupname"};
+  private static final String[] HELP =
+      {"Evaluates as true if the file belongs to the specified", "group."};
+  private String requiredGroup;
+
+  Group() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    requiredGroup = getArgument(1);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    String group = getFileStatus(item, depth).getGroup();
+    if (requiredGroup.equals(group)) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Mtime.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Mtime.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -mtime expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Mtime extends NumberExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Mtime.class, "-mtime");
+    factory.addClass(Mmin.class, "-mmin");
+  }
+
+  private static final String[] USAGE = {"-mtime n", "-mmin n"};
+  private static final String[] HELP =
+      {"Evaluates as true if the file modification time subtracted",
+          "from the start time is n days (or minutes if -mmin is used)"};
+
+  /**
+   * Constructs a Mtime expression with a parameter size of 1 day.
+   */
+  Mtime() {
+    this(DAY_IN_MILLISECONDS);
+  }
+
+  /**
+   * Constructs a Mtime expression using the specified units for the parameter.
+   *
+   * @param units expression parameter size in milliseconds
+   */
+  private Mtime(long units) {
+    super(units);
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    return applyNumber(
+        getOptions().getStartTime() - getFileStatus(item, depth).getModificationTime());
+  }
+
+  /**
+   * Implement -mmin expression (similar to -mtime but in minutes rather than
+   * days).
+   */
+  final static class Mmin extends FilterExpression {
+    Mmin() {
+      super(new Mtime(MINUTE_IN_MILLISECONDS));
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Newer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Newer.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Deque;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -newer expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Newer extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Newer.class, "-newer");
+  }
+
+  private static final String[] USAGE = {"-newer file"};
+  private static final String[] HELP = {"Evaluates as true if the modification time of the current",
+      "file is more recent than the modification time of the", "specified file."};
+
+  private long filetime;
+
+  Newer() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    String pathname = getArgument(1);
+    PathData pathData = new PathData(pathname, getConf());
+    filetime = getFileStatus(pathData, 0).getModificationTime();
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    if (getFileStatus(item, depth).getModificationTime() > filetime) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Nogroup.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Nogroup.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -nogroup expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Nogroup extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Nogroup.class, "-nogroup");
+  }
+
+  private static final String[] USAGE = {"-nogroup"};
+  private static final String[] HELP =
+      {"Evaluates as true if the file does not have a valid group."};
+
+  Nogroup() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    String group = getFileStatus(item, depth).getGroup();
+    if ((group == null) || (group.isEmpty())) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Nouser.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Nouser.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -nouser expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Nouser extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Nouser.class, "-nouser");
+  }
+
+  private static final String[] USAGE = {"-nouser"};
+  private static final String[] HELP =
+      {"Evaluates as true if the file does not have a valid owner."};
+
+  Nouser() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    String user = getFileStatus(item, depth).getOwner();
+    if ((user == null) || (user.isEmpty())) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/NumberExpression.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/NumberExpression.java
@@ -35,9 +35,15 @@ public abstract class NumberExpression extends BaseExpression {
    */
   protected static final long MINUTE_IN_MILLISECONDS = 60000L;
 
-  private long max = -1L;
-  private long min = -1L;
+  private long max = Long.MIN_VALUE;
+  private long min = Long.MIN_VALUE;
   private long units = 1L;
+
+  protected enum MODE {
+    ROUND_UP, ROUND_DOWN,
+  }
+
+  private MODE mode = MODE.ROUND_DOWN;
 
   /**
    * Constructor specifying for size of units to used as the expression
@@ -58,6 +64,10 @@ public abstract class NumberExpression extends BaseExpression {
     this.units = units;
   }
 
+  protected void setMode(MODE mode) {
+    this.mode = mode;
+  }
+
   @Override
   public void prepare() throws IOException {
     parseArgument(getArgument(1));
@@ -75,13 +85,27 @@ public abstract class NumberExpression extends BaseExpression {
     } else if (arg.isEmpty()) {
       throw new IllegalArgumentException("Invalid empty argument");
     }
-    if (arg.startsWith("+")) {
-      min = (Long.parseLong(arg.substring(1)) * units) + units;
-    } else if (arg.startsWith("-")) {
-      max = (Long.parseLong(arg.substring(1)) * units) - 1L;
-    } else {
-      min = Long.parseLong(arg) * units;
-      max = min + units - 1L;
+    switch (mode) {
+    case ROUND_UP:
+      if (arg.startsWith("+")) {
+        min = (Long.parseLong(arg.substring(1)) * units) + 1L;
+      } else if (arg.startsWith("-")) {
+        max = (Long.parseLong(arg.substring(1)) * units) - units;
+      } else {
+        max = Long.parseLong(arg) * units;
+        min = max - units + 1L;
+      }
+      break;
+    case ROUND_DOWN:
+      if (arg.startsWith("+")) {
+        min = (Long.parseLong(arg.substring(1)) * units) + units;
+      } else if (arg.startsWith("-")) {
+        max = (Long.parseLong(arg.substring(1)) * units) - 1L;
+      } else {
+        min = Long.parseLong(arg) * units;
+        max = min + units - 1L;
+      }
+      break;
     }
   }
 
@@ -98,10 +122,10 @@ public abstract class NumberExpression extends BaseExpression {
    * {@link Result#FAIL} otherwise
    */
   protected Result applyNumber(long value) {
-    if ((min > -1L) && (min > value)) {
+    if ((min > Long.MIN_VALUE) && (min > value)) {
       return Result.FAIL;
     }
-    if ((max > -1L) && (max < value)) {
+    if ((max > Long.MIN_VALUE) && (max < value)) {
       return Result.FAIL;
     }
     return Result.PASS;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/NumberExpression.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/NumberExpression.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Deque;
+
+/**
+ * Base class for numeric {@link Expression}s.
+ * Implements helper methods for processing numeric arguments.
+ */
+public abstract class NumberExpression extends BaseExpression {
+  /**
+   * Number of milliseconds in a day.
+   */
+  protected static final long DAY_IN_MILLISECONDS = 86400000L;
+
+  /**
+   * Number of milliseconds in a minute.
+   */
+  protected static final long MINUTE_IN_MILLISECONDS = 60000L;
+
+  private long max = -1L;
+  private long min = -1L;
+  private long units = 1L;
+
+  /**
+   * Constructor specifying for size of units to used as the expression
+   * argument.
+   *
+   * @param units size of the expression argument compared to the item being
+   *              processed.
+   */
+  protected NumberExpression(long units) {
+    setUnits(units);
+  }
+
+  protected NumberExpression() {
+    this(1L);
+  }
+
+  protected void setUnits(long units) {
+    this.units = units;
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    parseArgument(getArgument(1));
+  }
+
+  /**
+   * Parse the argument string to extract the numeric argument.
+   *
+   * @param arg String to be parsed
+   * @throws IllegalArgumentException if there is a problem parsing the argument
+   */
+  protected void parseArgument(String arg) throws IllegalArgumentException {
+    if (arg == null) {
+      throw new IllegalArgumentException("Invalid null argument");
+    } else if (arg.isEmpty()) {
+      throw new IllegalArgumentException("Invalid empty argument");
+    }
+    if (arg.startsWith("+")) {
+      min = (Long.parseLong(arg.substring(1)) * units) + units;
+    } else if (arg.startsWith("-")) {
+      max = (Long.parseLong(arg.substring(1)) * units) - 1L;
+    } else {
+      min = Long.parseLong(arg) * units;
+      max = min + units - 1L;
+    }
+  }
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+
+  /**
+   * Apply this {@link Expression} to the given value.
+   *
+   * @param value what to apply the expression to
+   * @return {@link Result#PASS} is the value is within range,
+   * {@link Result#FAIL} otherwise
+   */
+  protected Result applyNumber(long value) {
+    if ((min > -1L) && (min > value)) {
+      return Result.FAIL;
+    }
+    if ((max > -1L) && (max < value)) {
+      return Result.FAIL;
+    }
+    return Result.PASS;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/NumberExpression.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/NumberExpression.java
@@ -106,6 +106,8 @@ public abstract class NumberExpression extends BaseExpression {
         max = min + units - 1L;
       }
       break;
+    default:
+      throw new AssertionError("Unexpected mode: " + mode);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
@@ -79,10 +79,10 @@ final class Perm extends BaseExpression {
       permission = new FsPermission(arg).toShort();
     } else {
       // the argument is a symbolic mode
-      int shift;
-      Operator operator = null;
-      int value = 0;
       for (String part : arg.split(",")) {
+        int shift;
+        Operator operator = null;
+        int value = 0;
         int position = 0;
         switch (part.charAt(position++)) {
         case 'u':

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
@@ -42,7 +42,7 @@ final class Perm extends BaseExpression {
       "The mode may be specified using either symbolic notation,",
       "eg 'u=rwx,g+x+w' or as an octal number."};
 
-  private int permission;
+  private int permission = 0;
   private boolean mask = false;
 
   Perm() {
@@ -80,10 +80,11 @@ final class Perm extends BaseExpression {
     } else {
       // the argument is a symbolic mode
       int shift;
-      Operator operator;
-      int value;
-      for (int i = 0; i < arg.length(); i++) {
-        switch (arg.charAt(i++)) {
+      Operator operator = null;
+      int value = 0;
+      for (String part : arg.split(",")) {
+        int position = 0;
+        switch (part.charAt(position++)) {
         case 'u':
           shift = 6;
           break;
@@ -99,8 +100,9 @@ final class Perm extends BaseExpression {
         default:
           throw new IllegalArgumentException("Invalid mode: " + argument);
         }
-        if (i < arg.length()) {
-          switch (arg.charAt(i++)) {
+        outer:
+        while (position < part.length()) {
+          switch (part.charAt(position++)) {
           case '=':
             operator = EQUALS;
             break;
@@ -113,35 +115,41 @@ final class Perm extends BaseExpression {
           default:
             throw new IllegalArgumentException("Invalid mode: " + argument);
           }
-        } else {
-          throw new IllegalArgumentException("Invalid mode: " + argument);
-        }
-
-        value = 0;
-        for (; (i < arg.length()) && (arg.charAt(i) != ','); i++) {
-          switch (arg.charAt(i)) {
-          case 'r':
-            value |= 4;
-            break;
-          case 'w':
-            value |= 2;
-            break;
-          case 'x':
-            value |= 1;
-            break;
-          default:
-            throw new IllegalArgumentException("Invalid mode: " + argument);
+          value = 0;
+          while (position < part.length()) {
+            switch (part.charAt(position)) {
+            case 'r':
+              value |= 4;
+              break;
+            case 'w':
+              value |= 2;
+              break;
+            case 'x':
+              value |= 1;
+              break;
+            default:
+               applyPermission(operator, shift, value);
+              continue outer;
+            }
+            position++;
           }
         }
-        if (shift != -1) {
-          permission = operator.apply(permission, shift, value);
-        } else {
-          permission = operator.apply(permission, 6, value);
-          permission = operator.apply(permission, 3, value);
-          permission = operator.apply(permission, 0, value);
+        if (operator == null || value == 0 ) {
+          throw new IllegalArgumentException("Invalid mode: " + argument);
         }
+        applyPermission(operator, shift, value);
       }
     }
+  }
+
+  private void applyPermission(Operator operator, int shift, int value) {
+    if (shift != -1) {
+      permission = operator.apply(permission, shift, value);
+      return;
+    }
+    permission = operator.apply(permission, 6, value);
+    permission = operator.apply(permission, 3, value);
+    permission = operator.apply(permission, 0, value);
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
@@ -1,0 +1,209 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Deque;
+
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -perm expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Perm extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Perm.class, "-perm");
+  }
+
+  private static final String[] USAGE = {"-perm [-]mode", "-perm [-]onum"};
+  private static final String[] HELP = {"Evaluates as true if the file permissions match that",
+      "specified. If the hyphen is specified then the expression",
+      "shall evaluate as true if at least the bits specified",
+      "match, otherwise an exact match is required.",
+      "The mode may be specified using either symbolic notation,",
+      "eg 'u=rwx,g+x+w' or as an octal number."};
+
+  private int permission;
+  private boolean mask = false;
+
+  Perm() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    parseArgument(getArgument(1));
+  }
+
+  /**
+   * Parse an argument string to build the permission mask.
+   *
+   * @param argument String to be parsed
+   * @throws IllegalArgumentException if the argument is invalid
+   */
+  private void parseArgument(String argument) throws IllegalArgumentException {
+    String arg = argument;
+    if (arg == null) {
+      throw new IllegalArgumentException("Invalid null argument");
+    }
+    if (arg.isEmpty()) {
+      throw new IllegalArgumentException("Invalid empty argument");
+    }
+    if (arg.startsWith("-")) {
+      mask = true;
+      arg = arg.substring(1);
+    }
+    if (Character.isDigit(arg.charAt(0))) {
+      // the argument is a numeric mode
+      permission = new FsPermission(arg).toShort();
+    } else {
+      // the argument is a symbolic mode
+      int shift;
+      Operator operator;
+      int value;
+      for (int i = 0; i < arg.length(); i++) {
+        switch (arg.charAt(i++)) {
+        case 'u':
+          shift = 6;
+          break;
+        case 'g':
+          shift = 3;
+          break;
+        case 'o':
+          shift = 0;
+          break;
+        case 'a':
+          shift = -1;
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid mode: " + argument);
+        }
+        if (i < arg.length()) {
+          switch (arg.charAt(i++)) {
+          case '=':
+            operator = EQUALS;
+            break;
+          case '+':
+            operator = PLUS;
+            break;
+          case '-':
+            operator = MINUS;
+            break;
+          default:
+            throw new IllegalArgumentException("Invalid mode: " + argument);
+          }
+        } else {
+          throw new IllegalArgumentException("Invalid mode: " + argument);
+        }
+
+        value = 0;
+        for (; (i < arg.length()) && (arg.charAt(i) != ','); i++) {
+          switch (arg.charAt(i)) {
+          case 'r':
+            value |= 4;
+            break;
+          case 'w':
+            value |= 2;
+            break;
+          case 'x':
+            value |= 1;
+            break;
+          default:
+            throw new IllegalArgumentException("Invalid mode: " + argument);
+          }
+        }
+        if (shift != -1) {
+          permission = operator.apply(permission, shift, value);
+        } else {
+          permission = operator.apply(permission, 6, value);
+          permission = operator.apply(permission, 3, value);
+          permission = operator.apply(permission, 0, value);
+        }
+      }
+    }
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    int itemPermission = getFileStatus(item, depth).getPermission().toShort();
+    if (itemPermission == permission) {
+      return Result.PASS;
+    } else if (mask && ((itemPermission & permission) == permission)) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+
+  /**
+   * Interface representing an operator for defining a permission within an
+   * argument.
+   */
+  private interface Operator {
+    int apply(int current, int shift, int value);
+  }
+
+  /**
+   * Operator to set a permission.
+   */
+  private static final Operator EQUALS = new Operator() {
+    public int apply(int current, int shift, int value) {
+      return (current & ~(7 << shift)) | (value << shift);
+    }
+
+    public String toString() {
+      return "equals";
+    }
+  };
+
+  /**
+   * Operator to add a permission.
+   */
+  private static final Operator PLUS = new Operator() {
+    public int apply(int current, int shift, int value) {
+      return current | (value << shift);
+    }
+
+    public String toString() {
+      return "plus";
+    }
+  };
+
+  /**
+   * Operator to remove a permission.
+   */
+  private static final Operator MINUS = new Operator() {
+    public int apply(int current, int shift, int value) {
+      return current & ~(value << shift);
+    }
+
+    public String toString() {
+      return "minus";
+    }
+  };
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Perm.java
@@ -128,13 +128,13 @@ final class Perm extends BaseExpression {
               value |= 1;
               break;
             default:
-               applyPermission(operator, shift, value);
+              applyPermission(operator, shift, value);
               continue outer;
             }
             position++;
           }
         }
-        if (operator == null || value == 0 ) {
+        if (operator == null || value == 0) {
           throw new IllegalArgumentException("Invalid mode: " + argument);
         }
         applyPermission(operator, shift, value);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Regex.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Regex.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Deque;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -name expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Regex extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Regex.class, "-regex");
+    factory.addClass(Iregex.class, "-iregex");
+  }
+
+  private static final String[] USAGE = {"-regex pattern", "-iregex pattern"};
+  private static final String[] HELP = {"Evaluates as true if the whole file path matches the",
+      "regular expression pattern. If -iregex is used then", "the match is case insensitive."};
+
+  private final RegexMatcher matcher = new JavaRegexMatcher();
+  private boolean caseSensitive = true;
+
+  Regex() {
+    this(true);
+  }
+
+  /**
+   * Construct a new regex {@link Expression}.
+   *
+   * @param caseSensitive if true then a case-sensitive match will be performed
+   */
+  private Regex(boolean caseSensitive) {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+    setCaseSensitive(caseSensitive);
+  }
+
+  private void setCaseSensitive(boolean caseSensitive) {
+    this.caseSensitive = caseSensitive;
+  }
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    String pattern = getArgument(1);
+    matcher.setup(pattern, caseSensitive);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    String path = getPath(item).toString();
+    if (matcher.matches(path)) {
+      return Result.PASS;
+    } else {
+      return Result.FAIL;
+    }
+  }
+
+  /**
+   * Case-insensitive version of the -name expression.
+   */
+  static class Iregex extends FilterExpression {
+    Iregex() {
+      super(new Regex(false));
+    }
+  }
+
+  private interface RegexMatcher {
+    void setup(String regex, boolean caseSensitive);
+
+    boolean matches(String input);
+  }
+
+  /**
+   * Regex matcher using Java regular expression syntax.
+   */
+  private static final class JavaRegexMatcher implements RegexMatcher {
+    private Pattern pattern;
+
+    public void setup(String regex, boolean caseSensitive) {
+      int flags = 0;
+      if (!caseSensitive) {
+        flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+      }
+      pattern = Pattern.compile(regex, flags);
+    }
+
+    public boolean matches(String input) {
+      return pattern.matcher(input).matches();
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Replicas.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Replicas.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -replicas expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Replicas extends NumberExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Replicas.class, "-replicas");
+  }
+
+  private static final String[] USAGE = {"-replicas n"};
+  private static final String[] HELP = {"Evaluates to true if the number of file replicas is n."};
+
+  Replicas() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    return applyNumber(getFileStatus(item, depth).getReplication());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Size.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Size.java
@@ -48,6 +48,7 @@ final class Size extends NumberExpression {
       arg = arg.substring(0, arg.length() - 1);
     } else {
       setUnits(512);
+      setMode(MODE.ROUND_UP);
     }
     super.parseArgument(arg);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Size.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Size.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -size expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Size extends NumberExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Size.class, "-size");
+  }
+
+  private static final String[] USAGE = {"-size n[c]"};
+  private static final String[] HELP =
+      {"Evaluates to true if the file size in 512 byte blocks is n.",
+          "If n is followed by the character 'c' then the size is in", "bytes."};
+
+  Size() {
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  protected void parseArgument(String arg) throws IllegalArgumentException {
+    if (arg.endsWith("c")) {
+      arg = arg.substring(0, arg.length() - 1);
+    } else {
+      setUnits(512);
+    }
+    super.parseArgument(arg);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    return applyNumber(getFileStatus(item, depth).getLen());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Type.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Type.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -type expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class Type extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(Type.class, "-type");
+  }
+
+  private static final String[] USAGE = {"-type filetype"};
+  private static final String[] HELP =
+      {"Evaluates to true if the file type matches that specified.",
+          "The following file type values are supported:",
+          "'d' (directory), 'l' (symbolic link), 'f' (regular file)."};
+
+  private static final FileType DIRECTORY;
+  private static final FileType SYMBOLIC_LINK;
+  private static final FileType REGULAR_FILE;
+  private static final Map<String, FileType> FILE_TYPES;
+
+  static {
+    DIRECTORY = new FileType("d") {
+      public boolean matches(FileStatus stat) {
+        return stat.isDirectory();
+      }
+    };
+    SYMBOLIC_LINK = new FileType("l") {
+      public boolean matches(FileStatus stat) {
+        return stat.isSymlink();
+      }
+    };
+    REGULAR_FILE = new FileType("f") {
+      public boolean matches(FileStatus stat) {
+        return stat.isFile();
+      }
+    };
+
+    HashMap<String, FileType> map = new HashMap<>();
+    map.put(DIRECTORY.getCode(), DIRECTORY);
+    map.put(SYMBOLIC_LINK.getCode(), SYMBOLIC_LINK);
+    map.put(REGULAR_FILE.getCode(), REGULAR_FILE);
+    FILE_TYPES = Collections.unmodifiableMap(map);
+  }
+
+  Type() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  private static abstract class FileType {
+    private final String code;
+
+    private FileType(String code) {
+      this.code = code;
+    }
+
+    public String getCode() {
+      return this.code;
+    }
+
+    public abstract boolean matches(FileStatus stat);
+  }
+
+  private FileType fileType = null;
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    String arg = getArgument(1);
+    if (FILE_TYPES.containsKey(arg)) {
+      this.fileType = FILE_TYPES.get(arg);
+    } else {
+      throw new IOException("Invalid file type: " + arg);
+    }
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    if (this.fileType.matches(getFileStatus(item, depth))) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/User.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/User.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import java.io.IOException;
+import java.util.Deque;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+/**
+ * Implements the -user expression for the {@link org.apache.hadoop.fs.shell.find.Find} command.
+ */
+final class User extends BaseExpression {
+  /**
+   * Registers this expression with the specified factory.
+   */
+  public static void registerExpression(ExpressionFactory factory) throws IOException {
+    factory.addClass(User.class, "-user");
+  }
+
+  private static final String[] USAGE = {"-user username"};
+  private static final String[] HELP =
+      {"Evaluates as true if the owner of the file matches the", "specified user."};
+
+  private String requiredUser;
+
+  User() {
+    super();
+    setUsage(USAGE);
+    setHelp(HELP);
+  }
+
+  @Override
+  public void addArguments(Deque<String> args) {
+    addArguments(args, 1);
+  }
+
+  @Override
+  public void prepare() throws IOException {
+    requiredUser = getArgument(1);
+  }
+
+  @Override
+  public Result apply(PathData item, int depth) throws IOException {
+    if (requiredUser.equals(getFileStatus(item, depth).getOwner())) {
+      return Result.PASS;
+    }
+    return Result.FAIL;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for the execution of a find command.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.shell.find;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
@@ -311,13 +311,69 @@ Finds all files that match the specified expression and applies selected actions
 
 The following primary expressions are recognised:
 
+*   -atime n<br />-amin n
+
+    Evaluates as true if the file access time subtracted from the start time is n days (or minutes if -amin is used).
+
+*   -blocksize n
+
+    Evaluates to true if the block size of the file is n.
+
+*   -empty
+
+    Evaluates as true if the file is empty or directory has no contents.
+
+*   -group groupname
+
+    Evaluates as true if the file belongs to the specified group.
+
+*   -mtime n<br />-mmin n
+
+    Evaluates as true if the file modification time subtracted from the start time is n days (or minutes if -mmin is used)
+
 *   -name pattern<br />-iname pattern
 
     Evaluates as true if the basename of the file matches the pattern using standard file system globbing. If -iname is used then the match is case insensitive.
 
+*   -newer file
+
+    Evaluates as true if the modification time of the current file is more recent than the modification time of the specified file.
+
+*   -nogroup
+
+    Evaluates as true if the file does not have a valid group.
+
+*   -nouser
+
+    Evaluates as true if the file does not have a valid owner.
+
+*   -perm [-]mode<br />-perm [-]onum
+
+    Evaluates as true if the file permissions match that specified. If the hyphen is specified then the expression shall evaluate as true if at least the bits specified match, otherwise an exact match is required. The mode may be specified using either symbolic notation, eg 'u=rwx,g+x+w' or as an octal number.
+
 *   -print<br />-print0
 
     Always evaluates to true. Causes the current pathname to be written to standard output. If the -print0 expression is used then an ASCII NULL character is appended.
+
+*   -regex pattern<br />-iregex pattern
+
+    Evaluates as true if the whole file path matches the regular expression pattern. If -iregex is used then the match is case insensitive.
+
+*   -replicas n
+
+    Evaluates to true if the number of file replicas is n.
+
+*   -size n[c]
+
+    Evaluates to true if the file size in 512 byte blocks is n. If n is followed by the character 'c' then the size is in bytes.
+
+*   -type filetype
+
+    Evaluates to true if the file type matches that specified. The following file type values are supported: 'd' (directory), 'l' (symbolic link), 'f' (regular file).
+
+*   -user username
+
+    Evaluates as true if the owner of the file matches the specified user.
 
 The following operators are recognised:
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestAmin.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestAmin.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestAmin {
+  private static final long MIN = 60L * 1000L;
+  private static final long NOW = new Date().getTime();
+  private FileSystem mockFs;
+
+  private PathData fourMinutes;
+  private PathData fiveMinutes;
+  private PathData fiveMinutesMinus;
+  private PathData sixMinutes;
+  private PathData sixMinutesMinus;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    fourMinutes = createPathData("fourMinutes", NOW - (4L * MIN));
+    fiveMinutes = createPathData("fiveMinutes", NOW - (5L * MIN));
+    fiveMinutesMinus = createPathData("fiveMinutesMinus", NOW - ((5L * MIN) - 1L));
+    sixMinutes = createPathData("sixMinutes", NOW - (6L * MIN));
+    sixMinutesMinus = createPathData("sixMinutesMinus", NOW - ((6L * MIN) - 1L));
+  }
+
+  private PathData createPathData(String name, long atime) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getAccessTime()).thenReturn(atime);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test an exact match
+  @Test
+  public void testExact() throws IOException {
+    Atime.Amin amin = new Atime.Amin();
+    addArgument(amin, "5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    amin.setOptions(options);
+    amin.prepare();
+
+    assertEquals(Result.FAIL, amin.apply(fourMinutes, -1));
+    assertEquals(Result.FAIL, amin.apply(fiveMinutesMinus, -1));
+    assertEquals(Result.PASS, amin.apply(fiveMinutes, -1));
+    assertEquals(Result.PASS, amin.apply(sixMinutesMinus, -1));
+    assertEquals(Result.FAIL, amin.apply(sixMinutes, -1));
+  }
+
+  // test a greater than match
+  @Test
+  public void testGreater() throws IOException {
+    Atime.Amin amin = new Atime.Amin();
+    addArgument(amin, "+5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    amin.setOptions(options);
+    amin.prepare();
+
+    assertEquals(Result.FAIL, amin.apply(fourMinutes, -1));
+    assertEquals(Result.FAIL, amin.apply(fiveMinutesMinus, -1));
+    assertEquals(Result.FAIL, amin.apply(fiveMinutes, -1));
+    assertEquals(Result.FAIL, amin.apply(sixMinutesMinus, -1));
+    assertEquals(Result.PASS, amin.apply(sixMinutes, -1));
+  }
+
+  // test a less than match
+  @Test
+  public void testLess() throws IOException {
+    Atime.Amin amin = new Atime.Amin();
+    addArgument(amin, "-5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    amin.setOptions(options);
+    amin.prepare();
+
+    assertEquals(Result.PASS, amin.apply(fourMinutes, -1));
+    assertEquals(Result.PASS, amin.apply(fiveMinutesMinus, -1));
+    assertEquals(Result.FAIL, amin.apply(fiveMinutes, -1));
+    assertEquals(Result.FAIL, amin.apply(sixMinutesMinus, -1));
+    assertEquals(Result.FAIL, amin.apply(sixMinutes, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestAtime.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestAtime.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestAtime {
+  private static final long DAY = 86400L * 1000L;
+  private static final long NOW = new Date().getTime();
+
+  private FileSystem mockFs;
+
+  private PathData fourDays;
+  private PathData fiveDays;
+  private PathData fiveDaysMinus;
+  private PathData sixDays;
+  private PathData sixDaysMinus;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    fourDays = createPathData("fourDays", NOW - (4L * DAY));
+    fiveDays = createPathData("fiveDays", NOW - (5L * DAY));
+    fiveDaysMinus = createPathData("fiveDaysMinus", NOW - ((5L * DAY) - 1L));
+    sixDays = createPathData("sixDays", (6L * DAY));
+    sixDaysMinus = createPathData("sixDaysMinus", NOW - ((6L * DAY) - 1L));
+  }
+
+  private PathData createPathData(String name, long atime) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getAccessTime()).thenReturn(atime);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test exact match
+  @Test
+  public void testExact() throws IOException {
+    Atime atime = new Atime();
+    addArgument(atime, "5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    atime.setOptions(options);
+    atime.prepare();
+
+    assertEquals(Result.FAIL, atime.apply(fourDays, -1));
+    assertEquals(Result.FAIL, atime.apply(fiveDaysMinus, -1));
+    assertEquals(Result.PASS, atime.apply(fiveDays, -1));
+    assertEquals(Result.PASS, atime.apply(sixDaysMinus, -1));
+    assertEquals(Result.FAIL, atime.apply(sixDays, -1));
+  }
+
+  // test greater than match
+  @Test
+  public void testGreater() throws IOException {
+    Atime atime = new Atime();
+    addArgument(atime, "+5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    atime.setOptions(options);
+    atime.prepare();
+
+    assertEquals(Result.FAIL, atime.apply(fourDays, -1));
+    assertEquals(Result.FAIL, atime.apply(fiveDaysMinus, -1));
+    assertEquals(Result.FAIL, atime.apply(fiveDays, -1));
+    assertEquals(Result.FAIL, atime.apply(sixDaysMinus, -1));
+    assertEquals(Result.PASS, atime.apply(sixDays, -1));
+  }
+
+  // test less than match
+  @Test
+  public void testLess() throws IOException {
+    Atime atime = new Atime();
+    addArgument(atime, "-5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    atime.setOptions(options);
+    atime.prepare();
+
+    assertEquals(Result.PASS, atime.apply(fourDays, -1));
+    assertEquals(Result.PASS, atime.apply(fiveDaysMinus, -1));
+    assertEquals(Result.FAIL, atime.apply(fiveDays, -1));
+    assertEquals(Result.FAIL, atime.apply(sixDaysMinus, -1));
+    assertEquals(Result.FAIL, atime.apply(sixDays, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestBlocksize.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestBlocksize.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestBlocksize {
+  private FileSystem mockFs;
+
+  private PathData one;
+  private PathData two;
+  private PathData three;
+  private PathData four;
+  private PathData five;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    one = createPathData("one", 1);
+    two = createPathData("two", 2);
+    three = createPathData("three", 3);
+    four = createPathData("four", 4);
+    five = createPathData("five", 5);
+  }
+
+  private PathData createPathData(String name, long blockSize) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getBlockSize()).thenReturn(blockSize);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test exact match
+  @Test
+  public void applyEquals() throws IOException {
+    Blocksize blocksize = new Blocksize();
+    addArgument(blocksize, "3");
+    blocksize.setOptions(new FindOptions());
+    blocksize.prepare();
+
+    assertEquals(Result.FAIL, blocksize.apply(one, -1));
+    assertEquals(Result.FAIL, blocksize.apply(two, -1));
+    assertEquals(Result.PASS, blocksize.apply(three, -1));
+    assertEquals(Result.FAIL, blocksize.apply(four, -1));
+    assertEquals(Result.FAIL, blocksize.apply(five, -1));
+  }
+
+  // test greater than match
+  @Test
+  public void applyGreaterThan() throws IOException {
+    Blocksize blocksize = new Blocksize();
+    addArgument(blocksize, "+3");
+    blocksize.setOptions(new FindOptions());
+    blocksize.prepare();
+
+    assertEquals(Result.FAIL, blocksize.apply(one, -1));
+    assertEquals(Result.FAIL, blocksize.apply(two, -1));
+    assertEquals(Result.FAIL, blocksize.apply(three, -1));
+    assertEquals(Result.PASS, blocksize.apply(four, -1));
+    assertEquals(Result.PASS, blocksize.apply(five, -1));
+  }
+
+  // test less than match
+  @Test
+  public void applyLessThan() throws IOException {
+    Blocksize blocksize = new Blocksize();
+    addArgument(blocksize, "-3");
+    blocksize.setOptions(new FindOptions());
+    blocksize.prepare();
+
+    assertEquals(Result.PASS, blocksize.apply(one, -1));
+    assertEquals(Result.PASS, blocksize.apply(two, -1));
+    assertEquals(Result.FAIL, blocksize.apply(three, -1));
+    assertEquals(Result.FAIL, blocksize.apply(four, -1));
+    assertEquals(Result.FAIL, blocksize.apply(five, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestEmpty.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestEmpty.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestEmpty {
+  private FileSystem mockFs;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+  }
+
+  private PathData createPathData(String name, boolean isEmpty, boolean isDir) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.isDirectory()).thenReturn(isDir);
+    when(fileStatus.getLen()).thenReturn(isEmpty ? 0L : 1L);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    when(mockFs.listStatus(eq(path))).thenReturn(
+        isEmpty ? new FileStatus[0] : new FileStatus[] {new FileStatus()});
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test with an empty file
+  @Test
+  public void applyEmptyFile() throws IOException {
+    PathData item = createPathData("emptyFile", true, false);
+
+    Empty empty = new Empty();
+    empty.setOptions(new FindOptions());
+
+    assertEquals(Result.PASS, empty.apply(item, -1));
+  }
+
+  // test with a non-empty file
+  @Test
+  public void applyNotEmptyFile() throws IOException {
+    PathData item = createPathData("notEmptyFile", false, false);
+
+    Empty empty = new Empty();
+    empty.setOptions(new FindOptions());
+
+    assertEquals(Result.FAIL, empty.apply(item, -1));
+  }
+
+  // test with an empty directory
+  @Test
+  public void applyEmptyDirectory() throws IOException {
+    PathData item = createPathData("emptyDirectory", true, true);
+
+    Empty empty = new Empty();
+    empty.setOptions(new FindOptions());
+
+    assertEquals(Result.PASS, empty.apply(item, -1));
+  }
+
+  // test with a non-empty directory
+  @Test
+  public void applyNotEmptyDirectory() throws IOException {
+    PathData item = createPathData("notEmptyDirectory", false, true);
+
+    Empty empty = new Empty();
+    empty.setOptions(new FindOptions());
+
+    assertEquals(Result.FAIL, empty.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestFind.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestFind.java
@@ -213,6 +213,210 @@ public class TestFind {
     assertEquals(expected, expression.toString());
   }
 
+  // check -atime is correct handled
+  @Test
+  public void processOptionsAtime() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -atime 10";
+    String expected = "And(;Atime(10;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -amin is correctly handled
+  @Test
+  public void processOptionsAmin() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -amin 10";
+    String expected = "And(;Amin-Atime(10;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -blocksize is correctly handled
+  @Test
+  public void processOptionsBlocksize() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -blocksize 16";
+    String expected = "And(;Blocksize(16;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -empty is handled correctly
+  @Test
+  public void processOptionsEmpty() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -empty ";
+    String expected = "And(;Empty(;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -group is handled correctly
+  @Test
+  public void processOptionsGroup() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -group groupname";
+    String expected = "And(;Group(groupname;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -mtime is handled correctly
+  @Test
+  public void processOptionsMtime() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -mtime 40";
+    String expected = "And(;Mtime(40;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -mmin is handled correctly
+  @Test
+  public void processOptionsMmin() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -mmin 40";
+    String expected = "And(;Mmin-Mtime(40;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -newer is handled correctly
+  @Test
+  public void processOptionsNewer() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -newer 50";
+    String expected = "And(;Newer(50;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -nogroup is handled correctly
+  @Test
+  public void processOptionsNogroup() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -nogroup ";
+    String expected = "And(;Nogroup(;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -nouser is handled correctly
+  @Test
+  public void processOptionsNouser() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -nouser ";
+    String expected = "And(;Nouser(;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -perm is handled correctly
+  @Test
+  public void processOptionsPerm() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -perm permission";
+    String expected = "And(;Perm(permission;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -regex is handled correctly
+  @Test
+  public void processOptionsRegex() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -regex pattern";
+    String expected = "And(;Regex(pattern;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -iregex is handled correctly
+  @Test
+  public void processOptionsIregex() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -iregex pattern";
+    String expected = "And(;Iregex-Regex(pattern;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -replicas is handled correctly
+  @Test
+  public void processOptionsReplicas() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -replicas 60";
+    String expected = "And(;Replicas(60;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -size is handled correctly
+  @Test
+  public void processOptionsSize() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -size 60";
+    String expected = "And(;Size(60;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -type is handled correctly
+  @Test
+  public void processOptionsType() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -type d";
+    String expected = "And(;Type(d;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
+  // check -user is handled correctly
+  @Test
+  public void processOptionsUser() throws IOException {
+    Find find = new Find();
+    find.setConf(conf);
+    String args = "path -user username";
+    String expected = "And(;User(username;),Print(;))";
+    find.processOptions(getArgs(args));
+    Expression expression = find.getRootExpression();
+    assertEquals(expected, expression.toString());
+  }
+
   // check an implicit and is handled correctly
   @Test
   public void processOptionsNoop() throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestGroup.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestGroup.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestGroup {
+  private FileSystem mockFs;
+  private FileStatus fileStatus;
+  private PathData item;
+  private Group group;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    Path path = new Path("/one/two/test");
+    fileStatus = mock(FileStatus.class);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    item = new PathData(path.toString(), mockFs.getConf());
+
+    group = new Group();
+    addArgument(group, "group");
+    group.setOptions(new FindOptions());
+    group.prepare();
+  }
+
+  // test a matching group
+  @Test
+  public void applyMatch() throws IOException {
+    when(fileStatus.getGroup()).thenReturn("group");
+
+    assertEquals(Result.PASS, group.apply(item, -1));
+  }
+
+  // test a non-matching group
+  @Test
+  public void applyNotMatch() throws IOException {
+    when(fileStatus.getGroup()).thenReturn("notgroup");
+
+    assertEquals(Result.FAIL, group.apply(item, -1));
+  }
+
+  // test a blank group
+  @Test
+  public void applyBlank() throws IOException {
+    when(fileStatus.getGroup()).thenReturn("");
+
+    assertEquals(Result.FAIL, group.apply(item, -1));
+  }
+
+  // test a null group
+  @Test
+  public void applyNull() throws IOException {
+    when(fileStatus.getGroup()).thenReturn(null);
+
+    assertEquals(Result.FAIL, group.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestIregex.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestIregex.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.shell.PathData;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestIregex {
+  private FileSystem mockFs;
+  private Regex.Iregex regex;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+  }
+
+  private void setup(String pattern) throws IOException {
+    regex = new Regex.Iregex();
+    addArgument(regex, pattern);
+    regex.setOptions(new FindOptions());
+    regex.prepare();
+  }
+
+  // test a matching tail
+  @Test
+  public void applyPassTail() throws IOException {
+    setup(".*name");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+
+  // test a matching middle
+  @Test
+  public void applyPassMid() throws IOException {
+    setup(".*path.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+
+  // test a matching head
+  @Test
+  public void applyPassHead() throws IOException {
+    setup("/dir.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+
+  // test a non-matching regex
+  @Test
+  public void applyFail() throws IOException {
+    setup(".*not.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+
+  // test a non-matching head
+  @Test
+  public void applyFailHead() throws IOException {
+    setup("path.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+
+  // test a non-matching tail
+  @Test
+  public void applyFailTail() throws IOException {
+    setup(".*path");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+
+  // test matching mixed case
+  @Test
+  public void applyMixedCase() throws IOException {
+    setup(".*name");
+    PathData item = new PathData("/directory/path/NaMe", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestMmin.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestMmin.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestMmin {
+  private static final long MIN = 60L * 1000L;
+  private static final long NOW = new Date().getTime();
+
+  private FileSystem mockFs;
+
+  private PathData fourMinutes;
+  private PathData fiveMinutes;
+  private PathData fiveMinutesMinus;
+  private PathData sixMinutes;
+  private PathData sixMinutesMinus;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    fourMinutes = createPathData("fourMinutes", NOW - (4L * MIN));
+    fiveMinutes = createPathData("fiveMinutes", NOW - (5L * MIN));
+    fiveMinutesMinus = createPathData("fiveMinutesMinus", NOW - ((5L * MIN) - 1L));
+    sixMinutes = createPathData("sixMinutes", (6L * MIN));
+    sixMinutesMinus = createPathData("fiveMinutesPlus", NOW - ((6L * MIN) - 1L));
+  }
+
+  private PathData createPathData(String name, long mtime) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getModificationTime()).thenReturn(mtime);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test an exact match
+  @Test
+  public void testExact() throws IOException {
+    Mtime.Mmin mmin = new Mtime.Mmin();
+    addArgument(mmin, "5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    mmin.setOptions(options);
+    mmin.prepare();
+
+    assertEquals(Result.FAIL, mmin.apply(fourMinutes, -1));
+    assertEquals(Result.FAIL, mmin.apply(fiveMinutesMinus, -1));
+    assertEquals(Result.PASS, mmin.apply(fiveMinutes, -1));
+    assertEquals(Result.PASS, mmin.apply(sixMinutesMinus, -1));
+    assertEquals(Result.FAIL, mmin.apply(sixMinutes, -1));
+  }
+
+  // test a greater than match
+  @Test
+  public void testGreater() throws IOException {
+    Mtime.Mmin mmin = new Mtime.Mmin();
+    addArgument(mmin, "+5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    mmin.setOptions(options);
+    mmin.prepare();
+
+    assertEquals(Result.FAIL, mmin.apply(fourMinutes, -1));
+    assertEquals(Result.FAIL, mmin.apply(fiveMinutesMinus, -1));
+    assertEquals(Result.FAIL, mmin.apply(fiveMinutes, -1));
+    assertEquals(Result.FAIL, mmin.apply(sixMinutesMinus, -1));
+    assertEquals(Result.PASS, mmin.apply(sixMinutes, -1));
+  }
+
+  // test a less than match
+  @Test
+  public void testLess() throws IOException {
+    Mtime.Mmin mmin = new Mtime.Mmin();
+    addArgument(mmin, "-5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    mmin.setOptions(options);
+    mmin.prepare();
+
+    assertEquals(Result.PASS, mmin.apply(fourMinutes, -1));
+    assertEquals(Result.PASS, mmin.apply(fiveMinutesMinus, -1));
+    assertEquals(Result.FAIL, mmin.apply(fiveMinutes, -1));
+    assertEquals(Result.FAIL, mmin.apply(sixMinutesMinus, -1));
+    assertEquals(Result.FAIL, mmin.apply(sixMinutes, -1));
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestMtime.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestMtime.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestMtime {
+  private static final long DAY = 86400L * 1000L;
+  private static final long NOW = new Date().getTime();
+  private FileSystem mockFs;
+
+  private PathData fourDays;
+  private PathData fiveDays;
+  private PathData fiveDaysMinus;
+  private PathData sixDays;
+  private PathData sixDaysMinus;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    fourDays = createPathData("fourDays", NOW - (4L * DAY));
+    fiveDays = createPathData("fiveDays", NOW - (5L * DAY));
+    fiveDaysMinus = createPathData("fiveDaysMinus", NOW - ((5L * DAY) - 1L));
+    sixDays = createPathData("sixDays", NOW - (6L * DAY));
+    sixDaysMinus = createPathData("sixDaysMinus", NOW - ((6L * DAY) - 1L));
+  }
+
+  private PathData createPathData(String name, long mtime) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getModificationTime()).thenReturn(mtime);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test an exact match
+  @Test
+  public void testExact() throws IOException {
+    Mtime mtime = new Mtime();
+    addArgument(mtime, "5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    mtime.setOptions(options);
+    mtime.prepare();
+
+    assertEquals(Result.FAIL, mtime.apply(fourDays, -1));
+    assertEquals(Result.FAIL, mtime.apply(fiveDaysMinus, -1));
+    assertEquals(Result.PASS, mtime.apply(fiveDays, -1));
+    assertEquals(Result.PASS, mtime.apply(sixDaysMinus, -1));
+    assertEquals(Result.FAIL, mtime.apply(sixDays, -1));
+  }
+
+  // test a greater than match
+  @Test
+  public void testGreater() throws IOException {
+    Mtime mtime = new Mtime();
+    addArgument(mtime, "+5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    mtime.setOptions(options);
+    mtime.prepare();
+
+    assertEquals(Result.FAIL, mtime.apply(fourDays, -1));
+    assertEquals(Result.FAIL, mtime.apply(fiveDaysMinus, -1));
+    assertEquals(Result.FAIL, mtime.apply(fiveDays, -1));
+    assertEquals(Result.FAIL, mtime.apply(sixDaysMinus, -1));
+    assertEquals(Result.PASS, mtime.apply(sixDays, -1));
+  }
+
+  // test a less than match
+  @Test
+  public void testLess() throws IOException {
+    Mtime mtime = new Mtime();
+    addArgument(mtime, "-5");
+
+    FindOptions options = new FindOptions();
+    options.setStartTime(NOW);
+    mtime.setOptions(options);
+    mtime.prepare();
+
+    assertEquals(Result.PASS, mtime.apply(fourDays, -1));
+    assertEquals(Result.PASS, mtime.apply(fiveDaysMinus, -1));
+    assertEquals(Result.FAIL, mtime.apply(fiveDays, -1));
+    assertEquals(Result.FAIL, mtime.apply(sixDaysMinus, -1));
+    assertEquals(Result.FAIL, mtime.apply(sixDays, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNewer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNewer.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestNewer {
+  private static final long DAY = 86400L * 1000L;
+  private static final long NOW = new Date().getTime();
+  private FileSystem mockFs;
+  private Newer newer;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    PathData comparison = createPathData("comparison.file", NOW - (5L * DAY));
+
+    newer = new Newer();
+    newer.setConf(mockFs.getConf());
+    addArgument(newer, comparison.toString());
+    newer.setOptions(new FindOptions());
+    newer.prepare();
+  }
+
+  private PathData createPathData(String name, long mtime) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getModificationTime()).thenReturn(mtime);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test a newer file
+  @Test
+  public void testNewer() throws IOException {
+    PathData item = createPathData("/directory/path/newer.file", NOW - (4L * DAY));
+    assertEquals(Result.PASS, newer.apply(item, -1));
+  }
+
+  // test an equal-time file
+  @Test
+  public void testEqual() throws IOException {
+    PathData item = createPathData("/directory/path/equal.file", NOW - (5L * DAY));
+    assertEquals(Result.FAIL, newer.apply(item, -1));
+  }
+
+  // test an older file
+  @Test
+  public void testOlder() throws IOException {
+    PathData item = createPathData("/directory/path/older.file", NOW - (6L * DAY));
+    assertEquals(Result.FAIL, newer.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNogroup.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNogroup.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestNogroup {
+  private FileSystem mockFs;
+  private FileStatus fileStatus;
+  private PathData item;
+  private Nogroup nogroup;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    Path path = new Path("/one/two/test");
+    fileStatus = mock(FileStatus.class);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    item = new PathData(path.toString(), mockFs.getConf());
+
+    nogroup = new Nogroup();
+    nogroup.setOptions(new FindOptions());
+  }
+
+  // test file that has a group
+  @Test
+  public void applyHasGroup() throws IOException {
+    when(fileStatus.getGroup()).thenReturn("user");
+
+    assertEquals(Result.FAIL, nogroup.apply(item, -1));
+  }
+
+  // test file that has a blank group
+  @Test
+  public void applyBlank() throws IOException {
+    when(fileStatus.getGroup()).thenReturn("");
+
+    assertEquals(Result.PASS, nogroup.apply(item, -1));
+  }
+
+  // test file that has a null group
+  @Test
+  public void applyNull() throws IOException {
+    when(fileStatus.getGroup()).thenReturn(null);
+
+    assertEquals(Result.PASS, nogroup.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNouser.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNouser.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestNouser {
+  private FileSystem mockFs;
+  private FileStatus fileStatus;
+  private PathData item;
+  private Nouser nouser;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    Path path = new Path("/one/two/test");
+    fileStatus = mock(FileStatus.class);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    item = new PathData(path.toString(), mockFs.getConf());
+
+    nouser = new Nouser();
+    nouser.setOptions(new FindOptions());
+  }
+
+  // test with an existing user
+  @Test
+  public void applyPass() throws IOException {
+    when(fileStatus.getOwner()).thenReturn("user");
+
+    assertEquals(Result.FAIL, nouser.apply(item, -1));
+  }
+
+  // test with a blank user
+  @Test
+  public void applyBlank() throws IOException {
+    when(fileStatus.getOwner()).thenReturn("");
+
+    assertEquals(Result.PASS, nouser.apply(item, -1));
+  }
+
+  // test with a null user
+  @Test
+  public void applyNull() throws IOException {
+    when(fileStatus.getOwner()).thenReturn(null);
+
+    assertEquals(Result.PASS, nouser.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNumberExpression.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestNumberExpression.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestNumberExpression {
+
+  private final NumberExpression numberExpr = new NumberExpression() {
+    @Override
+    public Result apply(PathData item, int depth) {
+      return null;
+    }
+  };
+
+  // test the applyNumber method with an exact match
+  @Test
+  public void applyNumberEquals() throws IOException {
+    addArgument(numberExpr, "5");
+    numberExpr.setOptions(new FindOptions());
+    numberExpr.prepare();
+    assertEquals(Result.PASS, numberExpr.applyNumber(5));
+    assertEquals(Result.FAIL, numberExpr.applyNumber(4));
+    assertEquals(Result.FAIL, numberExpr.applyNumber(6));
+  }
+
+  // test the applyNumber method with a greater than match
+  @Test
+  public void applyNumberGreaterThan() throws IOException {
+    addArgument(numberExpr, "+5");
+    numberExpr.setOptions(new FindOptions());
+    numberExpr.prepare();
+    assertEquals(Result.FAIL, numberExpr.applyNumber(5));
+    assertEquals(Result.FAIL, numberExpr.applyNumber(4));
+    assertEquals(Result.PASS, numberExpr.applyNumber(6));
+  }
+
+  // test the applyNumber method with a less than match
+  @Test
+  public void applyNumberLessThan() throws IOException {
+    addArgument(numberExpr, "-5");
+    numberExpr.setOptions(new FindOptions());
+    numberExpr.prepare();
+    assertEquals(Result.FAIL, numberExpr.applyNumber(5));
+    assertEquals(Result.PASS, numberExpr.applyNumber(4));
+    assertEquals(Result.FAIL, numberExpr.applyNumber(6));
+  }
+
+  // test an invalid empty argument throws an exception
+  @Test
+  public void testInvalidEmptyArgument() throws IOException {
+    addArgument(numberExpr, "");
+    numberExpr.setOptions(new FindOptions());
+    IllegalArgumentException expected =
+        assertThrows(IllegalArgumentException.class, numberExpr::prepare);
+    assertEquals("Invalid empty argument", expected.getMessage());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestPerm.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestPerm.java
@@ -41,6 +41,7 @@ public class TestPerm {
   private PathData mode777;
   private PathData mode700;
   private PathData mode444;
+  private PathData mode730;
   private PathData mode740;
   private PathData mode123;
 
@@ -51,6 +52,7 @@ public class TestPerm {
     mode777 = createPathData("rwxrwxrwx", "-rwxrwxrwx");
     mode700 = createPathData("rwx______", "-rwx------");
     mode444 = createPathData("r__r__r__", "-r--r--r--");
+    mode730 = createPathData("rwx_wx___", "-rwx-wx---");
     mode740 = createPathData("rwxr_____", "-rwxr-----");
     mode123 = createPathData("__x_w__wx", "---x-w--wx");
   }
@@ -74,6 +76,7 @@ public class TestPerm {
     assertEquals(Result.FAIL, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.PASS, perm.apply(mode123, -1));
   }
@@ -89,6 +92,7 @@ public class TestPerm {
     assertEquals(Result.PASS, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.PASS, perm.apply(mode123, -1));
   }
@@ -104,6 +108,7 @@ public class TestPerm {
     assertEquals(Result.FAIL, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.PASS, perm.apply(mode123, -1));
   }
@@ -119,8 +124,25 @@ public class TestPerm {
     assertEquals(Result.PASS, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test a complex symbolic mode
+  @Test
+  public void applySymbolicMultipleOperator() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "u=rwx,g+x+w");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.FAIL, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.PASS, perm.apply(mode730, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.FAIL, perm.apply(mode123, -1));
   }
 
   // test a complex symbolic mode
@@ -134,6 +156,7 @@ public class TestPerm {
     assertEquals(Result.FAIL, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.PASS, perm.apply(mode123, -1));
   }
@@ -149,6 +172,7 @@ public class TestPerm {
     assertEquals(Result.PASS, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.FAIL, perm.apply(mode123, -1));
   }
@@ -164,6 +188,7 @@ public class TestPerm {
     assertEquals(Result.PASS, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.PASS, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.FAIL, perm.apply(mode123, -1));
   }
@@ -179,6 +204,7 @@ public class TestPerm {
     assertEquals(Result.FAIL, perm.apply(mode777, -1));
     assertEquals(Result.FAIL, perm.apply(mode700, -1));
     assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode730, -1));
     assertEquals(Result.FAIL, perm.apply(mode740, -1));
     assertEquals(Result.PASS, perm.apply(mode123, -1));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestPerm.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestPerm.java
@@ -1,0 +1,217 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestPerm {
+  private FileSystem mockFs;
+
+  private PathData mode777;
+  private PathData mode700;
+  private PathData mode444;
+  private PathData mode740;
+  private PathData mode123;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    mode777 = createPathData("rwxrwxrwx", "-rwxrwxrwx");
+    mode700 = createPathData("rwx______", "-rwx------");
+    mode444 = createPathData("r__r__r__", "-r--r--r--");
+    mode740 = createPathData("rwxr_____", "-rwxr-----");
+    mode123 = createPathData("__x_w__wx", "---x-w--wx");
+  }
+
+  private PathData createPathData(String name, String permission) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getPermission()).thenReturn(FsPermission.valueOf(permission));
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(path.toString(), mockFs.getConf());
+  }
+
+  // test an exact match of an octal mode
+  @Test
+  public void applyOctalExact() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "123");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.FAIL, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test a masked match of an octal mode
+  @Test
+  public void applyOctalMask() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "-123");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.PASS, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test an exact match of a symbolic mode
+  @Test
+  public void applySymbolicExact() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "u=x,g=w,o=wx");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.FAIL, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test a masked match of a symbolic mode
+  @Test
+  public void applySymbolicMask() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "-u=x,g=w,o=wx");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.PASS, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test a complex symbolic mode
+  @Test
+  public void applySymbolicComplex() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "u=xrw,g=x,o=wx,u-rw,g+w,g-x");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.FAIL, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test an all symbolic mode
+  @Test
+  public void applyAllSymbolic() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "a=rwx");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.PASS, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.FAIL, perm.apply(mode123, -1));
+  }
+
+  // test a masked match of a all symbolic mode
+  @Test
+  public void applyAllSymbolicMask() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "-a=r");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.PASS, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.PASS, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.FAIL, perm.apply(mode123, -1));
+  }
+
+  // test a complex all symbolic mode
+  @Test
+  public void applyAllSymbolicComplex() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "a=rwx,u-rw,g-rx,g+w,o-r");
+    perm.setOptions(new FindOptions());
+    perm.prepare();
+
+    assertEquals(Result.FAIL, perm.apply(mode777, -1));
+    assertEquals(Result.FAIL, perm.apply(mode700, -1));
+    assertEquals(Result.FAIL, perm.apply(mode444, -1));
+    assertEquals(Result.FAIL, perm.apply(mode740, -1));
+    assertEquals(Result.PASS, perm.apply(mode123, -1));
+  }
+
+  // test an invalid octal perm throws an exception
+  @ParameterizedTest
+  @ValueSource(strings = {"888", "1888"})
+  public void testInvalidOctalPerm(String argument) throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, argument);
+    perm.setOptions(new FindOptions());
+    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, perm::prepare);
+    assertEquals(argument, expected.getMessage());
+  }
+
+  // test an invalid perm throws an exception
+  @ParameterizedTest
+  @ValueSource(strings = {"t=x,g=w,o=wx", "u^x,g=w,o=wx", "u", "u=v,g=w,o=wx"})
+  public void testInvalidPerm(String argument) throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, argument);
+    perm.setOptions(new FindOptions());
+    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, perm::prepare);
+    assertEquals("Invalid mode: " + argument, expected.getMessage());
+  }
+
+  // test an invalid empty argument throws an exception
+  @Test
+  public void testInvalidEmptyArgument() throws IOException {
+    Perm perm = new Perm();
+    addArgument(perm, "");
+    perm.setOptions(new FindOptions());
+    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, perm::prepare);
+    assertEquals("Invalid empty argument", expected.getMessage());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestPerm.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestPerm.java
@@ -222,7 +222,7 @@ public class TestPerm {
 
   // test an invalid perm throws an exception
   @ParameterizedTest
-  @ValueSource(strings = {"t=x,g=w,o=wx", "u^x,g=w,o=wx", "u", "u=v,g=w,o=wx"})
+  @ValueSource(strings = {"t=x,g=w,o=wx", "u^x,g=w,o=wx", "u", "u=v,g=w,o=wx", "u=rwx,g"})
   public void testInvalidPerm(String argument) throws IOException {
     Perm perm = new Perm();
     addArgument(perm, argument);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestRegex.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestRegex.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestRegex {
+  private FileSystem mockFs;
+  private Regex regex;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+  }
+
+  private void setup(String pattern) throws IOException {
+    regex = new Regex();
+    addArgument(regex, pattern);
+    FindOptions options = new FindOptions();
+    options.setConfiguration(new Configuration());
+    regex.setOptions(options);
+    regex.prepare();
+  }
+
+  // test a matching tail
+  @Test
+  public void applyPassTail() throws IOException {
+    setup(".*name");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+
+  // test a matching middle
+  @Test
+  public void applyPassMid() throws IOException {
+    setup(".*path.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+
+  // test a matching head
+  @Test
+  public void applyPassHead() throws IOException {
+    setup("/dir.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.PASS, regex.apply(item, -1));
+  }
+
+  // test a non-matching regex
+  @Test
+  public void applyFail() throws IOException {
+    setup(".*not.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+
+  // test a non-matching head
+  @Test
+  public void applyFailHead() throws IOException {
+    setup("path.*");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+
+  // test a non-matching tail
+  @Test
+  public void applyFailTail() throws IOException {
+    setup(".*path");
+    PathData item = new PathData("/directory/path/name", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+
+  // test matching mixed case
+  @Test
+  public void applyMixedCase() throws IOException {
+    setup(".*name");
+    PathData item = new PathData("/directory/path/NaMe", mockFs.getConf());
+    assertEquals(Result.FAIL, regex.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestReplicas.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestReplicas.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestReplicas {
+  private FileSystem mockFs;
+
+  private PathData one;
+  private PathData two;
+  private PathData three;
+  private PathData four;
+  private PathData five;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    one = createPathData("one", (short) 1);
+    two = createPathData("two", (short) 2);
+    three = createPathData("three", (short) 3);
+    four = createPathData("four", (short) 4);
+    five = createPathData("five", (short) 5);
+  }
+
+  private PathData createPathData(String name, short replicas) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getReplication()).thenReturn(replicas);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test an exact match
+  @Test
+  public void applyEquals() throws IOException {
+    Replicas rep = new Replicas();
+    addArgument(rep, "3");
+    rep.setOptions(new FindOptions());
+    rep.prepare();
+
+    assertEquals(Result.FAIL, rep.apply(one, -1));
+    assertEquals(Result.FAIL, rep.apply(two, -1));
+    assertEquals(Result.PASS, rep.apply(three, -1));
+    assertEquals(Result.FAIL, rep.apply(four, -1));
+    assertEquals(Result.FAIL, rep.apply(five, -1));
+  }
+
+  // test a greater than match
+  @Test
+  public void applyGreaterThan() throws IOException {
+    Replicas rep = new Replicas();
+    addArgument(rep, "+3");
+    rep.setOptions(new FindOptions());
+    rep.prepare();
+
+    assertEquals(Result.FAIL, rep.apply(one, -1));
+    assertEquals(Result.FAIL, rep.apply(two, -1));
+    assertEquals(Result.FAIL, rep.apply(three, -1));
+    assertEquals(Result.PASS, rep.apply(four, -1));
+    assertEquals(Result.PASS, rep.apply(five, -1));
+  }
+
+  // test a less than match
+  @Test
+  public void applyLessThan() throws IOException {
+    Replicas rep = new Replicas();
+    addArgument(rep, "-3");
+    rep.setOptions(new FindOptions());
+    rep.prepare();
+
+    assertEquals(Result.PASS, rep.apply(one, -1));
+    assertEquals(Result.PASS, rep.apply(two, -1));
+    assertEquals(Result.FAIL, rep.apply(three, -1));
+    assertEquals(Result.FAIL, rep.apply(four, -1));
+    assertEquals(Result.FAIL, rep.apply(five, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestSize.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestSize.java
@@ -70,8 +70,8 @@ public class TestSize {
     assertEquals(Result.PASS, size.apply(fiveBlocks, -1));
     assertEquals(Result.FAIL, size.apply(sixBlocks, -1));
     assertEquals(Result.FAIL, size.apply(fourBlocks, -1));
-    assertEquals(Result.PASS, size.apply(fiveBlocksPlus, -1));
-    assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.PASS, size.apply(fiveBlocksMinus, -1));
   }
 
   // test greater than match in blocks
@@ -85,7 +85,7 @@ public class TestSize {
     assertEquals(Result.FAIL, size.apply(fiveBlocks, -1));
     assertEquals(Result.PASS, size.apply(sixBlocks, -1));
     assertEquals(Result.FAIL, size.apply(fourBlocks, -1));
-    assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.PASS, size.apply(fiveBlocksPlus, -1));
     assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
   }
 
@@ -101,7 +101,7 @@ public class TestSize {
     assertEquals(Result.FAIL, size.apply(sixBlocks, -1));
     assertEquals(Result.PASS, size.apply(fourBlocks, -1));
     assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
-    assertEquals(Result.PASS, size.apply(fiveBlocksMinus, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
   }
 
   // test exact match in bytes

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestSize.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestSize.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestSize {
+  private FileSystem mockFs;
+
+  private PathData fiveBlocks;
+  private PathData fourBlocks;
+  private PathData sixBlocks;
+  private PathData fiveBlocksMinus;
+  private PathData fiveBlocksPlus;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    fiveBlocks = createPathData("fiveBlocks", 5L * 512L);
+    sixBlocks = createPathData("sixBlocks", 6L * 512L);
+    fourBlocks = createPathData("fourBlocks", 4L * 512L);
+    fiveBlocksPlus = createPathData("fiveBlocksPlus", (5L * 512L) + 511L);
+    fiveBlocksMinus = createPathData("fiveBlocksMinus", (5L * 512L) - 1L);
+  }
+
+  private PathData createPathData(String name, long length) throws IOException {
+    Path path = new Path(name);
+    FileStatus fileStatus = mock(FileStatus.class);
+    when(fileStatus.getLen()).thenReturn(length);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    return new PathData(name, mockFs.getConf());
+  }
+
+  // test exact match in blocks
+  @Test
+  public void applyEqualsBlock() throws IOException {
+    Size size = new Size();
+    addArgument(size, "5");
+    size.setOptions(new FindOptions());
+    size.prepare();
+
+    assertEquals(Result.PASS, size.apply(fiveBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(sixBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fourBlocks, -1));
+    assertEquals(Result.PASS, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
+  }
+
+  // test greater than match in blocks
+  @Test
+  public void applyGreaterThanBlock() throws IOException {
+    Size size = new Size();
+    addArgument(size, "+5");
+    size.setOptions(new FindOptions());
+    size.prepare();
+
+    assertEquals(Result.FAIL, size.apply(fiveBlocks, -1));
+    assertEquals(Result.PASS, size.apply(sixBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fourBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
+  }
+
+  // test less than match in blocks
+  @Test
+  public void applyLessThanBlock() throws IOException {
+    Size size = new Size();
+    addArgument(size, "-5");
+    size.setOptions(new FindOptions());
+    size.prepare();
+
+    assertEquals(Result.FAIL, size.apply(fiveBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(sixBlocks, -1));
+    assertEquals(Result.PASS, size.apply(fourBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.PASS, size.apply(fiveBlocksMinus, -1));
+  }
+
+  // test exact match in bytes
+  @Test
+  public void applyEqualsBytes() throws IOException {
+    Size size = new Size();
+    addArgument(size, (5 * 512) + "c");
+    size.setOptions(new FindOptions());
+    size.prepare();
+
+    assertEquals(Result.PASS, size.apply(fiveBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(sixBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fourBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
+  }
+
+  // test greater than match in bytes
+  @Test
+  public void applyGreaterThanBytes() throws IOException {
+    Size size = new Size();
+    addArgument(size, "+" + (5 * 512) + "c");
+    size.setOptions(new FindOptions());
+    size.prepare();
+
+    assertEquals(Result.FAIL, size.apply(fiveBlocks, -1));
+    assertEquals(Result.PASS, size.apply(sixBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fourBlocks, -1));
+    assertEquals(Result.PASS, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksMinus, -1));
+  }
+
+  // test less than match in bytes
+  @Test
+  public void applyLessThanBytes() throws IOException {
+    Size size = new Size();
+    addArgument(size, "-" + (5 * 512) + "c");
+    size.setOptions(new FindOptions());
+    size.prepare();
+
+    assertEquals(Result.FAIL, size.apply(fiveBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(sixBlocks, -1));
+    assertEquals(Result.PASS, size.apply(fourBlocks, -1));
+    assertEquals(Result.FAIL, size.apply(fiveBlocksPlus, -1));
+    assertEquals(Result.PASS, size.apply(fiveBlocksMinus, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestType.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestType.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestType {
+  private FileSystem mockFs;
+
+  private PathData item;
+  private FileStatus fileStatus;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    Path path = new Path("/one/two/test");
+    fileStatus = mock(FileStatus.class);
+    when(fileStatus.isDirectory()).thenReturn(false);
+    when(fileStatus.isSymlink()).thenReturn(false);
+    when(fileStatus.isFile()).thenReturn(false);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    item = new PathData(path.toString(), mockFs.getConf());
+  }
+
+  // test path is a directory
+  @Test
+  public void testIsDirectory() throws IOException {
+    Type type = new Type();
+    addArgument(type, "d");
+    type.setOptions(new FindOptions());
+    type.prepare();
+
+    when(fileStatus.isDirectory()).thenReturn(true);
+
+    assertEquals(Result.PASS, type.apply(item, -1));
+  }
+
+  // test path is not a directory
+  @Test
+  public void testIsNotDirectory() throws IOException {
+    Type type = new Type();
+    addArgument(type, "d");
+    type.setOptions(new FindOptions());
+    type.prepare();
+
+    when(fileStatus.isDirectory()).thenReturn(false);
+
+    assertEquals(Result.FAIL, type.apply(item, -1));
+  }
+
+  // test path is a symlink
+  @Test
+  public void testIsSymlink() throws IOException {
+    Type type = new Type();
+    addArgument(type, "l");
+    type.setOptions(new FindOptions());
+    type.prepare();
+
+    when(fileStatus.isSymlink()).thenReturn(true);
+
+    assertEquals(Result.PASS, type.apply(item, -1));
+  }
+
+  // test path is not a symlink
+  @Test
+  public void testIsNotSymlink() throws IOException {
+    Type type = new Type();
+    addArgument(type, "l");
+    type.setOptions(new FindOptions());
+    type.prepare();
+
+    when(fileStatus.isSymlink()).thenReturn(false);
+
+    assertEquals(Result.FAIL, type.apply(item, -1));
+  }
+
+  // test path is a file
+  @Test
+  public void testIsFile() throws IOException {
+    Type type = new Type();
+    addArgument(type, "f");
+    type.setOptions(new FindOptions());
+    type.prepare();
+
+    when(fileStatus.isFile()).thenReturn(true);
+
+    assertEquals(Result.PASS, type.apply(item, -1));
+  }
+
+  // test path is not a file
+  @Test
+  public void testIsNotFile() throws IOException {
+    Type type = new Type();
+    addArgument(type, "f");
+    type.setOptions(new FindOptions());
+    type.prepare();
+
+    when(fileStatus.isFile()).thenReturn(false);
+
+    assertEquals(Result.FAIL, type.apply(item, -1));
+  }
+
+  // test an invalid file type throws an exception
+  @Test
+  public void testInvalidType() throws IOException {
+    Type type = new Type();
+    addArgument(type, "a");
+    type.setOptions(new FindOptions());
+    IOException expected = assertThrows(IOException.class, type::prepare);
+    assertEquals("Invalid file type: a", expected.getMessage());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestUser.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestUser.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.shell.find;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.apache.hadoop.fs.shell.find.TestHelper.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.shell.PathData;
+
+public class TestUser {
+  private FileSystem mockFs;
+  private FileStatus fileStatus;
+  private PathData item;
+  private User user;
+
+  @BeforeEach
+  public void resetMock() throws IOException {
+    mockFs = MockFileSystem.setup();
+
+    Path path = new Path("/one/two/test");
+    fileStatus = mock(FileStatus.class);
+    when(mockFs.getFileStatus(eq(path))).thenReturn(fileStatus);
+    item = new PathData(path.toString(), mockFs.getConf());
+
+    user = new User();
+    addArgument(user, "user");
+    user.setOptions(new FindOptions());
+    user.prepare();
+  }
+
+  // test a matching file owner
+  @Test
+  public void applyMatch() throws IOException {
+    when(fileStatus.getOwner()).thenReturn("user");
+
+    assertEquals(Result.PASS, user.apply(item, -1));
+  }
+
+  // test a non-matching file owner
+  @Test
+  public void applyNotMatch() throws IOException {
+    when(fileStatus.getOwner()).thenReturn("notuser");
+
+    assertEquals(Result.FAIL, user.apply(item, -1));
+  }
+
+  // test a blank file owner
+  @Test
+  public void applyBlank() throws IOException {
+    when(fileStatus.getOwner()).thenReturn("");
+
+    assertEquals(Result.FAIL, user.apply(item, -1));
+  }
+
+  // test a null file owner
+  @Test
+  public void applyNull() throws IOException {
+    when(fileStatus.getOwner()).thenReturn(null);
+
+    assertEquals(Result.FAIL, user.apply(item, -1));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/resources/testConf.xml
+++ b/hadoop-common-project/hadoop-common/src/test/resources/testConf.xml
@@ -1161,21 +1161,85 @@
   applies selected actions to them\. If no &lt;path&gt; is specified
   then defaults to the current working directory\. If no
   expression is specified then defaults to -print\.
-  
+\s*
   The following primary expressions are recognised:
+    -atime n
+    -amin n
+      Evaluates as true if the file access time subtracted from
+      the start time is n days \(or minutes if -amin is used\)\.
+\s*
+    -blocksize n
+      Evaluates to true if the block size of the file is n\.
+\s*
+    -empty
+      Evaluates as true if the file is empty or directory has no
+      contents\.
+\s*
+    -group groupname
+      Evaluates as true if the file belongs to the specified
+      group\.
+\s*
+    -mtime n
+    -mmin n
+      Evaluates as true if the file modification time subtracted
+      from the start time is n days \(or minutes if -mmin is used\)
+\s*
     -name pattern
     -iname pattern
       Evaluates as true if the basename of the file matches the
       pattern using standard file system globbing\.
       If -iname is used then the match is case insensitive\.
-  
+\s*
+    -newer file
+      Evaluates as true if the modification time of the current
+      file is more recent than the modification time of the
+      specified file\.
+\s*
+    -nogroup
+      Evaluates as true if the file does not have a valid group\.
+\s*
+    -nouser
+      Evaluates as true if the file does not have a valid owner\.
+\s*
+    -perm \[-\]mode
+    -perm \[-\]onum
+      Evaluates as true if the file permissions match that
+      specified\. If the hyphen is specified then the expression
+      shall evaluate as true if at least the bits specified
+      match, otherwise an exact match is required\.
+      The mode may be specified using either symbolic notation,
+      eg 'u=rwx,g\+x\+w' or as an octal number\.
+\s*
     -print
     -print0
       Always evaluates to true. Causes the current pathname to be
       written to standard output followed by a newline. If the -print0
       expression is used then an ASCII NULL character is appended rather
       than a newline.
-  
+\s*
+    -regex pattern
+    -iregex pattern
+      Evaluates as true if the whole file path matches the
+      regular expression pattern\. If -iregex is used then
+      the match is case insensitive\.
+\s*
+    -replicas n
+      Evaluates to true if the number of file replicas is n\.
+\s*
+    -size n\[c\]
+      Evaluates to true if the file size in 512 byte blocks is n\.
+      If n is followed by the character 'c' then the size is in
+      bytes\.
+\s*
+    -type filetype
+      Evaluates to true if the file type matches that specified.
+      The following file type values are supported:
+      'd' \(directory\), 'l' \(symbolic link\), 'f' \(regular file\)\.
+\s*
+    -user username
+      Evaluates as true if the owner of the file matches the
+      specified user\.
+\s*
   The following operators are recognised:
     expression -a expression
     expression -and expression

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/cli/TestHDFSCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/cli/TestHDFSCLI.java
@@ -49,6 +49,8 @@ public class TestHDFSCLI extends CLITestHelperDFS {
     
     // Many of the tests expect a replication value of 1 in the output
     conf.setInt(DFSConfigKeys.DFS_REPLICATION_KEY, 1);
+    // Disable caching so that the configuration can be overridden
+    conf.setBoolean("fs.hdfs.impl.disable.cache", true);
 
     // Build racks and hosts configuration to test dfsAdmin -printTopology
     String [] racks =  {"/rack1", "/rack1", "/rack2", "/rack2",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testHDFSConf.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testHDFSConf.xml
@@ -17983,7 +17983,7 @@ $</expected-output>
         <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
         <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
         <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
-        <command>-fs NAMENODE -find /findtest -size +60c -size -1</command>
+        <command>-fs NAMENODE -find /findtest -size +1</command>
       </test-commands>
       <cleanup-commands>
         <command>-fs NAMENODE -rm -r /findtest</command>
@@ -17991,7 +17991,7 @@ $</expected-output>
       <comparators>
         <comparator>
           <type>RegexpAcrossOutputComparator</type>
-          <expected-output>^/findtest/item4/item4b
+          <expected-output>^/findtest/item5
 $</expected-output>
         </comparator>
       </comparators>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testHDFSConf.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testHDFSConf.xml
@@ -17622,6 +17622,475 @@ $</expected-output>
       </comparators>
     </test>
     <test> <!-- TESTED -->
+      <description>find: -atime </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -touch -a /findtest</command>
+        <command>-fs NAMENODE -touch -a /findtest/item1</command>
+        <command>-fs NAMENODE -touch -a /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touch -a /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -touch -a -t 20060401:195000 /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -touch -a /findtest/item2</command>
+        <command>-fs NAMENODE -touch -a /findtest/item3</command>
+        <command>-fs NAMENODE -touch -a /findtest/item4</command>
+        <command>-fs NAMENODE -touch -a /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -touch -a /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -touch -a -t 20060401:195000 /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -atime +1</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1b
+/findtest/item5
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -amin </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -touch -a /findtest</command>
+        <command>-fs NAMENODE -touch -a /findtest/item1</command>
+        <command>-fs NAMENODE -touch -a /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touch -a /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -touch -a -t 20060401:195000 /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -touch -a /findtest/item2</command>
+        <command>-fs NAMENODE -touch -a /findtest/item3</command>
+        <command>-fs NAMENODE -touch -a /findtest/item4</command>
+        <command>-fs NAMENODE -touch -a /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -touch -a /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -touch -a -t 20060401:195000 /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -amin +1</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1b
+/findtest/item5
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -blocksize </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -Ddfs.blocksize=268435456 -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -Ddfs.blocksize=134217728 -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -Ddfs.blocksize=268435456 -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -Ddfs.blocksize=268435456 -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -Ddfs.blocksize=134217728 -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -stat /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -blocksize 268435456</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1a/item1aa
+/findtest/item2
+/findtest/item4/item4b
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -empty </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -empty</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1a/item1aa
+/findtest/item3
+/findtest/item4/item4a
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -user </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -chown newowner:newgroup /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -chown newowner:newgroup /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -find /findtest -user newowner</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1b
+/findtest/item4/item4a
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -group </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -chown newowner:newgroup /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -chown newowner:newgroup /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -find /findtest -group newgroup</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1b
+/findtest/item4/item4a
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -mtime </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -touch -m -t 20060401:195000 /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -touch -m -t 20060401:195000 /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -mtime +1</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1b
+/findtest/item5
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -mmin </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -touch -m -t 20060401:195000 /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -touch -m -t 20060401:195000 /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -mmin +1</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1b
+/findtest/item5
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -newer </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -newer /findtest/item4/item4a</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest
+/findtest/item4
+/findtest/item4/item4b
+/findtest/item5
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -perm </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -chmod 700 /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -chmod 600 /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -chmod 400 /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -perm 600</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item4/item4b
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -replicas </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -setrep 3 /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -setrep 3 /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -setrep 2 /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -replicas 3</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1/item1a/item1aa
+/findtest/item4/item4b
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -size </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -size +60c -size -1</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item4/item4b
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -type </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -type d</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /donotfind</command>
+        <command>-fs NAMENODE -rm -r donotfind</command>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest
+/findtest/item1
+/findtest/item1/item1a
+/findtest/item3
+/findtest/item4
+/findtest/item4/item4a
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -regex </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -regex .*item1.*</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1
+/findtest/item1/item1a
+/findtest/item1/item1a/item1aa
+/findtest/item1/item1b
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
+      <description>find: -iregex </description>
+      <test-commands>
+        <command>-fs NAMENODE -mkdir /findtest</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1</command>
+        <command>-fs NAMENODE -mkdir /findtest/item1/item1a</command>
+        <command>-fs NAMENODE -touchz /findtest/item1/item1a/item1aa</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item1/item1b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data60bytes /findtest/item2</command>
+        <command>-fs NAMENODE -mkdir /findtest/item3</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4</command>
+        <command>-fs NAMENODE -mkdir /findtest/item4/item4a</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data120bytes /findtest/item4/item4b</command>
+        <command>-fs NAMENODE -put CLITEST_DATA/data1k /findtest/item5</command>
+        <command>-fs NAMENODE -find /findtest -iregex .*ITEM1.*</command>
+      </test-commands>
+      <cleanup-commands>
+        <command>-fs NAMENODE -rm -r /findtest</command>
+      </cleanup-commands>
+      <comparators>
+        <comparator>
+          <type>RegexpAcrossOutputComparator</type>
+          <expected-output>^/findtest/item1
+/findtest/item1/item1a
+/findtest/item1/item1a/item1aa
+/findtest/item1/item1b
+$</expected-output>
+        </comparator>
+      </comparators>
+    </test>
+    <test> <!-- TESTED -->
       <description>truncate to 5 bytes after waiting for block recovery to complete</description>
       <test-commands>
         <command>-fs NAMENODE -mkdir -p /user/USERNAME/dir0</command>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Add match expressions to find command.
This pull request is based on the patch attached to the ticket in [HADOOP-10579](https://issues.apache.org/jira/browse/HADOOP-10579) and [HADOOP-10580](https://issues.apache.org/jira/browse/HADOOP-10580).

The main changes from the original patch are as follows:
- Add support for JUnit 5
- Add additional test cases
- Add `a` (all) to the symbolic notation target in `Perm.java`
- Remove `-regextype`
- Use Pattern flags for case-insentive regex matching
- Minor fixes
    - Replace `equals("")` with `isEmpty()`
    - Replace `throw new IOException` with `throw new IllegalArgumentException`
    - Other small cleanup changes.
- Code reformatting

### How was this patch tested?

- Pass the tests in `hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find` on local.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html