### PR TITLE
HDFS-17889: [ARR] Enable the router asynchronous RPC feature to handle getHAServiceState

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncClientProtocol.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hadoop.ha.HAServiceProtocol;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -1191,6 +1192,12 @@ public class RouterAsyncClientProtocol extends RouterClientProtocol {
     rpcServer.checkOperation(NameNode.OperationCategory.WRITE, true);
     getSecurityManager().cancelDelegationToken(token);
     asyncComplete(null);
+  }
+
+  @Override
+  public HAServiceProtocol.HAServiceState getHAServiceState() {
+    asyncComplete(super.getHAServiceState());
+    return asyncReturn(HAServiceProtocol.HAServiceState.class);
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpc.java
@@ -28,8 +28,18 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.apache.hadoop.fs.BatchedRemoteIterator.BatchedEntries;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.protocol.ClientProtocol;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.OpenFilesIterator;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
+import org.apache.hadoop.ipc.RemoteException;
+import java.lang.reflect.Method;
+import java.util.EnumSet;
 
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
@@ -38,6 +48,7 @@ import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncU
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Testing the asynchronous RPC functionality of the router.
@@ -97,5 +108,11 @@ public class TestRouterAsyncRpc extends TestRouterRpc {
     assertDoesNotThrow(() -> {
       rndRouter.getFileSystem().getDelegationToken(ugi.getShortUserName());
     });
+  }
+
+  @Test
+  public void testProxyGetHAServiceStateAsync() throws Exception {
+    HAServiceState state = getRouterProtocol().getHAServiceState();
+    assertNotNull(state);
   }
 }


### PR DESCRIPTION
JIRA: [HDFS-17889](https://issues.apache.org/jira/browse/HDFS-17889)

### Description of PR
When I tried to run getHAServiceState against a router RPC endpoint, I got an error that says return value is null. My proposed fix addresses this issue by implementing the function in RouterAsyncClientProtocol.java

---
Client code:
<img width="1186" height="1060" alt="image-2026-03-11-10-37-25-298" src="https://github.com/user-attachments/assets/147fe4f1-27a0-4c9d-a5de-2ba423419c4a" />

Error:
<img width="1570" height="676" alt="image-2026-03-11-10-39-49-796" src="https://github.com/user-attachments/assets/205f2398-aee0-4d3e-a595-b7cf927bb94c" />


### How was this patch tested?
```
mvn -pl hadoop-hdfs-project -Dtest="org.apache.hadoop.hdfs.server.federation.router.async.TestRouterAsyncRpc" test
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html