### PR TITLE
MAPREDUCE-7535. Setting the JSON provider to the customized one for M…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/jsonprovider/JsonProviderFeature.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/jsonprovider/JsonProviderFeature.java
@@ -28,6 +28,7 @@ public class JsonProviderFeature implements Feature {
   public boolean configure(FeatureContext context) {
     //Auto discovery should be disabled to ensure the custom providers will be used
     context.property(CommonProperties.MOXY_JSON_FEATURE_DISABLE, true);
+    context.property("jersey.config.jsonFeature", "JsonProviderFeature");
     context.register(IncludeRootJSONProvider.class, 2001);
     context.register(ExcludeRootJSONProvider.class, 2002);
     return true;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/jsonprovider/JsonProviderFeature.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/jsonprovider/JsonProviderFeature.java
@@ -22,13 +22,14 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
 import org.glassfish.jersey.CommonProperties;
+import org.glassfish.jersey.internal.InternalProperties;
 
 public class JsonProviderFeature implements Feature {
   @Override
   public boolean configure(FeatureContext context) {
     //Auto discovery should be disabled to ensure the custom providers will be used
     context.property(CommonProperties.MOXY_JSON_FEATURE_DISABLE, true);
-    context.property("jersey.config.jsonFeature", "JsonProviderFeature");
+    context.property(InternalProperties.JSON_FEATURE, "JsonProviderFeature");
     context.register(IncludeRootJSONProvider.class, 2001);
     context.register(ExcludeRootJSONProvider.class, 2002);
     return true;


### PR DESCRIPTION
…R webapp

Change-Id: I69d33a9d498e65504d805c6c2b9bdcc646c372c0

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
After a customized Moxy JSON provider has been introduced in the MR AM Webapp in [MAPREDUCE-7530](https://issues.apache.org/jira/browse/MAPREDUCE-7530) we need to set "jersey.config.jsonFeature" property to the customized JsonProviderFeature to prevent automatic discovery of legacy providers like EntityFilteringFeature.

As I could see the jersey-provided moxy in jersey media module also has this configuration, but we are using native moxy in Hadoop, so it is necessary to configure this setting explicitly

### How was this patch tested?
Tested MR jobs on a Hadoop cluster

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html