### PR TITLE
HADOOP-19829. Bump lz4-java 1.10.4

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -211,7 +211,7 @@ to be inclusive of all which may be included:
 
 hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/nvd3-1.8.5.* (css and js files)
 
-at.yawk.lz4:lz4-java:1.10.2
+at.yawk.lz4:lz4-java:1.10.4
 ch.qos.reload4j:reload4j:1.2.22
 com.aliyun:aliyun-java-core:0.2.11-beta
 com.aliyun:aliyun-java-sdk-core:4.5.10

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -154,7 +154,7 @@
     <metrics.version>3.2.4</metrics.version>
     <netty4.version>4.1.127.Final</netty4.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>
-    <lz4-java.version>1.10.2</lz4-java.version>
+    <lz4-java.version>1.10.4</lz4-java.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
 
     <!-- Maven protoc compiler -->


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19747 switched lz4-java to `at.yawk.lz4` group for security reason, but it unintentionally introduced performance regression.

https://github.com/yawkat/lz4-java/releases/tag/v1.10.4

> These changes attempt to fix the native performance regression in 1.9+. They should have no functional or security impact.

### How was this patch tested?

See the benchmark reports in Celeborn and Spark projects

- CELEBORN-2218 / https://github.com/apache/celeborn/pull/3555
- SPARK-55803 / https://github.com/apache/spark/pull/54585

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19829)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.