### PR TITLE
HDFS-17427. Thread hang when using NativeIO for shortcircuit-read.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/DfsClientShmManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/DfsClientShmManager.java
@@ -104,6 +104,16 @@ public class DfsClientShmManager implements Closeable {
      */
     private boolean loading = false;
 
+    /**
+     * The thread that is currently loading a shared memory segment, or null
+     * if no loading is in progress.  Used to detect re-entrant calls from
+     * the same thread (e.g. when NativeIO class initialization triggers an
+     * HDFS read, which re-enters allocSlot on the same thread).
+     *
+     * Protected by the manager lock.
+     */
+    private Thread loadingThread = null;
+
     EndpointShmManager (DatanodeInfo datanode) {
       this.datanode = datanode;
     }
@@ -240,11 +250,23 @@ public class DfsClientShmManager implements Closeable {
         // There are no free slots.  If someone is loading more slots, wait
         // for that to finish.
         if (loading) {
+          if (Thread.currentThread() == loadingThread) {
+            // The same thread that is already loading a segment has re-entered
+            // allocSlot (e.g. NativeIO.POSIX class initialization triggered an
+            // HDFS read via the context ClassLoader, which called back into
+            // this method on the same thread).  Waiting would deadlock because
+            // this thread is the one responsible for signalling finishedLoading.
+            // Return null so the caller falls back to a non-short-circuit read.
+            LOG.debug("{}: re-entrant allocSlot call detected on loading thread;"
+                + " skipping short-circuit shm to avoid deadlock.", this);
+            return null;
+          }
           LOG.trace("{}: waiting for loading to finish...", this);
           finishedLoading.awaitUninterruptibly();
         } else {
           // Otherwise, load the slot ourselves.
           loading = true;
+          loadingThread = Thread.currentThread();
           lock.unlock();
           DfsClientShm shm;
           try {
@@ -259,6 +281,7 @@ public class DfsClientShmManager implements Closeable {
           } finally {
             lock.lock();
             loading = false;
+            loadingThread = null;
             finishedLoading.signalAll();
           }
           if (shm.isDisconnected()) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestDfsClientShmManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestDfsClientShmManager.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.shortcircuit;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.hadoop.hdfs.ExtendedBlockId;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.shortcircuit.DfsClientShmManager.EndpointShmManager;
+import org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm.Slot;
+import org.apache.hadoop.net.unix.DomainSocketWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Unit tests for {@link DfsClientShmManager}.
+ */
+public class TestDfsClientShmManager {
+
+  @BeforeEach
+  public void before() {
+    assumeTrue(null == DomainSocketWatcher.getLoadingFailureReason(),
+        "Skipping test: native Unix domain socket support not available");
+  }
+
+  /**
+   * Regression test for HDFS-17427.
+   *
+   * When the thread that is loading a new shm segment calls allocSlot() again
+   * on the same thread (e.g. because NativeIO.POSIX class initialization
+   * triggers an HDFS read via a custom URLClassLoader whose classpath includes
+   * remote HDFS JARs), the method must return null instead of deadlocking on
+   * {@code finishedLoading.awaitUninterruptibly()}.
+   *
+   * The test would hang indefinitely without the fix; with the fix it returns
+   * null within the @Timeout window.
+   */
+  @Test
+  @Timeout(value = 10)
+  public void testReentrantAllocSlotAvoidsDeadlock() throws Exception {
+    DfsClientShmManager manager = new DfsClientShmManager(10);
+    try {
+      DatanodeInfo datanode = new DatanodeInfo.DatanodeInfoBuilder()
+          .setIpAddr("127.0.0.1")
+          .setHostName("localhost")
+          .setDatanodeUuid("test-dn-uuid")
+          .setXferPort(9866)
+          .build();
+      ExtendedBlockId blockId = new ExtendedBlockId(1L, "bp-test");
+      MutableBoolean usedPeer = new MutableBoolean(false);
+
+      // Access the manager's internal datanodes map and lock via reflection.
+      Field datanodesField =
+          DfsClientShmManager.class.getDeclaredField("datanodes");
+      datanodesField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      HashMap<DatanodeInfo, EndpointShmManager> datanodes =
+          (HashMap<DatanodeInfo, EndpointShmManager>) datanodesField.get(manager);
+
+      Field lockField = DfsClientShmManager.class.getDeclaredField("lock");
+      lockField.setAccessible(true);
+      ReentrantLock lock = (ReentrantLock) lockField.get(manager);
+
+      // Directly instantiate an EndpointShmManager (package-private inner
+      // class) and register it for the datanode.
+      Constructor<EndpointShmManager> ctor =
+          EndpointShmManager.class.getDeclaredConstructor(
+              DfsClientShmManager.class, DatanodeInfo.class);
+      ctor.setAccessible(true);
+      EndpointShmManager endpointManager = ctor.newInstance(manager, datanode);
+
+      lock.lock();
+      try {
+        datanodes.put(datanode, endpointManager);
+      } finally {
+        lock.unlock();
+      }
+
+      // Simulate the mid-requestNewShm state: the current thread set
+      // loading=true (and is responsible for signalling finishedLoading) but
+      // then re-enters allocSlot() before requestNewShm() returns — exactly
+      // what happens when NativeIO.POSIX.<clinit>() calls new Configuration()
+      // which loads resources via a URLClassLoader backed by remote HDFS JARs.
+      Field loadingField =
+          EndpointShmManager.class.getDeclaredField("loading");
+      loadingField.setAccessible(true);
+      Field loadingThreadField =
+          EndpointShmManager.class.getDeclaredField("loadingThread");
+      loadingThreadField.setAccessible(true);
+
+      loadingField.setBoolean(endpointManager, true);
+      loadingThreadField.set(endpointManager, Thread.currentThread());
+
+      // Call allocSlot() from the same thread.  Without HDFS-17427 fix this
+      // would block forever on finishedLoading.awaitUninterruptibly() because
+      // the current thread is the one that must eventually signal the
+      // condition.  With the fix it detects the re-entrant call and returns
+      // null so the caller can fall back to a non-short-circuit read.
+      Slot slot = manager.allocSlot(
+          datanode, null, usedPeer, blockId, "test-client");
+      assertNull(slot,
+          "Re-entrant allocSlot from the loading thread must return null "
+              + "to avoid deadlock (HDFS-17427)");
+    } finally {
+      manager.close();
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When an application runs on a DataNode with short-circuit reads enabled and a custom `URLClassLoader` (whose classpath contains remote HDFS JARs) set as the thread context ClassLoader, the main thread can hang indefinitely.

**Deadlock chain:**

1. Thread T enters `DfsClientShmManager.EndpointShmManager.allocSlot()`, sets `loading = true`, releases the lock, and calls `requestNewShm()`
2. `requestNewShm()` creates a `DfsClientShm`, whose constructor (`ShortCircuitShm`) calls `POSIX.mmap()` — triggering the `NativeIO.POSIX` class static initializer
3. The static initializer calls `new Configuration()`, which loads XML resources via the thread's **context ClassLoader**
4. If the context ClassLoader is a `URLClassLoader` backed by remote HDFS JARs, resolving those JARs triggers an HDFS read
5. That read re-enters `allocSlot()` on **the same thread T**, which acquires the lock (since it was released), sees `loading == true`, and calls `finishedLoading.awaitUninterruptibly()`
6. Thread T is now parked waiting for a condition that **it itself** must signal → **indefinite hang**

## Fix

Track which thread set `loading = true` via a new `loadingThread` field in `EndpointShmManager`. When `allocSlot()` detects that `loading == true` and the current thread **is** the loading thread, it returns `null` immediately instead of waiting. The caller then falls back transparently to a normal (non-short-circuit) read.

Changes:
- `DfsClientShmManager.java`: add `loadingThread` field; set/clear it alongside `loading`; detect and short-circuit re-entrant calls
- `TestDfsClientShmManager.java`: regression test that injects the re-entrant state via reflection and verifies `null` is returned within a 10-second timeout (would hang indefinitely before this fix)

## Test

```
mvn test -pl hadoop-hdfs-project/hadoop-hdfs-client \
  -Dtest=TestDfsClientShmManager
```

The test requires native Unix domain socket support (`libhadoop`) and auto-skips without it (matching the pattern used throughout the shortcircuit test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)