### PR TITLE
YARN-11933. TestAMSimulator fails due to shared node labels store directory.

### DIFF
--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/appmaster/TestAMSimulator.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/appmaster/TestAMSimulator.java
@@ -65,6 +65,7 @@ public class TestAMSimulator {
   private ResourceManager rm;
   private YarnConfiguration conf;
   private Path metricOutputDir;
+  private Path nodeLabelsStoreDir;
 
   private Class<?> slsScheduler;
   private Class<?> scheduler;
@@ -76,14 +77,16 @@ public class TestAMSimulator {
     });
   }
 
-  public void initTestAMSimulator(Class<?> pSlsScheduler, Class<?> pScheduler) {
+  public void initTestAMSimulator(Class<?> pSlsScheduler, Class<?> pScheduler)
+      throws IOException {
     this.slsScheduler = pSlsScheduler;
     this.scheduler = pScheduler;
     setup();
   }
 
-  public void setup() {
+  public void setup() throws IOException {
     createMetricOutputDir();
+    createNodeLabelsStoreDir();
 
     conf = new YarnConfiguration();
     conf.set(SLSConfiguration.METRICS_OUTPUT_DIR, metricOutputDir.toString());
@@ -91,6 +94,8 @@ public class TestAMSimulator {
     conf.set(SLSConfiguration.RM_SCHEDULER, scheduler.getName());
     conf.set(YarnConfiguration.NODE_LABELS_ENABLED, "true");
     conf.setBoolean(SLSConfiguration.METRICS_SWITCH, true);
+    conf.set(YarnConfiguration.FS_NODE_LABELS_STORE_ROOT_DIR,
+        nodeLabelsStoreDir.toUri().toString());
     rm = new ResourceManager();
     rm.init(conf);
     rm.start();
@@ -141,12 +146,22 @@ public class TestAMSimulator {
     }
   }
 
+  private void createNodeLabelsStoreDir() throws IOException {
+    Path testDir =
+        Paths.get(System.getProperty("test.build.data", "target/test-dir"));
+    nodeLabelsStoreDir = Files.createTempDirectory(testDir, "node-labels");
+  }
+
   private void deleteMetricOutputDir() {
     try {
       FileUtils.deleteDirectory(metricOutputDir.toFile());
     } catch (IOException e) {
       Assertions.fail(e.toString());
     }
+  }
+
+  private void deleteNodeLabelsStoreDir() throws IOException {
+    FileUtils.deleteDirectory(nodeLabelsStoreDir.toFile());
   }
 
   @ParameterizedTest
@@ -231,7 +246,7 @@ public class TestAMSimulator {
   @ParameterizedTest
   @MethodSource("params")
   public void testPackageRequests(Class<?> pSlsScheduler, Class<?> pScheduler)
-      throws YarnException {
+      throws YarnException, IOException {
     initTestAMSimulator(pSlsScheduler, pScheduler);
     MockAMSimulator app = new MockAMSimulator();
     List<ContainerSimulator> containerSimulators = new ArrayList<>();
@@ -383,11 +398,12 @@ public class TestAMSimulator {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws IOException {
     if (rm != null) {
       rm.stop();
     }
 
     deleteMetricOutputDir();
+    deleteNodeLabelsStoreDir();
   }
 }


### PR DESCRIPTION
### Description of PR

JIRA:YARN-11933. TestAMSimulator fails due to shared node labels store directory.

#### Problem

`TestAMSimulator` fails intermittently when running concurrently or repeatedly due to shared Node Labels Store directory conflicts. Multiple test instances write to the same default directory, causing interference and test failures.

#### Root Cause

The test does not specify an independent Node Labels Store directory via `YarnConfiguration.FS_NODE_LABELS_STORE_ROOT_DIR`. 
All test instances use the default shared path, leading to conflicts when:

- Tests run in parallel
- Multiple test executions overlap
- Concurrent parameterized test cases execute

#### Solution

Create isolated temporary directories for each test instance:

**Setup phase:** Create a unique temporary directory for Node Labels Store and configure it via `YarnConfiguration.FS_NODE_LABELS_STORE_ROOT_DIR`
**Teardown phase:** Clean up the temporary directory to prevent resource leaks

### How was this patch tested?

> ./mvnw -pl hadoop-tools/hadoop-sls -am -Dtest=org.apache.hadoop.yarn.sls.appmaster.TestAMSimulator test

```
[INFO] Running org.apache.hadoop.yarn.sls.appmaster.TestAMSimulator
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.144 s -- in org.apache.hadoop.yarn.sls.appmaster.TestAMSimulator
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html