### PR TITLE
MAPREDUCE-7531. TestMRJobs.testThreadDumpOnTaskTimeout flaky due to thread dump delayed write.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobs.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarOutputStream;
+import java.util.concurrent.TimeoutException;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.FileUtils;
@@ -85,6 +87,7 @@ import org.apache.hadoop.mapreduce.v2.app.speculate.Speculator;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ApplicationClassLoader;
 import org.apache.hadoop.util.ClassUtil;
 import org.apache.hadoop.util.JarFinder;
@@ -421,7 +424,7 @@ public class TestMRJobs {
   }
 
   @Test
-  @Timeout(value = 3000)
+  @Timeout(value = 300)
   public void testJobWithChangePriority() throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
     // Assumption can be removed when FS priority support is implemented
@@ -1233,73 +1236,132 @@ public class TestMRJobs {
     final String syslogGlob = appIdStr
         + Path.SEPARATOR + containerGlob
         + Path.SEPARATOR + TaskLog.LogName.SYSLOG;
-    int numAppMasters = 0;
-    int numMapTasks = 0;
+    final int expectedMapTasks = sleepConf.getBoolean(
+        MRJobConfig.JOB_UBERTASK_ENABLE, false) ? 0 : 1;
+    final int expectedAppMasters = 1;
+    // Thread dumps are written asynchronously; poll up to 30s to avoid flakes.
+    final class ThreadDumpScan {
+      int numAppMasters;
+      int numMapTasks;
+      boolean missingMapDump;
+      boolean unexpectedAmDump;
+      boolean missingUberAmDump;
 
-    for (int i = 0; i < NUM_NODE_MGRS; i++) {
-      final Configuration nmConf = mrCluster.getNodeManager(i).getConfig();
-      for (String logDir :
-               nmConf.getTrimmedStrings(YarnConfiguration.NM_LOG_DIRS)) {
-        final Path absSyslogGlob =
-            new Path(logDir + Path.SEPARATOR + syslogGlob);
-        LOG.info("Checking for glob: " + absSyslogGlob);
-        for (FileStatus syslog : localFs.globStatus(absSyslogGlob)) {
-          boolean foundAppMaster = false;
-          boolean foundThreadDump = false;
-
-          // Determine the container type
-          final BufferedReader syslogReader = new BufferedReader(
-              new InputStreamReader(localFs.open(syslog.getPath())));
-          try {
-            for (String line; (line = syslogReader.readLine()) != null; ) {
-              if (line.contains(MRAppMaster.class.getName())) {
-                foundAppMaster = true;
-                break;
-              }
-            }
-          } finally {
-            syslogReader.close();
-          }
-
-          // Check for thread dump in stdout
-          final Path stdoutPath = new Path(syslog.getPath().getParent(),
-              TaskLog.LogName.STDOUT.toString());
-          final BufferedReader stdoutReader = new BufferedReader(
-              new InputStreamReader(localFs.open(stdoutPath)));
-          try {
-            for (String line; (line = stdoutReader.readLine()) != null; ) {
-              if (line.contains("Full thread dump")) {
-                foundThreadDump = true;
-                break;
-              }
-            }
-          } finally {
-            stdoutReader.close();
-          }
-
-          if (foundAppMaster) {
-            numAppMasters++;
-            if (this instanceof TestUberAM) {
-              assertTrue(foundThreadDump, "No thread dump");
-            } else {
-              assertFalse(foundThreadDump, "Unexpected thread dump");
-            }
-          } else {
-            numMapTasks++;
-            assertTrue(foundThreadDump, "No thread dump");
-          }
-        }
+      void reset() {
+        numAppMasters = 0;
+        numMapTasks = 0;
+        missingMapDump = false;
+        unexpectedAmDump = false;
+        missingUberAmDump = false;
       }
+
+      boolean countsReady() {
+        return numAppMasters == expectedAppMasters
+            && numMapTasks == expectedMapTasks;
+      }
+
+      boolean dumpsReady() {
+        return !missingMapDump && !unexpectedAmDump && !missingUberAmDump;
+      }
+    }
+
+    final ThreadDumpScan scan = new ThreadDumpScan();
+    // Re-scan logs until expected containers and dumps are observed (or timeout).
+    try {
+      GenericTestUtils.waitFor(() -> {
+        scan.reset();
+        try {
+          for (int i = 0; i < NUM_NODE_MGRS; i++) {
+            final Configuration nmConf = mrCluster.getNodeManager(i).getConfig();
+            for (String logDir :
+                     nmConf.getTrimmedStrings(YarnConfiguration.NM_LOG_DIRS)) {
+              final Path absSyslogGlob =
+                  new Path(logDir + Path.SEPARATOR + syslogGlob);
+              LOG.info("Checking for glob: " + absSyslogGlob);
+              for (FileStatus syslog : localFs.globStatus(absSyslogGlob)) {
+                boolean foundAppMaster = false;
+                boolean foundThreadDump = false;
+
+                // Determine the container type and look for thread dump markers.
+                final BufferedReader syslogReader = new BufferedReader(
+                    new InputStreamReader(localFs.open(syslog.getPath())));
+                try {
+                  for (String line;
+                       (line = syslogReader.readLine()) != null; ) {
+                    if (line.contains(MRAppMaster.class.getName())) {
+                      foundAppMaster = true;
+                    }
+                    if (line.contains("Full thread dump")
+                        || line.contains("Process Thread Dump")) {
+                      foundThreadDump = true;
+                    }
+                  }
+                } finally {
+                  syslogReader.close();
+                }
+
+                // Thread dump may be emitted to stdout depending on logging.
+                final Path stdoutPath = new Path(syslog.getPath().getParent(),
+                    TaskLog.LogName.STDOUT.toString());
+                final BufferedReader stdoutReader = new BufferedReader(
+                    new InputStreamReader(localFs.open(stdoutPath)));
+                try {
+                  for (String line;
+                       (line = stdoutReader.readLine()) != null; ) {
+                    if (line.contains("Full thread dump")
+                        || line.contains("Process Thread Dump")) {
+                      foundThreadDump = true;
+                      break;
+                    }
+                  }
+                } finally {
+                  stdoutReader.close();
+                }
+
+                if (foundAppMaster) {
+                  scan.numAppMasters++;
+                  if (this instanceof TestUberAM) {
+                    if (!foundThreadDump) {
+                      scan.missingUberAmDump = true;
+                    }
+                  } else if (foundThreadDump) {
+                    scan.unexpectedAmDump = true;
+                  }
+                } else {
+                  scan.numMapTasks++;
+                  if (!foundThreadDump) {
+                    scan.missingMapDump = true;
+                  }
+                }
+              }
+            }
+          }
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+        // Both the container counts and expected dump presence must be satisfied.
+        return scan.countsReady() && scan.dumpsReady();
+      }, 1000, 30_000, "thread dump logs not ready");
+    } catch (TimeoutException e) {
+      LOG.warn("Timed out waiting for thread dump logs", e);
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
     }
 
     // Make sure we checked non-empty set
     //
-    assertEquals(1, numAppMasters, "No AppMaster log found!");
-    if (sleepConf.getBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false)) {
-      assertSame(0, numMapTasks, "MapTask log with uber found!");
+    assertEquals(expectedAppMasters, scan.numAppMasters,
+        "No AppMaster log found!");
+    assertSame(expectedMapTasks, scan.numMapTasks,
+        sleepConf.getBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false)
+            ? "MapTask log with uber found!"
+            : "No MapTask log found!");
+    if (this instanceof TestUberAM) {
+      assertFalse(scan.missingUberAmDump, "No thread dump");
     } else {
-      assertSame(1, numMapTasks, "No MapTask log found!");
+      assertFalse(scan.unexpectedAmDump, "Unexpected thread dump");
     }
+    assertFalse(scan.missingMapDump, "No thread dump");
   }
 
   private Path createTempFile(String filename, String contents)
@@ -1368,6 +1430,7 @@ public class TestMRJobs {
   }
 
   @Test
+  @Timeout(value = 300)
   public void testSharedCache() throws Exception {
     Path localJobJarPath = makeJobJarWithLib(TEST_ROOT_DIR.toUri().toString());
 
@@ -1450,6 +1513,7 @@ public class TestMRJobs {
   }
 
   @Test
+  @Timeout(value = 300)
   public void testSleepJobName() throws IOException {
     SleepJob sleepJob = new SleepJob();
     sleepJob.setConf(conf);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestUberAM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestUberAM.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,7 @@ public class TestUberAM extends TestMRJobs {
 
   @Override
   @Test
+  @Timeout(value = 300)
   public void testSleepJob()
   throws Exception {
     numSleepReducers = 1;
@@ -60,6 +62,7 @@ public class TestUberAM extends TestMRJobs {
   }
   
   @Test
+  @Timeout(value = 300)
   public void testSleepJobWithMultipleReducers()
   throws Exception {
     numSleepReducers = 3;
@@ -81,6 +84,7 @@ public class TestUberAM extends TestMRJobs {
 
   @Override
   @Test
+  @Timeout(value = 300)
   public void testRandomWriter()
   throws IOException, InterruptedException, ClassNotFoundException {
     super.testRandomWriter();
@@ -99,6 +103,7 @@ public class TestUberAM extends TestMRJobs {
 
   @Override
   @Test
+  @Timeout(value = 300)
   public void testFailingMapper()
   throws IOException, InterruptedException, ClassNotFoundException {
     LOG.info("\n\n\nStarting uberized testFailingMapper().");


### PR DESCRIPTION
### Description of PR

JIRA: MAPREDUCE-7531. TestMRJobs.testThreadDumpOnTaskTimeout flaky due to thread dump delayed write.

Fix flaky test `TestMRJobs.testThreadDumpOnTaskTimeout` that fails when thread dumps are written asynchronously after the initial log scan.


Changes:
- Replace single-pass log scan with `GenericTestUtils.waitFor()` retry logic (1s interval, 30s timeout) to handle asynchronous thread dump writes
- Introduce ThreadDumpScan inner class to track scan state across retries
- Defer assertions until after polling completes, preserving scan results even on timeout for better failure diagnostics
- Scan both syslog and stdout in the same pass, checking for both "Full thread dump" and "Process Thread Dump" patterns
- Replace immediate assertTrue/assertFalse calls with deferred checks to  allow retries when dumps are not yet present
- Fix testJobWithChangePriority timeout annotation (`3000` -> `300` seconds)
- Add missing `@Timeout(300)` annotations to `testSharedCache` and `testSleepJobName`

### How was this patch tested?

> ./mvnw -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient -am -Dtest=TestUberAM test

```
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.mapreduce.v2.TestUberAM
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 626.3 s -- in org.apache.hadoop.mapreduce.v2.TestUberAM
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html