### PR TITLE
YARN-11934. Fix testComponentHealthThresholdMonitor race condition.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
@@ -789,6 +789,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     compCounts.put("compa", 4L);
     exampleApp.getComponent("compa").setNumberOfContainers(4L);
     client.flexByRestService(exampleApp.getName(), compCounts);
+    waitForServiceToLeaveStable(client, exampleApp, 10_000, "compa");
     try {
       // Wait for 6 secs (window 3 secs + 1 for next poll + 2 for buffer). Since
       // the service will never go to stable state (because of anti-affinity the
@@ -815,6 +816,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     compCounts.put("compa", 5L);
     exampleApp.getComponent("compa").setNumberOfContainers(5L);
     client.flexByRestService(exampleApp.getName(), compCounts);
+    waitForServiceToLeaveStable(client, exampleApp, 10_000, "compa");
     try {
       // Wait for 14 secs (window 3 secs + 1 for next poll + 2 for buffer + 5
       // secs of service wait before shutting down + 3 secs app cleanup so that
@@ -858,6 +860,46 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         index++;
       }
     }
+  }
+
+  /**
+   * Wait for the service to leave STABLE state after a flex operation.
+   * This ensures the flex has taken effect before proceeding.
+   *
+   * @param client the service client
+   * @param service the service being flexed
+   * @param waitForMillis maximum wait time in milliseconds
+   * @param componentNames the component names to check for non-stable state
+   * @throws TimeoutException if service doesn't leave stable within timeout
+   * @throws InterruptedException if wait is interrupted
+   */
+  private void waitForServiceToLeaveStable(ServiceClient client, Service service,
+      int waitForMillis, String... componentNames)
+      throws TimeoutException, InterruptedException {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        Service status = client.getStatus(service.getName());
+        if (status.getState() != ServiceState.STABLE) {
+          return true;
+        }
+        if (componentNames == null || componentNames.length == 0) {
+          return false;
+        }
+        for (String componentName : componentNames) {
+          Component component = status.getComponent(componentName);
+          if (component == null) {
+            return false;
+          }
+          if (component.getState() != ComponentState.STABLE) {
+            return true;
+          }
+        }
+        return false;
+      } catch (Exception e) {
+        LOG.debug("Waiting for service to leave STABLE failed to fetch status", e);
+        return false;
+      }
+    }, 500, waitForMillis);
   }
 
 


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11934. Fix testComponentHealthThresholdMonitor race condition.

#### Problem

`TestYarnNativeServices.testComponentHealthThresholdMonitor` test fails intermittently with the following error:

```
[INFO] Running org.apache.hadoop.yarn.service.TestYarnNativeServices
[ERROR] Tests run: 16, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 953.6 s <<< FAILURE! -- in org.apache.hadoop.yarn.service.TestYarnNativeServices
[ERROR] org.apache.hadoop.yarn.service.TestYarnNativeServices.testComponentHealthThresholdMonitor -- Time elapsed: 72.65 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Service should not be in a stable state. It should throw a timeout exception.
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:138)
	at org.apache.hadoop.yarn.service.TestYarnNativeServices.testComponentHealthThresholdMonitor(TestYarnNativeServices.java:799)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

#### Root Case

The test has a race condition after calling `flexByRestService()`. The test expects `waitForServiceToBeStable()` to timeout (because anti-affinity prevents the 4th container from being allocated), but instead it returns immediately.
 
The issue occurs because:
1. `flexByRestService()` is called to change the number of containers
2. `waitForServiceToBeStable()` is called immediately after
3. If the flex operation hasn't taken effect yet, the service is still in the old STABLE state
4. `waitForServiceToBeStable()` returns immediately instead of waiting and timing out as expected

#### Solution
Introduce a new helper method `waitForServiceToLeaveStable()` that ensures the service state has transitioned away from STABLE before proceeding with subsequent assertions. This guarantees the flex operation has taken effect.

### How was this patch tested?

> ./mvnw -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core -Dtest=TestYarnNativeServices#testComponentHealthThresholdMonitor test

```
[INFO] --- surefire:3.5.3:test (default-test) @ hadoop-yarn-services-core ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.service.TestYarnNativeServices
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 92.31 s -- in org.apache.hadoop.yarn.service.TestYarnNativeServices
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:07 min
[INFO] Finished at: 2026-02-23T10:54:16+08:00
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html