### PR TITLE
HADOOP-19821. [3.4][JDK25] Token initialization fails with NoClassDefFoundError

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3519,9 +3519,13 @@ public abstract class FileSystem extends Configured
       if (!FILE_SYSTEMS_LOADED) {
         ServiceLoader<FileSystem> serviceLoader = ServiceLoader.load(FileSystem.class);
         Iterator<FileSystem> it = serviceLoader.iterator();
-        while (it.hasNext()) {
+        // both "hasNext()" and "next()" calls might trigger implementations loading.
+        while (true) {
           FileSystem fs;
           try {
+            if (!it.hasNext()) {
+              break;
+            }
             fs = it.next();
             try {
               SERVICE_FILE_SYSTEMS.put(fs.getScheme(), fs.getClass());
@@ -3535,7 +3539,7 @@ public abstract class FileSystem extends Configured
                   ClassUtil.findContainingJar(fs.getClass()));
               LOGGER.info("Full exception loading: {}", fs, e);
             }
-          } catch (ServiceConfigurationError ee) {
+          } catch (ServiceConfigurationError | LinkageError ee) {
             LOGGER.warn("Cannot load filesystem", ee);
           }
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/DtFileOperations.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/DtFileOperations.java
@@ -180,11 +180,15 @@ public final class DtFileOperations {
         Credentials.readTokenStorageFile(tokenFile, conf) : new Credentials();
     ServiceLoader<DtFetcher> loader = ServiceLoader.load(DtFetcher.class);
     Iterator<DtFetcher> iterator = loader.iterator();
-    while (iterator.hasNext()) {
+    // both "hasNext()" and "next()" calls might trigger implementations loading.
+    while (true) {
       DtFetcher fetcher;
       try {
+        if (!iterator.hasNext()) {
+          break;
+        }
         fetcher = iterator.next();
-      } catch (ServiceConfigurationError e) {
+      } catch (ServiceConfigurationError | LinkageError e) {
         // failure to load a token implementation
         // log at debug and continue.
         LOG.debug("Failed to load token fetcher implementation", e);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/Token.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/Token.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.security.token;
 
-import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Bytes;
 
 import org.apache.commons.codec.binary.Base64;
@@ -33,11 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.security.MessageDigest;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * The client-side form of the token.
@@ -128,13 +123,16 @@ public class Token<T extends TokenIdentifier> implements Writable {
     Class<? extends TokenIdentifier> cls = null;
     synchronized (Token.class) {
       if (tokenKindMap == null) {
-        tokenKindMap = Maps.newHashMap();
-        // start the service load process; it's only in the "next()" calls
-        // where implementations are loaded.
+        tokenKindMap = new HashMap<>();
+        // start the service load process;
+        // both "hasNext()" and "next()" calls might trigger implementations loading.
         final Iterator<TokenIdentifier> tokenIdentifiers =
             ServiceLoader.load(TokenIdentifier.class).iterator();
-        while (tokenIdentifiers.hasNext()) {
+        while (true) {
           try {
+            if (!tokenIdentifiers.hasNext()) {
+              break;
+            }
             TokenIdentifier id = tokenIdentifiers.next();
             LOG.debug("Added {}:{} into tokenKindMap", id.getKind(), id.getClass());
             tokenKindMap.put(id.getKind(), id.getClass());
@@ -451,7 +449,7 @@ public class Token<T extends TokenIdentifier> implements Writable {
         Bytes.concat(kind.getBytes(), identifier, password)).toString();
   }
 
-  private static ServiceLoader<TokenRenewer> renewers =
+  private final static ServiceLoader<TokenRenewer> renewers =
       ServiceLoader.load(TokenRenewer.class);
 
   private synchronized TokenRenewer getRenewer() throws IOException {
@@ -461,14 +459,18 @@ public class Token<T extends TokenIdentifier> implements Writable {
     renewer = TRIVIAL_RENEWER;
     synchronized (renewers) {
       Iterator<TokenRenewer> it = renewers.iterator();
-      while (it.hasNext()) {
+      // both "hasNext()" and "next()" calls might trigger implementations loading.
+      while (true) {
         try {
+          if (!it.hasNext()) {
+            break;
+          }
           TokenRenewer candidate = it.next();
           if (candidate.handleKind(this.kind)) {
             renewer = candidate;
             return renewer;
           }
-        } catch (ServiceConfigurationError e) {
+        } catch (ServiceConfigurationError | LinkageError e) {
           // failure to load a token implementation
           // log at debug and continue.
           LOG.debug("Failed to load token renewer implementation", e);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Cluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Cluster.java
@@ -76,13 +76,12 @@ public class Cluster {
     if (providerList == null) {
       synchronized (frameworkLoader) {
         if (providerList == null) {
-          List<ClientProtocolProvider> localProviderList =
-              new ArrayList<ClientProtocolProvider>();
+          List<ClientProtocolProvider> localProviderList = new ArrayList<>();
           try {
             for (ClientProtocolProvider provider : frameworkLoader) {
               localProviderList.add(provider);
             }
-          } catch(ServiceConfigurationError e) {
+          } catch(ServiceConfigurationError | LinkageError e) {
             LOG.info("Failed to instantiate ClientProtocolProvider, please "
                          + "check the /META-INF/services/org.apache."
                          + "hadoop.mapreduce.protocol.ClientProtocolProvider "

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestCluster.java
@@ -38,16 +38,16 @@ import java.util.ServiceConfigurationError;
  * Testing the Cluster initialization.
  */
 public class TestCluster {
-  @Test
+
   @SuppressWarnings("unchecked")
-  public void testProtocolProviderCreation() throws Exception {
-    Iterator iterator = mock(Iterator.class);
+  public void testProtocolProviderCreation(Throwable error) throws Exception {
+    Iterator<ClientProtocolProvider> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, true, true);
     when(iterator.next()).thenReturn(getClientProtocolProvider())
-        .thenThrow(new ServiceConfigurationError("Test error"))
+        .thenThrow(error)
         .thenReturn(getClientProtocolProvider());
 
-    Iterable frameworkLoader = mock(Iterable.class);
+    Iterable<ClientProtocolProvider> frameworkLoader = mock(Iterable.class);
     when(frameworkLoader.iterator()).thenReturn(iterator);
 
     Cluster.frameworkLoader = frameworkLoader;
@@ -58,6 +58,16 @@ public class TestCluster {
     assertNotNull("ClientProtocol is expected", testCluster.getClient());
     // Check if we do not try to load the providers after a failure.
     verify(iterator, times(2)).next();
+  }
+
+  @Test
+  public void testThrowServiceConfigurationError() throws Exception {
+    testProtocolProviderCreation(new ServiceConfigurationError("Test error"));
+  }
+
+  @Test
+  public void testThrowNoClassDefFoundError() throws Exception {
+    testProtocolProviderCreation(new NoClassDefFoundError("Test error"));
   }
 
   public ClientProtocolProvider getClientProtocolProvider() {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This is a clean backport of #8265 to branch-3.4.

### How was this patch tested?

See #8265

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19821)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No.