### PR TITLE
YARN-11931. Fix router webapp tests by adding EclipseLink test dependency.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
@@ -126,6 +126,12 @@
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.core</artifactId>
+      <version>${eclipse-persistence.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/JavaProcess.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/JavaProcess.java
@@ -40,7 +40,7 @@ public class JavaProcess {
     String javaBin =
         javaHome + File.separator + "bin" + File.separator + "java";
     String classpath = System.getProperty("java.class.path");
-    classpath = classpath.concat("./src/test/resources");
+    classpath = classpath + File.pathSeparator + "./src/test/resources";
     if (addClassPaths != null) {
       for (String addClasspath : addClassPaths) {
         classpath = classpath.concat(File.pathSeparatorChar + addClasspath);
@@ -60,7 +60,7 @@ public class JavaProcess {
     String javaHome = System.getProperty("java.home");
     String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
     String classpath = System.getProperty("java.class.path");
-    classpath = classpath.concat("./src/test/resources");
+    classpath = classpath + File.pathSeparator + "./src/test/resources";
     if (addClassPaths != null) {
       for (String addClasspath : addClassPaths) {
         classpath = classpath.concat(File.pathSeparatorChar + addClasspath);


### PR DESCRIPTION
### Description of PR

YARN-11931. Fix router webapp tests by adding EclipseLink test dependency.

After upgrading to Jersey `2.46`, `TestRouterWebServicesREST` and `TestFederationWebApp` fail with `NoClassDefFoundError for org.eclipse.persistence.internal.queries.ContainerPolicy`.

This patch adds `org.eclipse.persistence:org.eclipse.persistence.core` as a test dependency in `hadoop-yarn-server-router/pom.xml`.

Additionally, fixed a classpath concatenation bug in `JavaProcess.java` where File.pathSeparator was missing when appending test resources path.

Test Results:
- TestRouterWebServicesREST: 42 tests passed
- TestFederationWebApp: 52 tests passed

> TestRouterWebServicesREST

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.server.router.webapp.TestRouterWebServicesREST
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 61.18 s -- in org.apache.hadoop.yarn.server.router.webapp.TestRouterWebServicesREST
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```

> TestFederationWebApp

```
[INFO] Tests run: 52, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 116.1 s -- in org.apache.hadoop.yarn.server.router.webapp.TestFederationWebApp
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:20 min
[INFO] Finished at: 2026-02-21T14:19:09+08:00
[INFO] ------------------------------------------------------------------------
```

### How was this patch tested?

Exists Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html