### PR TITLE
HADOOP-19826. Add contract test to verify renaming empty dir works

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -351,4 +351,16 @@ public abstract class AbstractContractRenameTest extends
     assertPathExists(action, renameSrc);
   }
 
+  @Test
+  public void testRenameEmptyDirectory() throws Throwable {
+    var fs = getFileSystem();
+    var basePath = methodPath();
+    var source = new Path(basePath, "empty");
+    var dest = new Path(basePath, "dest");
+    fs.mkdirs(source);
+    fs.rename(source, dest);
+    assertPathExists("empty dir rename", dest);
+    assertPathDoesNotExist("empty dir rename", source);
+  }
+
 }


### PR DESCRIPTION
### How was this patch tested?

Test for handling of empty dirs; surprised we didn't have this in already.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html