### PR TITLE
HADOOP-19779: Follow-up fix in create-release script to parse JDK version from root pom.xml instead of hadoop-project/pom.xml

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -212,7 +212,7 @@ function set_defaults
   # Extract Java version from ${BASEDIR}/pom.xml
   # doing this outside of maven means we can do this before
   # the docker container comes up...
-  JVM_VERSION=$(grep "<javac.version>" "${BASEDIR}/hadoop-project/pom.xml" \
+  JVM_VERSION=$(grep "<javac.version>" "${BASEDIR}/pom.xml" \
     | head -1 \
     | sed  -e 's|^ *<javac.version>||' -e 's|</javac.version>.*$||')
 


### PR DESCRIPTION
### Description of PR

#8173 used the enforcer plugin to fail fast if trying to build with a JDK version less than 17. The Maven property declarations for JDK version were refactored so that they occur in just one place in the root pom.xml. The create-release script still had a dependency on finding it in hadoop-project/pom.xml though.

### How was this patch tested?

Attempts to run `create-release` for the 3.5.0 release were failing due to invalid `JAVA_HOME`, because the version segment in the path was empty. After applying this fix, the script works.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html