### PR TITLE
HDFS-17879. Premature error handling accesses uninitialized dnInfo.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -261,6 +261,12 @@ public class DFSStripedInputStream extends DFSInputStream {
         DFSClientFaultInjector.get().onCreateBlockReader(block, chunkIndex, offsetInBlock,
             readTo - offsetInBlock);
       } catch (IOException e) {
+        // dnInfo.addr is null if the exception occurred before getBestNodeDNAddrPair()
+        // was called (e.g. in refreshLocatedBlock()). In that case, DataNode-specific
+        // error handling cannot proceed, so rethrow immediately.
+        if (dnInfo.addr == null) {
+          throw e;
+        }
         if (e instanceof InvalidEncryptionKeyException &&
             retry.shouldRefetchEncryptionKey()) {
           DFSClient.LOG.info("Will fetch a new encryption key and retry, "

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStream.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import org.apache.hadoop.hdfs.StripeReader.BlockReaderInfo;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -796,5 +797,47 @@ public class TestDFSStripedInputStream {
     } finally {
       DFSClientFaultInjector.set(old);
     }
+  }
+
+  /**
+   * HDFS-17879: Test that an IOException thrown by refreshLocatedBlock()
+   * (before dnInfo is populated) is propagated cleanly without a
+   * NullPointerException from the catch block accessing dnInfo.addr.
+   */
+  @Test
+  public void testCreateBlockReaderExceptionBeforeDnInfoInit() throws Exception {
+    DFSTestUtil.createStripedFile(cluster, filePath, null, 1,
+        stripesPerBlock, false, ecPolicy);
+
+    DFSStripedInputStream in = new DFSStripedInputStream(
+        fs.getClient(), filePath.toString(), false, ecPolicy, null);
+
+    // Spy on the stream so we can make refreshLocatedBlock() throw
+    // before getBestNodeDNAddrPair() is called (i.e. before dnInfo is set).
+    DFSStripedInputStream spyIn = spy(in);
+    IOException injectedException = new IOException("Injected failure in refreshLocatedBlock");
+    doThrow(injectedException).when(spyIn).refreshLocatedBlock(
+        org.mockito.ArgumentMatchers.any());
+
+    LocatedBlocks lbs = fs.getClient().namenode.getBlockLocations(
+        filePath.toString(), 0, blockGroupSize);
+    LocatedStripedBlock lsb = (LocatedStripedBlock) lbs.getLocatedBlocks().get(0);
+    LocatedBlock[] targetBlocks = StripedBlockUtil.parseStripedBlockGroup(
+        lsb, cellSize, dataBlocks, parityBlocks);
+    BlockReaderInfo[] readerInfos = new BlockReaderInfo[dataBlocks + parityBlocks];
+
+    // Before the fix this would throw NullPointerException wrapping the real cause.
+    // After the fix it should propagate the original IOException directly.
+    try {
+      spyIn.createBlockReader(targetBlocks[0], 0, targetBlocks, readerInfos, 0, blockSize);
+      fail("Expected IOException to be thrown");
+    } catch (NullPointerException npe) {
+      fail("Got NullPointerException — dnInfo.addr was accessed before initialization. " +
+          "HDFS-17879 fix is missing.");
+    } catch (IOException e) {
+      assertEquals(injectedException, e,
+          "Should propagate the original IOException from refreshLocatedBlock");
+    }
+    spyIn.close();
   }
 }


### PR DESCRIPTION
### Description of PR

JIRA: https://issues.apache.org/jira/browse/HDFS-17879

#### Problem

In `DFSStripedInputStream.createBlockReader()`, `dnInfo` is initialized with all-null fields before the retry loop:

```java
DFSInputStream.DNAddrPair dnInfo =
    new DFSInputStream.DNAddrPair(null, null, null, null);
```

It is then populated by `getBestNodeDNAddrPair()` — but only after `refreshLocatedBlock()` is called first. If `refreshLocatedBlock()` throws an `IOException`, the catch block immediately accesses `dnInfo.addr` (still `null`), causing a `NullPointerException` that masks the original error:

```
NullPointerException at DFSStripedInputStream.java:267  (dnInfo.addr)
  caused by: IOException from refreshLocatedBlock()
```

#### Fix

Add a null check on `dnInfo.addr` at the top of the catch block. If `null`, the failure occurred before any DataNode was identified, so we rethrow the original `IOException` directly — preserving the real error for the caller.

```java
if (dnInfo.addr == null) {
  throw e;
}
```

#### Testing

Added `TestDFSStripedInputStream#testCreateBlockReaderExceptionBeforeDnInfoInit` which uses Mockito to make `refreshLocatedBlock()` throw an `IOException`, and verifies:
- Before fix: `NullPointerException` is thrown (masked error)
- After fix: original `IOException` is propagated cleanly

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?