### PR TITLE
HADOOP-19828. Build Docker image in CI only once per commit

### DIFF
--- a/.github/workflows/build-and-tag-hadoop-image.yaml
+++ b/.github/workflows/build-and-tag-hadoop-image.yaml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: build-and-tag-hadoop-image
+
+# This workflow builds (if necessary) and tags the Docker image.
+# Images are tagged by extracting the version from branch name:
+#   docker-hadoop-X.Y -> X.Y
+
+on:
+  push:
+    branches:
+      - 'docker-hadoop-**'
+      - '!docker-hadoop-runner-**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-hadoop-image.yaml
+
+  tag:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_ID: ${{ needs.build.outputs.image-id }}
+      REGISTRIES: ghcr.io
+    steps:
+      - name: Generate tags
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ${{ github.repository_owner }}/hadoop
+          tags: |
+            type=match,pattern=docker-hadoop-(.*),value={{branch}},group=1
+          flavor: |
+            latest=false
+
+      - name: Pull image
+        run: |
+          docker pull "$IMAGE_ID"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply tags to existing image
+        run: |
+          set -x
+          for registry in $REGISTRIES; do
+            opts="$(echo "$DOCKER_METADATA_OUTPUT_TAGS" | sed "s@^@--tag $registry/@g" | xargs echo)"
+            if [[ -n "$opts" ]]; then
+              docker buildx imagetools create $opts "$IMAGE_ID"
+            fi
+          done

--- a/.github/workflows/build-hadoop-image.yaml
+++ b/.github/workflows/build-hadoop-image.yaml
@@ -15,8 +15,8 @@
 
 name: build-hadoop-image
 
-# This workflow builds the Hadoop docker image.
-# For non-PR runs, it also pushes the image to the registry, tagging it based on the branch name.
+# This workflow builds the Docker image if it does not exists already.
+# For non-PR runs, it also publishes the image to the registry, tagging it by the full SHA of the commit.
 
 on:
   pull_request:
@@ -25,9 +25,17 @@ on:
       - 'docker-hadoop-**'
       - '!docker-hadoop-runner-**'
   push:
-    branches:
+    branches-ignore:
       - 'docker-hadoop-**'
-      - '!docker-hadoop-runner-**'
+  workflow_call:
+    outputs:
+      image-id:
+        description: "Docker image ID in repo/owner/name:tag format"
+        value: ${{ jobs.build.outputs.image-id }}
+
+concurrency:
+  group: ${{ github.sha }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -36,6 +44,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image-id: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Generate image ID
         id: meta
@@ -44,19 +54,31 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/hadoop
           tags: |
-            type=match,pattern=docker-hadoop-(.*),value={{branch}},group=1
-          flavor: |
-            latest=false
+            # keep single item
+            # any further tags should be added only in build-and-tag-hadoop-image.yaml, not here
+            type=sha,prefix=,format=long
+
+      - name: Check if image exists
+        id: pull
+        run: |
+          success=false
+          if docker pull "$DOCKER_METADATA_OUTPUT_TAGS"; then
+            success=true
+          fi
+
+          echo "success=$success" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
+        if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
 
       - name: Set up Docker Buildx
+        if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
 
       - name: Login to ghcr.io
         id: login
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
           registry: ghcr.io
@@ -65,6 +87,7 @@ jobs:
 
       - name: Build and push image
         id: build
+        if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub workflow for building Hadoop image in CI currently re-builds the image if the same commit is pushed to a different branch.  It should re-use existing image and only apply new tag.

Example: when creating new Hadoop version's image (e.g. Hadoop 3.4.3), the base branch needs to be created first with the latest commit of the previous version's branch.  PR would be opened against the new branch.

https://issues.apache.org/jira/browse/HADOOP-19828

## How was this patch tested?

1. Pushed to branch [HADOOP-19828](https://github.com/adoroszlai/hadoop/commits/HADOOP-19828) in my fork, workflow [built](https://github.com/adoroszlai/hadoop/actions/runs/22569984131/job/65375100990) the [image](https://github.com/adoroszlai/hadoop/pkgs/container/hadoop/712506322?tag=ec3742530801f18503107bce6b319325c206eb33).
2. Pushed to branch [HADOOP-19828-test](https://github.com/adoroszlai/hadoop/commits/HADOOP-19828-test), workflow [skipped build](https://github.com/adoroszlai/hadoop/actions/runs/22570278821/job/65376103203) after finding existing image.
3. Pushed to branch [docker-hadoop-HADOOP-19828](https://github.com/adoroszlai/hadoop/commits/docker-hadoop-HADOOP-19828), workflow [skipped build](https://github.com/adoroszlai/hadoop/actions/runs/22570309332/job/65376204875) and [published](https://github.com/adoroszlai/hadoop/actions/runs/22570309332/job/65376250087#step:5:49) the image with new tag [HADOOP-19828](https://github.com/adoroszlai/hadoop/pkgs/container/hadoop/712506322?tag=HADOOP-19828).

(Adapted from Ozone's [Docker image workflow](https://github.com/apache/ozone-docker/tree/latest/.github/workflows).)