### PR TITLE
YARN-11938. Integrate Scheduler UI to UI2

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterInfo.java
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.service.Service.STATE;
 import org.apache.hadoop.util.VersionInfo;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.util.YarnVersionInfo;
 
@@ -45,6 +46,7 @@ public class ClusterInfo {
   protected String haZooKeeperConnectionState;
 
   private String subClusterId;
+  private boolean schedulerUiEnabled;
 
   public ClusterInfo() {
   } // JAXB needs this
@@ -66,6 +68,10 @@ public class ClusterInfo {
     this.hadoopVersionBuiltOn = VersionInfo.getDate();
     this.haZooKeeperConnectionState =
         rm.getRMContext().getHAZookeeperConnectionState();
+    this.schedulerUiEnabled = rm.getConfig().getBoolean(
+        YarnConfiguration.YARN_WEBAPP_SCHEDULER_UI_ENABLE,
+        YarnConfiguration.DEFAULT_YARN_WEBAPP_SCHEDULER_UI_ENABLE
+    );
   }
 
   public String getState() {
@@ -122,5 +128,13 @@ public class ClusterInfo {
 
   public void setSubClusterId(String subClusterId) {
     this.subClusterId = subClusterId;
+  }
+
+  public boolean isSchedulerUiEnabled() {
+    return schedulerUiEnabled;
+  }
+
+  public void setSchedulerUiEnabled(boolean schedulerUiEnabled) {
+    this.schedulerUiEnabled = schedulerUiEnabled;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -345,7 +345,7 @@ public class TestRMWebServices extends JerseyTestBase {
       Exception {
     assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject info = json.getJSONObject("clusterInfo");
-    assertEquals(12, info.length(), "incorrect number of elements");
+    assertEquals(13, info.length(), "incorrect number of elements");
     verifyClusterGeneric(info.getLong("id"), info.getLong("startedOn"),
         info.getString("state"), info.getString("haState"),
         info.getString("haZooKeeperConnectionState"),
@@ -354,7 +354,6 @@ public class TestRMWebServices extends JerseyTestBase {
         info.getString("resourceManagerVersionBuiltOn"),
         info.getString("resourceManagerBuildVersion"),
         info.getString("resourceManagerVersion"));
-
   }
 
   public void verifyClusterGeneric(long clusterid, long startedon,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/controllers/application.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/controllers/application.js
@@ -79,5 +79,12 @@ export default Ember.Controller.extend({
       return this.model.timelineHealth.get('isTimelineUnHealthy');
     }
     return true;
-  }.property('model.timelineHealth')
+  }.property('model.timelineHealth'),
+
+  isSchedulerUiEnabled: function() {
+    if (this.model && this.model.clusterInfo) {
+      return this.model.clusterInfo.get('firstObject').get('schedulerUiEnabled');
+    }
+    return false;
+  }.property('model.isSchedulerUiEnabled')
 });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/cluster-info.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/cluster-info.js
@@ -30,5 +30,6 @@ export default DS.Model.extend({
   hadoopVersionBuiltOn: DS.attr('string'),
   getYARNBuildHash: function() {
 	return this.get("hadoopVersion") + " from " +  this.get("resourceManagerBuildVersion").split(" ")[2];
-  }.property("yarnHash")
+  }.property("yarnHash"),
+  schedulerUiEnabled: DS.attr('string')
 });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/application.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/application.hbs
@@ -71,6 +71,9 @@
               <span class="sr-only">(current)</span>
             {{/link-to}}
           {{/link-to}}
+          {{#if isSchedulerUiEnabled}}
+            <li><a href="/scheduler-ui" class="navigation-link ember-view">Scheduler UI</a></li>
+          {{/if}}
         </ul>
         {{#if userInfo}}
         <div class="loggedin-user">


### PR DESCRIPTION
### Description of PR

<img width="1094" height="191" alt="image" src="https://github.com/user-attachments/assets/d60c8ea6-acc7-48b1-8498-bcb11209d308" />
A link should be visible in UI2 nav bar to Scheduler UI, if Scheduler UI enabled.

### How was this patch tested?

Deployed to a cluster and turn on the scheduler ui.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html