### PR TITLE
MAPREDUCE-7533. MR AM UI wont be loaded on root path

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebApp.java
@@ -41,6 +41,7 @@ public class AMWebApp extends WebApp implements AMParams {
     bind(AppContext.class).toInstance(appContext);
     route("/", AppController.class);
     route("/app", AppController.class);
+    route("/mapreduce", AppController.class);
     route(pajoin("/job", JOB_ID), AppController.class, "job");
     route(pajoin("/conf", JOB_ID), AppController.class, "conf");
     route(pajoin("/jobcounters", JOB_ID), AppController.class, "jobCounters");


### PR DESCRIPTION
### Description of PR

If we click on the ApplicationMaster link on the RM UI it will redirect us to the root of the AM web server what will forward the call (302) to /mapreduce but that path is currently empty and will return 404

### How was this patch tested?

Manually deployed a cluster

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No ai was used