### PR TITLE
HDFS-17886. Fix namenode storageDirectory errors when doCheckpoint updateStorageVersion failed because of doCheckpoint thread interrupted when standby namenode ha failover to active

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorage.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -1171,6 +1172,10 @@ public class NNStorage extends Storage implements Closeable,
     for (StorageDirectory sd : getStorageDirs()) {
       try {
         writeProperties(sd);
+      } catch (ClosedByInterruptException e) {
+        LOG.warn("Error during write properties to the VERSION file to {}",
+            sd, e);
+        return;
       } catch (Exception e) {
         LOG.warn("Error during write properties to the VERSION file to {}",
             sd, e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNUpdateStorageVersionWhenInterrupt.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNUpdateStorageVersionWhenInterrupt.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdfs.server.namenode;
 
 import java.io.File;
@@ -20,10 +37,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestNNUpdateStorageVersionWhenInterrupt {
-  static String nnDir =
+  private static final String nnDir =
       GenericTestUtils.getTestDir("dfs").getAbsolutePath() + File.separator + "namenode";
-  static NNStorage nnStorage;
-  static GenericTestUtils.LogCapturer nnStorageLog;
+  private static NNStorage nnStorage;
+  private static GenericTestUtils.LogCapturer nnStorageLog;
 
   @BeforeAll
   public static void setUp() throws IOException, URISyntaxException {
@@ -45,7 +62,7 @@ public class TestNNUpdateStorageVersionWhenInterrupt {
   @Test
   public void test()
       throws IOException, URISyntaxException, InterruptedException, TimeoutException {
-    Thread thread = new updateVersionFileThread(nnStorage);
+    Thread thread = new UpdateVersionFileThread(nnStorage);
     assertEquals(1, nnStorage.getNumStorageDirs());
 
     thread.start();
@@ -57,10 +74,10 @@ public class TestNNUpdateStorageVersionWhenInterrupt {
     assertEquals(1, nnStorage.getNumStorageDirs());
   }
 
-  private static class updateVersionFileThread extends Thread {
+  private static class UpdateVersionFileThread extends Thread {
     NNStorage nnStorage;
 
-    public updateVersionFileThread(NNStorage nnStorage) {
+    UpdateVersionFileThread(NNStorage nnStorage) {
       this.nnStorage = nnStorage;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNUpdateStorageVersionWhenInterrupt.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNUpdateStorageVersionWhenInterrupt.java
@@ -1,0 +1,77 @@
+package org.apache.hadoop.hdfs.server.namenode;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.server.common.Storage.StorageDirectory;
+import org.apache.hadoop.test.GenericTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestNNUpdateStorageVersionWhenInterrupt {
+  static String nnDir =
+      GenericTestUtils.getTestDir("dfs").getAbsolutePath() + File.separator + "namenode";
+  static NNStorage nnStorage;
+  static GenericTestUtils.LogCapturer nnStorageLog;
+
+  @BeforeAll
+  public static void setUp() throws IOException, URISyntaxException {
+    String scheme = "file:///";
+    Collection<URI> dirs = new ArrayList<>();
+    dirs.add(new URI(scheme + nnDir));
+    nnStorage = new NNStorage(new Configuration(), dirs, dirs);
+
+    StorageDirectory sd = new StorageDirectory(new File(nnDir));
+    Path versionFile = sd.getVersionFile().toPath();
+    Files.createDirectories(versionFile.getParent());
+    if (!Files.exists(versionFile)) {
+      Files.createFile(versionFile);
+    }
+
+    nnStorageLog = GenericTestUtils.LogCapturer.captureLogs(NNStorage.LOG);
+  }
+
+  @Test
+  public void test()
+      throws IOException, URISyntaxException, InterruptedException, TimeoutException {
+    Thread thread = new updateVersionFileThread(nnStorage);
+    assertEquals(1, nnStorage.getNumStorageDirs());
+
+    thread.start();
+    thread.interrupt();
+
+    GenericTestUtils.waitFor(
+        () -> nnStorageLog.getOutput().contains("java.nio.channels.ClosedByInterruptException"),
+        200, 20000);
+    assertEquals(1, nnStorage.getNumStorageDirs());
+  }
+
+  private static class updateVersionFileThread extends Thread {
+    NNStorage nnStorage;
+
+    public updateVersionFileThread(NNStorage nnStorage) {
+      this.nnStorage = nnStorage;
+    }
+
+    @Override
+    public void run() {
+      try {
+        nnStorage.writeAll();
+      } catch (IOException ignored) {
+
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Fix namenode storageDirectory errors when doCheckpoint updateStorageVersion failed because of doCheckpoint thread interrupted when standby namenode ha failover to active
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

As Discribe of [HDFS-17886](https://issues.apache.org/jira/browse/HDFS-17886) 

When namenode ha failover occurs, the standby namenode convert to active namenode，it will interrupt doCheckpoint thread.  There is an extremely small probability that doCheckpoint updateStorageVersion() will throw java.nio.channels.ClosedByInterruptException. It will lead to the storage directory errors and remove from available list.




The relevant error log is as follows：

```
2026-01-29 20:13:38,234 WARN org.apache.hadoop.hdfs.server.common.Storage: Error during write properties to the VERSION file to Storage Directory root= /data/hadoop/hdfs/namenode; location= null
java.nio.channels.ClosedByInterruptException
        at java.base/java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:199)
        at java.base/sun.nio.ch.FileChannelImpl.endBlocking(FileChannelImpl.java:162)
        at java.base/sun.nio.ch.FileChannelImpl.position(FileChannelImpl.java:342)
        at org.apache.hadoop.hdfs.server.common.Storage.writeProperties(Storage.java:1284)
        at org.apache.hadoop.hdfs.server.common.Storage.writeProperties(Storage.java:1263)
        at org.apache.hadoop.hdfs.server.common.Storage.writeProperties(Storage.java:1254)
        at org.apache.hadoop.hdfs.server.namenode.NNStorage.writeAll(NNStorage.java:1169)
        at org.apache.hadoop.hdfs.server.namenode.FSImage.updateStorageVersion(FSImage.java:1106)
        at org.apache.hadoop.hdfs.server.namenode.FSImage.saveNamespace(FSImage.java:1165)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer.doCheckpoint(StandbyCheckpointer.java:227)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer.access$1300(StandbyCheckpointer.java:64)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread.doWork(StandbyCheckpointer.java:480)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread.access$600(StandbyCheckpointer.java:383)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread$1.run(StandbyCheckpointer.java:403)
        at org.apache.hadoop.security.SecurityUtil.doAsLoginUserOrFatal(SecurityUtil.java:503)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread.run(StandbyCheckpointer.java:399)
2026-01-29 20:13:38,238 ERROR org.apache.hadoop.hdfs.server.common.Storage: Error reported on storage directory Storage Directory root= /data/hadoop/hdfs/namenode; location= null
2026-01-29 20:13:38,238 WARN org.apache.hadoop.hdfs.server.common.Storage: About to remove corresponding storage: /data/hadoop/hdfs/namenode
2026-01-29 20:13:38,245 ERROR org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer: Exception in doCheckpoint
java.io.IOException: All the storage failed while writing properties to VERSION file
        at org.apache.hadoop.hdfs.server.namenode.NNStorage.writeAll(NNStorage.java:1175)
        at org.apache.hadoop.hdfs.server.namenode.FSImage.updateStorageVersion(FSImage.java:1106)
        at org.apache.hadoop.hdfs.server.namenode.FSImage.saveNamespace(FSImage.java:1165)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer.doCheckpoint(StandbyCheckpointer.java:227)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer.access$1300(StandbyCheckpointer.java:64)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread.doWork(StandbyCheckpointer.java:480)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread.access$600(StandbyCheckpointer.java:383)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread$1.run(StandbyCheckpointer.java:403)
        at org.apache.hadoop.security.SecurityUtil.doAsLoginUserOrFatal(SecurityUtil.java:503)
        at org.apache.hadoop.hdfs.server.namenode.ha.StandbyCheckpointer$CheckpointerThread.run(StandbyCheckpointer.java:399)
```



And java.nio.channels.ClosedByInterruptException is not a disk errors , so  it should not remove from available storage list.