### PR TITLE
YARN-11937. Forward hadoop-jwt with YARN proxy

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/JWTRedirectAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/JWTRedirectAuthenticationHandler.java
@@ -71,7 +71,7 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
  */
 public class JWTRedirectAuthenticationHandler extends
     AltKerberosAuthenticationHandler {
-  private static Logger LOG = LoggerFactory
+  private static final Logger LOG = LoggerFactory
       .getLogger(JWTRedirectAuthenticationHandler.class);
 
   public static final String AUTHENTICATION_PROVIDER_URL =
@@ -79,11 +79,12 @@ public class JWTRedirectAuthenticationHandler extends
   public static final String PUBLIC_KEY_PEM = "public.key.pem";
   public static final String EXPECTED_JWT_AUDIENCES = "expected.jwt.audiences";
   public static final String JWT_COOKIE_NAME = "jwt.cookie.name";
+  public static final String DEFAULT_JWT_COOKIE_NAME = "hadoop-jwt";
   private static final String ORIGINAL_URL_QUERY_PARAM = "originalUrl=";
   private String authenticationProviderUrl = null;
   private RSAPublicKey publicKey = null;
   private List<String> audiences = null;
-  private String cookieName = "hadoop-jwt";
+  private String cookieName = DEFAULT_JWT_COOKIE_NAME;
 
   /**
    * Primarily for testing, this provides a way to set the publicKey for

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2846,6 +2846,10 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_RM_PROXY_CONNECTION_TIMEOUT =
       60000;
 
+  public static final String RM_PROXY_JWT_FORWARD_ENABLED = RM_PREFIX + "proxy.jwt-forward.enabled";
+
+  public static final boolean DEFAULT_RM_PROXY_JWT_FORWARD_ENABLED = true;
+
   /**
    * Interval of time the linux container executor should try cleaning up
    * cgroups entry when cleaning up a container. This is required due to what 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2832,6 +2832,16 @@
     <value>60000</value>
   </property>
 
+  <property>
+    <description>When enabled, the proxy extracts the configured JWT cookie
+      (typically "hadoop-jwt") from the incoming request and includes it in proxied requests.
+      This allows the AM web interface to recognize the authenticated user without
+      requiring a separate login. When disabled, no JWT cookie is forwarded,
+      isolating AM UIs from RM-level authentication.</description>
+    <name>yarn.resourcemanager.proxy.jwt-forward.enabled</name>
+    <value>true</value>
+  </property>
+
   <!-- Applications' Configuration -->
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/ProxyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/ProxyUtils.java
@@ -20,16 +20,21 @@ package org.apache.hadoop.yarn.server.webproxy;
 
 import org.apache.hadoop.yarn.webapp.MimeType;
 import org.apache.hadoop.yarn.webapp.hamlet2.Hamlet;
+import org.apache.http.client.methods.HttpRequestBase;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Class containing general purpose proxy utilities
@@ -121,5 +126,41 @@ public class ProxyUtils {
     if (!(req instanceof HttpServletRequest)) {
       throw new ServletException(E_HTTP_HTTPS_ONLY);
     }
+  }
+
+  /**
+   * Returns the value of a cookie with the given name from the HTTP servlet request.
+   * Cookie name comparison is case-insensitive. If the request contains no cookies
+   * or the specified cookie is not present, this method returns {@code null}.
+   *
+   * @param req the HTTP servlet request containing cookies
+   * @param cookieName the name of the cookie to retrieve
+   * @return the cookie value, or {@code null} if not found
+   */
+  public static String getCookie(HttpServletRequest req, String cookieName) {
+    Cookie[] cookies = req.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (cookieName.equalsIgnoreCase(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Sets the {@code Cookie} header on the given HTTP request using the provided cookies.
+   * Cookies are formatted according to the standard HTTP header syntax:
+   * {@code name=value; name2=value2}.
+   *
+   * @param req the HTTP request on which to set the cookie header
+   * @param cookies a map of cookie names to cookie values
+   */
+  public static void setCookies(HttpRequestBase req, Map<String, String> cookies) {
+    req.setHeader("Cookie", cookies.entrySet()
+        .stream()
+        .map(entry -> entry.getKey() + "=" + entry.getValue())
+        .collect(Collectors.joining("; ")));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/ProxyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/ProxyUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.yarn.server.webproxy;
 
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.yarn.webapp.MimeType;
 import org.apache.hadoop.yarn.webapp.hamlet2.Hamlet;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -135,13 +137,13 @@ public class ProxyUtils {
    *
    * @param req the HTTP servlet request containing cookies
    * @param cookieName the name of the cookie to retrieve
-   * @return the cookie value, or {@code null} if not found
+   * @return the cookie value, or {@code null} if not found or cookieName is blank
    */
   public static String getCookie(HttpServletRequest req, String cookieName) {
     Cookie[] cookies = req.getCookies();
-    if (cookies != null) {
+    if (cookies != null && StringUtils.isNotBlank(cookieName)) {
       for (Cookie cookie : cookies) {
-        if (cookieName.equalsIgnoreCase(cookie.getName())) {
+        if (cookieName.equals(cookie.getName())) {
           return cookie.getValue();
         }
       }
@@ -158,6 +160,9 @@ public class ProxyUtils {
    * @param cookies a map of cookie names to cookie values
    */
   public static void setCookies(HttpRequestBase req, Map<String, String> cookies) {
+    if (MapUtils.isEmpty(cookies)) {
+      return;
+    }
     req.setHeader("Cookie", cookies.entrySet()
         .stream()
         .map(entry -> entry.getKey() + "=" + entry.getValue())

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -82,6 +82,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.security.authentication.server.JWTRedirectAuthenticationHandler.DEFAULT_JWT_COOKIE_NAME;
 import static org.apache.hadoop.security.authentication.server.JWTRedirectAuthenticationHandler.JWT_COOKIE_NAME;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_RM_PROXY_JWT_FORWARD_ENABLED;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.RM_PROXY_JWT_FORWARD_ENABLED;
 import static org.apache.hadoop.yarn.server.webproxy.ProxyUtils.getCookie;
 import static org.apache.hadoop.yarn.server.webproxy.ProxyUtils.setCookies;
 
@@ -146,7 +148,11 @@ public class WebAppProxyServlet extends HttpServlet {
     this.failurePageUrlBase =
         StringHelper.pjoin(WebAppUtils.getResolvedRMWebAppURLWithScheme(conf),
           "cluster", "failure");
-    this.jwtCookieName = conf.get(JWT_COOKIE_NAME, DEFAULT_JWT_COOKIE_NAME);
+    boolean jwtForwardEnabled =
+        conf.getBoolean(RM_PROXY_JWT_FORWARD_ENABLED, DEFAULT_RM_PROXY_JWT_FORWARD_ENABLED);
+    this.jwtCookieName = jwtForwardEnabled
+        ? conf.get(JWT_COOKIE_NAME, DEFAULT_JWT_COOKIE_NAME)
+        : null;
   }
 
   private String getRmAppPageUrlBase(ApplicationId id) throws YarnException, IOException {
@@ -325,7 +331,7 @@ public class WebAppProxyServlet extends HttpServlet {
     String user = req.getRemoteUser();
     if (StringUtils.hasLength(user)) {
       LOG.debug("Cookie {} will be set", PROXY_USER_COOKIE_NAME);
-      cookies.put(PROXY_USER_COOKIE_NAME, URLEncoder.encode(user, "ASCII"));
+      cookies.put(PROXY_USER_COOKIE_NAME, URLEncoder.encode(user, StandardCharsets.US_ASCII));
     }
     String jwtCookie = getCookie(req, jwtCookieName);
     if (StringUtils.hasLength(jwtCookie)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -34,8 +34,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.ServletContext;
@@ -50,6 +52,7 @@ import javax.ws.rs.core.UriBuilderException;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -77,6 +80,11 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.security.authentication.server.JWTRedirectAuthenticationHandler.DEFAULT_JWT_COOKIE_NAME;
+import static org.apache.hadoop.security.authentication.server.JWTRedirectAuthenticationHandler.JWT_COOKIE_NAME;
+import static org.apache.hadoop.yarn.server.webproxy.ProxyUtils.getCookie;
+import static org.apache.hadoop.yarn.server.webproxy.ProxyUtils.setCookies;
+
 public class WebAppProxyServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -99,6 +107,7 @@ public class WebAppProxyServlet extends HttpServlet {
   private transient List<TrackingUriPlugin> trackingUriPlugins;
   private final String failurePageUrlBase;
   private transient YarnConfiguration conf;
+  private final String jwtCookieName;
 
   /**
    * HTTP methods.
@@ -137,6 +146,7 @@ public class WebAppProxyServlet extends HttpServlet {
     this.failurePageUrlBase =
         StringHelper.pjoin(WebAppUtils.getResolvedRMWebAppURLWithScheme(conf),
           "cluster", "failure");
+    this.jwtCookieName = conf.get(JWT_COOKIE_NAME, DEFAULT_JWT_COOKIE_NAME);
   }
 
   private String getRmAppPageUrlBase(ApplicationId id) throws YarnException, IOException {
@@ -311,11 +321,19 @@ public class WebAppProxyServlet extends HttpServlet {
       }
     }
 
+    Map<String, String> cookies = new HashMap<>();
     String user = req.getRemoteUser();
-    if (user != null && !user.isEmpty()) {
-      base.setHeader("Cookie",
-          PROXY_USER_COOKIE_NAME + "=" + URLEncoder.encode(user, "ASCII"));
+    if (StringUtils.hasLength(user)) {
+      LOG.debug("Cookie {} will be set", PROXY_USER_COOKIE_NAME);
+      cookies.put(PROXY_USER_COOKIE_NAME, URLEncoder.encode(user, "ASCII"));
     }
+    String jwtCookie = getCookie(req, jwtCookieName);
+    if (StringUtils.hasLength(jwtCookie)) {
+      LOG.debug("Cookie {} will be set", jwtCookieName);
+      cookies.put(jwtCookieName, jwtCookie);
+    }
+    setCookies(base, cookies);
+
     OutputStream out = resp.getOutputStream();
     HttpClient client = httpClientBuilder.build();
     try {
@@ -335,7 +353,7 @@ public class WebAppProxyServlet extends HttpServlet {
       base.releaseConnection();
     }
   }
-  
+
   private static String getCheckCookieName(ApplicationId id){
     return "checked_"+id;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.webproxy;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.servlet.http.Cookie;
@@ -30,7 +31,9 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,4 +68,18 @@ public class TestProxyUtils {
     assertEquals("bar=222; foo=foo_value", valueCaptor.getValue());
   }
 
+  @Test
+  void testSetEmptyCookie() {
+    HttpRequestBase mock = mock(HttpRequestBase.class);
+    ProxyUtils.setCookies(mock, new HashMap<>());
+    verify(mock, never()).setHeader(anyString(), anyString());
+  }
+
+
+  @Test
+  void testSetNullCookie() {
+    HttpRequestBase mock = mock(HttpRequestBase.class);
+    ProxyUtils.setCookies(mock, null);
+    verify(mock, never()).setHeader(anyString(), anyString());
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUtils.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.webproxy;
+
+import java.util.Map;
+import java.util.TreeMap;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.http.client.methods.HttpRequestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestProxyUtils {
+
+  @Test
+  void testGetCookie() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    Cookie[] cookies = {
+        new Cookie("foo", "foo_value"),
+        new Cookie("bar", "222")
+    };
+    when(req.getCookies()).thenReturn(cookies);
+    assertEquals("foo_value", ProxyUtils.getCookie(req, "foo"));
+    assertEquals("222", ProxyUtils.getCookie(req, "bar"));
+    assertNull(ProxyUtils.getCookie(req, "baz"));
+  }
+
+  @Test
+  void testSetCookie() {
+    HttpRequestBase mock = mock(HttpRequestBase.class);
+    Map<String, String> cookies = new TreeMap<>();
+    cookies.put("foo", "foo_value");
+    cookies.put("bar", "222");
+    ProxyUtils.setCookies(mock, cookies);
+    ArgumentCaptor<String> headerCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mock, times(1))
+        .setHeader(headerCaptor.capture(), valueCaptor.capture());
+    assertEquals("Cookie", headerCaptor.getValue());
+    assertEquals("bar=222; foo=foo_value", valueCaptor.getValue());
+  }
+
+}


### PR DESCRIPTION
### Description of PR

YARN web proxy not forwards hadoop-jwt token.
So if we
- have a YARN application (lets say spark)
- and we check the RM UI2 via KNOX proxy
- and we click the ApplicationMaster link on the application page of the spark app

The browser will be forwarded to the SparkAM ui
for example: /gateway/cdp-proxy/yarnuiv2/proxy/application_1771935206205_0001/

SparkAM wont receive the hadoop-jwt cookie, so will ask user to login.

Instead of this if we can pass the jwt cookie for the AM so the user can see the AM UI after login state, and wont need to login again.

Security NOTE:
If user clicks on a non trusted application AM UI then the jwt token may leak, but i dont think that is a valid case that non trusted application is running on a cluster.

### How was this patch tested?

Manually created a cluster with spark and knox, and checked the token will be forwarded.
UT was created.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI was used.