### PR TITLE
HADOOP-19833. Add regression test for fs.s3a.classloader.isolation=false behavior.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -663,7 +663,17 @@ public final class S3AUtils {
     try {
       ClassLoader classLoader;
       if (conf != null) {
-        classLoader = conf.getClassLoader();
+        if (conf.getBoolean(AWS_S3_CLASSLOADER_ISOLATION,
+            DEFAULT_AWS_S3_CLASSLOADER_ISOLATION)) {
+          classLoader = conf.getClassLoader();
+        } else {
+          ClassLoader confLoader = conf.getClassLoader();
+          classLoader = (confLoader != null) ? confLoader
+              : Thread.currentThread().getContextClassLoader();
+        }
+        if (classLoader == null) {
+          classLoader = S3AUtils.class.getClassLoader();
+        }
         LOG.debug("Loading class {} with Configuration classloader {}",
               className, classLoader);
       } else {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -663,17 +663,7 @@ public final class S3AUtils {
     try {
       ClassLoader classLoader;
       if (conf != null) {
-        if (conf.getBoolean(AWS_S3_CLASSLOADER_ISOLATION,
-            DEFAULT_AWS_S3_CLASSLOADER_ISOLATION)) {
-          classLoader = conf.getClassLoader();
-        } else {
-          ClassLoader confLoader = conf.getClassLoader();
-          classLoader = (confLoader != null) ? confLoader
-              : Thread.currentThread().getContextClassLoader();
-        }
-        if (classLoader == null) {
-          classLoader = S3AUtils.class.getClassLoader();
-        }
+        classLoader = conf.getClassLoader();
         LOG.debug("Loading class {} with Configuration classloader {}",
               className, classLoader);
       } else {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
@@ -217,13 +217,17 @@ public class ITestS3AFileSystemIsolatedClassloader extends AbstractS3ATestBase {
     Map<String, String> confToSet =
         mapOf(Constants.AWS_S3_CLASSLOADER_ISOLATION, "false");
     assertInNewFilesystem(confToSet, (fs) -> {
-      Configuration conf = fs.getConf();
-      AwsCredentialsProvider provider = S3AUtils.getInstanceFromReflection(
-          customClassName, conf, null, AwsCredentialsProvider.class, "create",
-          Constants.AWS_CREDENTIALS_PROVIDER);
-      Assertions.assertThat(provider)
-          .describedAs("getInstanceFromReflection with isolation=false")
-          .isInstanceOf(CustomCredentialsProvider.class);
+      try {
+        Configuration conf = fs.getConf();
+        AwsCredentialsProvider provider = S3AUtils.getInstanceFromReflection(
+            customClassName, conf, null, AwsCredentialsProvider.class, "create",
+            Constants.AWS_CREDENTIALS_PROVIDER);
+        Assertions.assertThat(provider)
+            .describedAs("getInstanceFromReflection with isolation=false")
+            .isInstanceOf(CustomCredentialsProvider.class);
+      } catch (IOException e) {
+        throw new AssertionError("getInstanceFromReflection threw", e);
+      }
     });
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
@@ -205,4 +205,25 @@ public class ITestS3AFileSystemIsolatedClassloader extends AbstractS3ATestBase {
               .isInstanceOf(CustomCredentialsProvider.class);
     });
   }
+
+  /**
+   * HADOOP-19833: When isolation=false, getInstanceFromReflection must use
+   * the context classloader (or conf's classloader) so that classes from the
+   * application classpath can be loaded. This test calls getInstanceFromReflection
+   * directly with isolation=false and verifies the custom class is instantiated.
+   */
+  @Test
+  public void testGetInstanceFromReflectionWithIsolationFalse() throws Exception {
+    Map<String, String> confToSet =
+        mapOf(Constants.AWS_S3_CLASSLOADER_ISOLATION, "false");
+    assertInNewFilesystem(confToSet, (fs) -> {
+      Configuration conf = fs.getConf();
+      AwsCredentialsProvider provider = S3AUtils.getInstanceFromReflection(
+          customClassName, conf, null, AwsCredentialsProvider.class, "create",
+          Constants.AWS_CREDENTIALS_PROVIDER);
+      Assertions.assertThat(provider)
+          .describedAs("getInstanceFromReflection with isolation=false")
+          .isInstanceOf(CustomCredentialsProvider.class);
+    });
+  }
 }


### PR DESCRIPTION
### Problem

The current branch no longer changes production logic. It only adds regression coverage around the behavior expected for fs.s3a.classloader.isolation=false.

### Change

This PR is test-only.

It adds coverage in ITestS3AFileSystemIsolatedClassloader for the isolation=false path by calling getInstanceFromReflection directly and verifying that a custom credentials provider can be instantiated when the Configuration or application classloader supplies the class.

No production code changes are included in this branch.

### Validation

The latest successful Yetus run for this branch passed compile, shadedclient, spotbugs, javadocs, and the hadoop-aws unit test suite.

### JIRA

This PR should be read as regression coverage related to HADOOP-19833, not as a standalone production fix in itself.