### PR TITLE
YARN-11935. Fix deadlock in TestRMHA#testTransitionedToStandbyShouldNotHang.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.DrainDispatcher;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
+import org.apache.hadoop.yarn.event.InlineDispatcher;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.resourcemanager.recovery.records.ApplicationStateData;
 import org.apache.hadoop.yarn.server.resourcemanager.recovery.MemoryRMStateStore;
@@ -490,6 +491,16 @@ public class TestRMHA extends AbstractHadoopTestBase {
     };
     memStore.init(conf);
     rm = new MockRM(conf, memStore) {
+      @Override
+      protected Dispatcher createDispatcher() {
+        return new InlineDispatcher();
+      }
+
+      @Override
+      public void drainEvents() {
+        // InlineDispatcher dispatches synchronously; nothing to drain here.
+      }
+
       @Override
       void stopActiveServices() {
         try {


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11935. Fix deadlock in TestRMHA#testTransitionedToStandbyShouldNotHang.

#### Problem

`testTransitionedToStandbyShouldNotHang` hangs and eventually times out after 100 seconds ([YARN-11898](https://issues.apache.org/jira/browse/YARN-11898) only added a timeout, it didn’t fix the root cause).

#### Root Cause

The test creates a deadlock between the RM lock and the dispatcher thread:

1. Thread `t` calls `rm.transitionToStandby(true)` and holds the RM monitor (method is `synchronized`)
2. Inside, the overridden `stopActiveServices()` sleeps 10 seconds (intentionally widening the window)
3. Meanwhile the main thread calls `updateApplicationState(null)` → triggers `StoreFencedException`
4. This emits `RMFatalEvent(STATE_STORE_FENCED)`, handled by the *async dispatcher thread*
5. The dispatcher thread calls `handleTransitionToStandByInNewThread()`, which is *synchronized* and needs the RM lock
6. At the same time `transitionToStandby(true)` stops the dispatcher and `join()`s the event thread
7. Deadlock:
   - `t` holds RM lock and waits for dispatcher thread to exit
   - dispatcher thread waits for RM lock
   - main thread waits on `t.join()`

#### Solution

Use `InlineDispatcher` for this specific test:

`InlineDispatcher` handles events synchronously on the calling thread
1. No separate dispatcher thread → no lock contention
2. Override `drainEvents()` as no-op to avoid “Not a Drain Dispatcher”
3. Keep the 10s sleep to preserve the slow-shutdown simulation

### How was this patch tested?

> /mvnw -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager -am -Dtest=TestRMHA#testTransitionedToStandbyShouldNotHang test

```
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.server.resourcemanager.TestRMHA
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.20 s -- in org.apache.hadoop.yarn.server.resourcemanager.TestRMHA
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html