### PR TITLE
HADOOP-19822: Upgrade Avro to 1.11.5

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -365,7 +365,7 @@ io.swagger:swagger-annotations:1.5.4
 javax.inject:javax.inject:1
 net.java.dev.jna:jna:5.2.0
 net.minidev:accessors-smart:1.21
-org.apache.avro:avro:1.11.4
+org.apache.avro:avro:1.11.5
 org.apache.commons:commons-compress:1.26.1
 org.apache.commons:commons-configuration2:2.10.1
 org.apache.commons:commons-csv:1.9.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -62,7 +62,7 @@
     <java.security.egd>file:///dev/urandom</java.security.egd>
 
     <!-- avro version -->
-    <avro.version>1.11.4</avro.version>
+    <avro.version>1.11.5</avro.version>
 
     <!-- jersey version -->
     <jersey2.version>2.46</jersey2.version>


### PR DESCRIPTION
### Description of PR

We can upgrade to Avro 1.11.5 for inclusion in the Hadoop 3.5.0 release.

### How was this patch tested?

Local build and test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html