### PR TITLE
MAPREDUCE-7527. Fix /jobhistory/attempts/ page not rendering attempt information

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebApp.java
@@ -27,8 +27,11 @@ import static org.apache.hadoop.yarn.webapp.YarnWebParams.NM_NODENAME;
 
 import org.apache.hadoop.mapreduce.v2.app.AppContext;
 import org.apache.hadoop.mapreduce.v2.app.webapp.AMParams;
+import org.apache.hadoop.mapreduce.v2.app.webapp.App;
 import org.apache.hadoop.mapreduce.v2.hs.HistoryContext;
 import org.apache.hadoop.yarn.webapp.WebApp;
+
+import com.google.inject.Singleton;
 
 public class HsWebApp extends WebApp implements AMParams {
 
@@ -40,6 +43,7 @@ public class HsWebApp extends WebApp implements AMParams {
 
   @Override
   public void setup() {
+    bind(App.class).in(Singleton.class);
     bind(AppContext.class).toInstance(history);
     bind(HistoryContext.class).toInstance(history);
     route("/", HsController.class);


### PR DESCRIPTION
### Description of PR

Fix /jobhistory/attempts/ page not rendering attempt information

### How was this patch tested?
Built locally:
<img width="3440" height="1700" alt="image" src="https://github.com/user-attachments/assets/c0c955d9-4893-4d27-992c-7ef6486612b2" />


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html