### PR TITLE
HADOOP-19826. Add contract test to verify renaming empty dir works.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -147,6 +147,22 @@ public abstract class AbstractContractRenameTest extends
   }
 
   @Test
+  public void testRenameEmptyDir() throws Throwable {
+    describe("Verify renaming an empty directory to a new path works");
+    FileSystem fs = getFileSystem();
+    Path emptySrc = path("testRenameEmptyDir/src");
+    Path emptyDest = path("testRenameEmptyDir/dest");
+    mkdirs(emptySrc.getParent());
+    fs.mkdirs(emptySrc);
+    assertIsDirectory(emptySrc);
+    boolean renamed = rename(emptySrc, emptyDest);
+    assertTrue(renamed, "rename(emptyDir, newPath) should return true");
+    assertIsDirectory(emptyDest);
+    assertPathDoesNotExist("source empty dir should not exist after rename",
+        emptySrc);
+  }
+
+  @Test
   public void testRenameDirIntoExistingDir() throws Throwable {
     describe("Verify renaming a dir into an existing dir puts it"
         + " underneath"


### PR DESCRIPTION
## HADOOP-19826. Add contract test to verify renaming empty dir works

### Summary

Adds a contract test `testRenameEmptyDir` in `AbstractContractRenameTest` that verifies filesystems correctly support renaming an empty directory to a new path: create an empty directory, rename it to a new path, assert rename returns true and the directory exists at the destination and no longer at the source.

### Change

- **File:** `hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java`
- New test method `testRenameEmptyDir()`: creates an empty dir under `testRenameEmptyDir/src`, renames it to `testRenameEmptyDir/dest`, asserts `rename()` returns true, destination is a directory, and source path does not exist.

### JIRA

Fixes HADOOP-19826
