### PR TITLE
YARN-11932. Fix TestYarnFederationWithFairScheduler timeout caused by shared NodeLabel storage.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockSubCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockSubCluster.java
@@ -20,10 +20,14 @@ package org.apache.hadoop.yarn.server.router.subcluster;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
 
 import static org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubCluster.ZK_FEDERATION_STATESTORE;
 
@@ -87,6 +91,10 @@ public class TestMockSubCluster {
     conf.set(YarnConfiguration.FEDERATION_STATESTORE_CLIENT_CLASS, ZK_FEDERATION_STATESTORE);
     conf.set(CommonConfigurationKeys.ZK_ADDRESS, pZkAddress);
     conf.set(YarnConfiguration.RM_CLUSTER_ID, pSubClusterId);
+    File nodeLabelsDir = GenericTestUtils.getTestDir(
+        "node-labels-" + pSubClusterId + "-" + Time.now());
+    conf.set(YarnConfiguration.FS_NODE_LABELS_STORE_ROOT_DIR,
+        nodeLabelsDir.toURI().toString());
     if (schedulerType.equals("fair-scheduler")) {
       conf.set("yarn.resourcemanager.scheduler.class",
           "org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler");


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11932. Fix TestYarnFederationWithFairScheduler timeout caused by shared NodeLabel storage.

TestYarnFederationWithFairScheduler#testMetricsInfo intermittently times out because multiple test subclusters share the same NodeLabel storage directory (/tmp/hadoop-yarn-$USER/node-labels) by default. Residual editlog entries containing "delete default label" operations from previous tests cause RM startup to fail with "Node label=default to be removed doesn't existed in cluster node labels collection".

This pr sets an isolated NodeLabel storage directory for each subcluster using GenericTestUtils.getTestDir() with a unique name pattern (node-labels-{subClusterId}-{timestamp}) to avoid reusing old editlog files.


### How was this patch tested?

Exists Junit Test.

```
[INFO] Running org.apache.hadoop.yarn.server.router.subcluster.fair.TestYarnFederationWithFairScheduler
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 72.80 s -- in org.apache.hadoop.yarn.server.router.subcluster.fair.TestYarnFederationWithFairScheduler
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:34 min
[INFO] Finished at: 2026-02-21T15:18:57+08:00
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html