### PR TITLE
HDFS-17888. Fix MiniCluster startup & HttpServer service's conf issues.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -222,7 +222,7 @@ public abstract class GenericTestUtils {
     }
     File dir = new File(prop).getAbsoluteFile();
     if (dir.mkdirs() && !dir.exists()) {
-      throw new IllegalArgumentException("File " + dir + " should exist");
+      throw new IllegalStateException("Directory " + dir + " not created");
     }
     return dir;
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -221,8 +221,9 @@ public abstract class GenericTestUtils {
       prop = DEFAULT_TEST_DATA_DIR;
     }
     File dir = new File(prop).getAbsoluteFile();
-    dir.mkdirs();
-    assertExists(dir);
+    if (dir.mkdirs() && !dir.exists()) {
+      throw new IllegalArgumentException("File " + dir + " should exist");
+    }
     return dir;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1562,7 +1562,10 @@ public class DataNode extends ReconfigurableBase
     DFSUtil.addInternalPBProtocol(getConf(), InterDatanodeProtocolPB.class, service,
         ipcServer);
 
-    LOG.info("Opened IPC server at {}", ipcServer.getListenerAddress());
+    InetSocketAddress listenerAddress = ipcServer.getListenerAddress();
+    LOG.info("Opened IPC server at {}", listenerAddress);
+    dnConf.getConf().set(DFS_DATANODE_IPC_ADDRESS_KEY,
+        listenerAddress.getHostName() + ":" + listenerAddress.getPort());
 
     // set service-level authorization security policy
     if (getConf().getBoolean(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -305,7 +305,7 @@ public class DatanodeHttpServer implements Closeable {
       httpAddress = getChannelLocalAddress(httpServer, infoAddr);
       conf.set(DFSConfigKeys.DFS_DATANODE_HTTP_ADDRESS_KEY,
           NetUtils.getHostPortString(httpAddress));
-      LOG.info("Listening HTTP traffic on {}", httpAddress);
+      LOG.info("Listening for HTTP traffic on {}", httpAddress);
     }
 
     if (httpsServer != null) {
@@ -316,7 +316,7 @@ public class DatanodeHttpServer implements Closeable {
       httpsAddress = getChannelLocalAddress(httpsServer, secInfoSocAddr);
       conf.set(DFSConfigKeys.DFS_DATANODE_HTTPS_ADDRESS_KEY,
           NetUtils.getHostPortString(httpsAddress));
-      LOG.info("Listening HTTPS traffic on {}", httpsAddress);
+      LOG.info("Listening for HTTPS traffic on {}", httpsAddress);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -303,7 +303,9 @@ public class DatanodeHttpServer implements Closeable {
     if (httpServer != null) {
       InetSocketAddress infoAddr = DataNode.getInfoAddr(conf);
       httpAddress = getChannelLocalAddress(httpServer, infoAddr);
-      LOG.info("Listening HTTP traffic on " + httpAddress);
+      conf.set(DFSConfigKeys.DFS_DATANODE_HTTP_ADDRESS_KEY,
+          NetUtils.getHostPortString(httpAddress));
+      LOG.info("Listening HTTP traffic on {}", httpAddress);
     }
 
     if (httpsServer != null) {
@@ -312,7 +314,9 @@ public class DatanodeHttpServer implements Closeable {
               DFS_DATANODE_HTTPS_ADDRESS_KEY,
               DFS_DATANODE_HTTPS_ADDRESS_DEFAULT));
       httpsAddress = getChannelLocalAddress(httpsServer, secInfoSocAddr);
-      LOG.info("Listening HTTPS traffic on " + httpsAddress);
+      conf.set(DFSConfigKeys.DFS_DATANODE_HTTPS_ADDRESS_KEY,
+          NetUtils.getHostPortString(httpsAddress));
+      LOG.info("Listening HTTPS traffic on {}", httpsAddress);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
@@ -193,7 +193,7 @@ public class NameNodeHttpServer {
       if (httpAddress != null) {
         conf.set(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY,
             NetUtils.getHostPortString(httpAddress));
-        LOG.info("Listening HTTP traffic on {}", httpAddress);
+        LOG.info("Listening for HTTP traffic on {}", httpAddress);
       }
     }
 
@@ -202,7 +202,7 @@ public class NameNodeHttpServer {
       if (httpsAddress != null) {
         conf.set(DFSConfigKeys.DFS_NAMENODE_HTTPS_ADDRESS_KEY,
             NetUtils.getHostPortString(httpsAddress));
-        LOG.info("Listening HTTPS traffic on {}", httpsAddress);
+        LOG.info("Listening for HTTPS traffic on {}", httpsAddress);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
@@ -54,12 +54,17 @@ import org.apache.hadoop.security.http.RestCsrfPreventionFilter;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates the HTTP server started by the NameNode. 
  */
 @InterfaceAudience.Private
 public class NameNodeHttpServer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NameNodeHttpServer.class);
+
   private HttpServer2 httpServer;
   private final Configuration conf;
   private final NameNode nn;
@@ -185,14 +190,20 @@ public class NameNodeHttpServer {
     int connIdx = 0;
     if (policy.isHttpEnabled()) {
       httpAddress = httpServer.getConnectorAddress(connIdx++);
-      conf.set(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY,
-          NetUtils.getHostPortString(httpAddress));
+      if (httpAddress != null) {
+        conf.set(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY,
+            NetUtils.getHostPortString(httpAddress));
+        LOG.info("Listening HTTP traffic on {}", httpAddress);
+      }
     }
 
     if (policy.isHttpsEnabled()) {
       httpsAddress = httpServer.getConnectorAddress(connIdx);
-      conf.set(DFSConfigKeys.DFS_NAMENODE_HTTPS_ADDRESS_KEY,
-          NetUtils.getHostPortString(httpsAddress));
+      if (httpsAddress != null) {
+        conf.set(DFSConfigKeys.DFS_NAMENODE_HTTPS_ADDRESS_KEY,
+            NetUtils.getHostPortString(httpsAddress));
+        LOG.info("Listening HTTPS traffic on {}", httpsAddress);
+      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/datanode/datanode.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/datanode/datanode.html
@@ -68,7 +68,7 @@
 
 <script type="text/x-dust-template" id="tmpl-dn">
 {#dn}
-<div class="page-header"><h1>DataNode on <small>{HostName}:{DataPort}</small></h1></div>
+<div class="page-header"><h1>DataNode on <small>{HostName}:{RpcPort}</small></h1></div>
 <table class="table table-bordered table-striped">
   <tr><th>Cluster ID:</th><td>{ClusterId}</td></tr>
   <tr><th>Started:</th><td>{DNStartedTimeInMillis|date_tostring}</td></tr>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeConfig.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeConfig.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs;
 
 import static org.apache.hadoop.hdfs.server.common.Util.fileAsURI;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -178,10 +178,12 @@ public class TestDatanodeConfig {
       dn = DataNode.createDataNode(new String[] {}, conf);
       Configuration dnConf = dn.getConf();
       InetSocketAddress listenerAddress = dn.ipcServer.getListenerAddress();
-      assertEquals(dnConf.get(DFSConfigKeys.DFS_DATANODE_IPC_ADDRESS_KEY),
-          listenerAddress.getHostName() + ":" + listenerAddress.getPort());
-      assertEquals(dnConf.get(DFSConfigKeys.DFS_DATANODE_HTTP_ADDRESS_KEY),
-          listenerAddress.getHostName() + ":" + dn.getHttpPort());
+      assertThat(listenerAddress.getHostName() + ":" + listenerAddress.getPort())
+          .describedAs("IPC Address is inconsistent")
+          .isEqualTo(dnConf.get(DFSConfigKeys.DFS_DATANODE_IPC_ADDRESS_KEY));
+      assertThat(listenerAddress.getHostName() + ":" + dn.getHttpPort())
+          .describedAs("HTTP Address is inconsistent")
+          .isEqualTo(dnConf.get(DFSConfigKeys.DFS_DATANODE_HTTP_ADDRESS_KEY));
     } finally {
       if (dn != null) {
         dn.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeConfig.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeConfig.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs;
 
 import static org.apache.hadoop.hdfs.server.common.Util.fileAsURI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -165,6 +167,25 @@ public class TestDatanodeConfig {
       }
       conf.setLong(DFSConfigKeys.DFS_DATANODE_MAX_LOCKED_MEMORY_KEY,
           prevLimit);
+    }
+  }
+
+  @Test
+  public void testDataNodeIpcAndHttpSeverConf() throws Exception {
+    Configuration conf = cluster.getConfiguration(0);
+    DataNode dn = null;
+    try {
+      dn = DataNode.createDataNode(new String[] {}, conf);
+      Configuration dnConf = dn.getConf();
+      InetSocketAddress listenerAddress = dn.ipcServer.getListenerAddress();
+      assertEquals(dnConf.get(DFSConfigKeys.DFS_DATANODE_IPC_ADDRESS_KEY),
+          listenerAddress.getHostName() + ":" + listenerAddress.getPort());
+      assertEquals(dnConf.get(DFSConfigKeys.DFS_DATANODE_HTTP_ADDRESS_KEY),
+          listenerAddress.getHostName() + ":" + dn.getHttpPort());
+    } finally {
+      if (dn != null) {
+        dn.shutdown();
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/projects/HDFS/issues/HDFS-17888

Startup MiniCluster

`nohup bin/mapred minicluster -format -nomr > log 2>&1 &`

When using the CLI MiniCluster feature for testing of other functions, the following issues were found:

1. Currently, MiniCluster cannot be started due to the absence of the Jupiter package.
2. If the HttpServer port is 0, a free port will be randomly assigned, but The port on DataNode UI is 0.
3. DataNode HttpServer port usage error. According to NameNode, the port used here should be RpcServer, not the port for data transmission.
4. Add logs related to httpServer to view the NameNode httpServer port, making it easier for users to find the HttpServer address and view some data.

<img width="1147" height="351" alt="image" src="https://github.com/user-attachments/assets/10de0bc3-f20f-4492-bf63-035d11389338" />

<img width="790" height="577" alt="image" src="https://github.com/user-attachments/assets/e61aae8c-a81a-4809-98b1-dd17bad6e4c7" />

### How was this patch tested?
Add UT & Local startup MiniCluster

`mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true -Denforcer.skip=true`

`nohup bin/mapred minicluster -format -nomr > log 2>&1 &`