### PR TITLE
HDFS-17843. FileSystem.createFile() fails with relative path.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -541,7 +541,7 @@ public class DistributedFileSystem extends FileSystem
     return new FileSystemLinkResolver<HdfsDataOutputStream>() {
       @Override
       public HdfsDataOutputStream doCall(final Path p) throws IOException {
-        final DFSOutputStream out = dfs.create(getPathName(f), permission,
+        final DFSOutputStream out = dfs.create(getPathName(p), permission,
             overwrite ? EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE)
                 : EnumSet.of(CreateFlag.CREATE),
             true, replication, blockSize, progress, bufferSize, null,
@@ -623,7 +623,7 @@ public class DistributedFileSystem extends FileSystem
     return new FileSystemLinkResolver<HdfsDataOutputStream>() {
       @Override
       public HdfsDataOutputStream doCall(final Path p) throws IOException {
-        final DFSOutputStream out = dfs.create(getPathName(f), permission,
+        final DFSOutputStream out = dfs.create(getPathName(p), permission,
             flag, true, replication, blockSize, progress, bufferSize,
             checksumOpt, favoredNodes, ecPolicyName, storagePolicy);
         return safelyCreateWrappedOutputStream(out);
@@ -681,7 +681,7 @@ public class DistributedFileSystem extends FileSystem
     return new FileSystemLinkResolver<HdfsDataOutputStream>() {
       @Override
       public HdfsDataOutputStream doCall(final Path p) throws IOException {
-        final DFSOutputStream out = dfs.create(getPathName(f), permission,
+        final DFSOutputStream out = dfs.create(getPathName(p), permission,
             flag, false, replication, blockSize, progress, bufferSize,
             checksumOpt, favoredNodes, ecPolicyName, storagePolicyName);
         return safelyCreateWrappedOutputStream(out);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -1925,6 +1925,35 @@ public class TestDistributedFileSystem {
   }
 
   @Test
+  public void testCreateFileWithRelativePath() throws Exception {
+    Configuration conf = getTestConfiguration();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1).build()) {
+      DistributedFileSystem fs = cluster.getFileSystem();
+      fs.mkdirs(fs.getHomeDirectory());
+
+      // HDFS-17843: createFile() and create() with favored nodes should both
+      // handle relative paths the same way as fs.create().
+      Path relative = new Path("testRelativeCreate");
+      try (FSDataOutputStream out = fs.createFile(relative).build()) {
+        out.write(42);
+      }
+      assertTrue(fs.exists(fs.makeQualified(relative)),
+          "File created via createFile() with relative path should exist");
+
+      Path relativeFavored = new Path("testRelativeCreateFavored");
+      try (FSDataOutputStream out = fs.create(relativeFavored,
+          FsPermission.getFileDefault(), true, 4096, (short) 1,
+          fs.getDefaultBlockSize(relativeFavored), null,
+          new InetSocketAddress[0])) {
+        out.write(42);
+      }
+      assertTrue(fs.exists(fs.makeQualified(relativeFavored)),
+          "File created via create() with favored nodes and relative path should exist");
+    }
+  }
+
+  @Test
   public void testDFSDataOutputStreamBuilderForAppend() throws IOException {
     Configuration conf = getTestConfiguration();
     String testFile = "/testDFSDataOutputStreamBuilderForAppend";


### PR DESCRIPTION
### Description of PR

JIRA: https://issues.apache.org/jira/browse/HDFS-17843

`DistributedFileSystem.createFile()` (builder pattern) and `create()` with favored nodes threw `IllegalArgumentException` when passed a relative path, while `fs.create()` worked correctly.

#### Root Cause

In three `create()` overloads, the `doCall(Path p)` method passed the original outer variable `f` (potentially relative) to `getPathName()` instead of the resolved absolute path `p` computed by `fixRelativePart()` + symlink resolution:

```java
// Before (buggy)
public HdfsDataOutputStream doCall(final Path p) throws IOException {
    final DFSOutputStream out = dfs.create(getPathName(f), ...);

// After (fixed)
public HdfsDataOutputStream doCall(final Path p) throws IOException {
    final DFSOutputStream out = dfs.create(getPathName(p), ...);
```

The three affected methods are:
- `create(Path, FsPermission, boolean, int, short, long, Progressable, InetSocketAddress[])` — create with favored nodes
- `create(Path, FsPermission, EnumSet, int, short, long, Progressable, ChecksumOpt, InetSocketAddress[], String, String)` — create with EC/storage policy (used by `createFile()` builder)
- `createNonRecursive(Path, FsPermission, EnumSet, int, short, long, Progressable, ChecksumOpt, InetSocketAddress[], String, String)`

#### Testing

Added `TestDistributedFileSystem#testCreateFileWithRelativePath` covering both `createFile()` builder and `create()` with favored nodes using relative paths. Also verified manually against a running single-node HDFS cluster.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?