### PR TITLE
HADOOP-19825. Create docker image for Hadoop 3.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 FROM ghcr.io/apache/hadoop-runner:jdk11-u2204
-ARG HADOOP_VERSION=3.4.2
-ARG HADOOP_FLAVOR=-lean
+ARG HADOOP_VERSION=3.4.3
 ARG BASE_URL=https://dlcdn.apache.org/hadoop/common
 ARG TARGETPLATFORM
 WORKDIR /opt/hadoop
@@ -26,7 +25,7 @@ RUN set -eux; \
         linux/arm64) HADOOP_ARCH='-aarch64' ;; \
         *) echo "Unsupported platform: ${TARGETPLATFORM}"; exit 1 ;; \
     esac; \
-    export HADOOP_URL="${BASE_URL}/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}${HADOOP_ARCH}${HADOOP_FLAVOR}.tar.gz"; \
+    export HADOOP_URL="${BASE_URL}/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}${HADOOP_ARCH}.tar.gz"; \
     curl -LSs "$HADOOP_URL" | tar -x -z --strip-components 1 && rm -rf /opt/hadoop/share/doc
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create Docker image for Hadoop 3.4.3.  Remove `HADOOP_FLAVOR` parameter, since this version is released only without AWS SDK jars, no special `lean` version exists.

https://issues.apache.org/jira/browse/HADOOP-19825

## How was this patch tested?

CI build in fork: https://github.com/adoroszlai/hadoop/actions/runs/22800826284

```bash
$ docker run -it --rm ghcr.io/adoroszlai/hadoop:78d97d7423c5abb3da83ff1a7260de6fcdee1c44 hadoop version
Hadoop 3.4.3
Source code repository https://github.com/apache/hadoop.git -r 9d50c6884666e794e45102260a4017bb31802e1b
Compiled by stevel on 2026-02-13T14:23Z
Compiled on platform linux-x86_64
Compiled with protoc 3.23.4
From source with checksum 2331238c4c2929e66645316a32a8613
This command was run using /opt/hadoop/share/hadoop/common/hadoop-common-3.4.3.jar
```