### PR TITLE
HADOOP-19827. Upgrade kafka-clients to 3.9.2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -385,7 +385,7 @@ org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.13
 org.apache.httpcomponents.client5:httpclient5:5.5
 org.apache.httpcomponents.core5:httpcore5:5.5
-org.apache.kafka:kafka-clients:3.9.0
+org.apache.kafka:kafka-clients:3.9.2
 org.apache.kerby:kerb-admin:2.0.3
 org.apache.kerby:kerb-client:2.0.3
 org.apache.kerby:kerb-common:2.0.3

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -49,7 +49,7 @@
     <!-- Version number for xerces used by JDiff -->
     <xerces.jdiff.version>2.12.2</xerces.jdiff.version>
 
-    <kafka.version>3.9.0</kafka.version>
+    <kafka.version>3.9.2</kafka.version>
 
     <commons-daemon.version>1.0.13</commons-daemon.version>
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19827. Upgrade kafka-clients to 3.9.2.

HADOOP-19747 intended to upgrade lz4-java from `org.lz4:lz4-java` to `at.yawk.lz4:lz4-java` but actually didn't succeed.

Download Hadoop 3.5.0 RC0
```
$ find hadoop-3.5.0 -iname '*lz4-java*'
hadoop-3.5.0/share/hadoop/tools/lib/lz4-java-1.8.0.jar
```

This is because kafka-clients 3.9.0 still pulls old `org.lz4:lz4-java`, it was fixed in

> [[KAFKA-19951](https://issues.apache.org/jira/browse/KAFKA-19951)] - switch lz4-java to at.yawk.lz4 version due to CVE

https://archive.apache.org/dist/kafka/3.9.2/RELEASE_NOTES.html

### How was this patch tested?

```
$ ./start-build-env.sh
...
$ ./mvnw clean package -Pdist,native -DskipTests -Dtar -Dmaven.javadoc.skip=true
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18:12 min
[INFO] Finished at: 2026-03-02T07:47:21Z
[INFO] ------------------------------------------------------------------------
$ find hadoop-dist/target/hadoop-3.6.0-SNAPSHOT -iname '*lz4-java*'
hadoop-dist/target/hadoop-3.6.0-SNAPSHOT/share/hadoop/tools/lib/lz4-java-1.10.2.jar
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19827)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.