### PR TITLE
HADOOP-19801. Allow skipping recursive deletes for non-empty S3A directories.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1777,6 +1777,20 @@ public final class Constants {
    */
   public static final boolean DIRECTORY_OPERATIONS_PURGE_UPLOADS_DEFAULT = false;
 
+  /**
+   * When true, recursive deletion of a non-empty directory uses a single delete
+   * request for the directory key (prefix) instead of listing and deleting contained
+   * objects first. Only enable this for S3-compatible endpoints that support
+   * deleting non-empty directories (path prefix) in one request (e.g. VAST).
+   * Value: {@value}.
+   */
+  public static final String DELETE_NON_EMPTY_DIRECTORY_ENABLED =
+      "fs.s3a.delete.non-empty-directory.enabled";
+
+  /**
+   * Default value of {@link #DELETE_NON_EMPTY_DIRECTORY_ENABLED}: {@value}.
+   */
+  public static final boolean DELETE_NON_EMPTY_DIRECTORY_ENABLED_DEFAULT = false;
 
   /**
    * Is the higher performance copy from local file to S3 enabled?

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -411,6 +411,12 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   private boolean dirOperationsPurgeUploads;
 
   /**
+   * When true, recursive deletion of a non-empty directory uses a single delete
+   * request for the directory key (for S3-compatible endpoints that support it).
+   */
+  private boolean deleteNonEmptyDirectoryEnabled;
+
+  /**
    * Page size for deletions.
    */
   private int pageSize;
@@ -686,6 +692,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       // should the delete also purge uploads?
       dirOperationsPurgeUploads = conf.getBoolean(DIRECTORY_OPERATIONS_PURGE_UPLOADS,
           DIRECTORY_OPERATIONS_PURGE_UPLOADS_DEFAULT);
+
+      deleteNonEmptyDirectoryEnabled = conf.getBoolean(DELETE_NON_EMPTY_DIRECTORY_ENABLED,
+          DELETE_NON_EMPTY_DIRECTORY_ENABLED_DEFAULT);
 
       this.isMultipartUploadEnabled = conf.getBoolean(MULTIPART_UPLOADS_ENABLED,
           DEFAULT_MULTIPART_UPLOAD_ENABLED);
@@ -2616,7 +2625,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         throws IOException {
       auditSpan.activate();
       once("delete", path.toString(), () ->
-          S3AFileSystem.this.deleteObjectAtPath(path, key, isFile));
+          S3AFileSystem.this.deleteObjectAtPath(
+              path, key, isFile));
     }
 
     @Override
@@ -3223,7 +3233,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     } else {
       instrumentation.directoryDeleted();
     }
-    deleteObject(key);
+    incrementWriteOperations();
+    getStore().deleteObject(getRequestFactory()
+        .newDeleteObjectRequestBuilder(key)
+        .build());
   }
 
   /**
@@ -3576,7 +3589,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
               recursive,
               new OperationCallbacksImpl(storeContext),
               pageSize,
-              dirOperationsPurgeUploads));
+              dirOperationsPurgeUploads,
+              deleteNonEmptyDirectoryEnabled));
       if (outcome) {
         try {
           maybeCreateFakeParentDirectory(path);
@@ -5411,6 +5425,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       // Do directory operations purge uploads.
     case DIRECTORY_OPERATIONS_PURGE_UPLOADS:
       return dirOperationsPurgeUploads;
+
+    case DELETE_NON_EMPTY_DIRECTORY_ENABLED:
+      return deleteNonEmptyDirectoryEnabled;
 
       // this is a v2 sdk release.
     case STORE_CAPABILITY_AWS_V2:

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DeleteOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DeleteOperation.java
@@ -50,7 +50,17 @@ import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.submit;
 
 /**
  * Implementation of the delete() operation.
- * This issues only one bulk delete at a time,
+ * A non-empty directory, as well as a directory where its emptiness
+ * is unknown, is deleted by listing all contained files (or objects
+ * with matching key prefix), then deleting those files (objects) in
+ * bulk delete requests, and finally deleting the (then) empty
+ * directory itself.
+ * <p>
+ * When "fs.s3a.delete.non-empty-directory.enabled" is true, only
+ * one delete request is sent for the directory (key prefix). The
+ * S3 endpoint has to support this feature.
+ * <p>
+ * Bulk deletes are issued only one at a time,
  * intending to update S3Guard after every request succeeded.
  * Now that S3Guard has been removed, it
  * would be possible to issue multiple delete calls
@@ -118,6 +128,12 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
   private final boolean dirOperationsPurgeUploads;
 
   /**
+   * When true, non-empty directories are deleted with a single request
+   * (for S3-compatible endpoints that support it).
+   */
+  private final boolean deleteNonEmptyDirectoryEnabled;
+
+  /**
    * Count of uploads aborted.
    */
   private Optional<Long> uploadsAborted = Optional.empty();
@@ -130,13 +146,15 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
    * @param callbacks callback provider
    * @param pageSize size of delete pages
    * @param dirOperationsPurgeUploads Do directory operations purge pending uploads?
+   * @param deleteNonEmptyDirectoryEnabled use single delete for non-empty dirs when supported
    */
   public DeleteOperation(final StoreContext context,
       final S3AFileStatus status,
       final boolean recursive,
       final OperationCallbacks callbacks,
       final int pageSize,
-      final boolean dirOperationsPurgeUploads) {
+      final boolean dirOperationsPurgeUploads,
+      final boolean deleteNonEmptyDirectoryEnabled) {
 
     super(context);
     this.status = status;
@@ -149,6 +167,7 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
     executor = MoreExecutors.listeningDecorator(
         context.createThrottledExecutor(1));
     this.dirOperationsPurgeUploads = dirOperationsPurgeUploads;
+    this.deleteNonEmptyDirectoryEnabled = deleteNonEmptyDirectoryEnabled;
   }
 
   public long getFilesDeleted() {
@@ -166,6 +185,16 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
 
   /**
    * Delete a file or directory tree.
+   * <p>
+   * A non-empty directory, as well as a directory where its emptiness
+   * is unknown, is deleted by listing all contained files (or objects
+   * with matching key prefix), then deleting those files (objects) in
+   * bulk delete requests, and finally deleting the (then) empty
+   * directory itself.
+   * <p>
+   * When "fs.s3a.delete.non-empty-directory.enabled" is true, only
+   * one delete request is sent for the directory (key prefix). The
+   * S3 endpoint has to support this feature.
    * <p>
    * This call does not create any fake parent directory; that is
    * left to the caller.
@@ -223,6 +252,10 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
       }
       if (status.isEmptyDirectory() == Tristate.TRUE) {
         LOG.debug("deleting empty directory {}", path);
+        deleteObjectAtPath(path, key, false);
+      } else if (deleteNonEmptyDirectoryEnabled) {
+        LOG.debug("deleting non-empty directory {} with single request "
+            + "(endpoint supports it)", path);
         deleteObjectAtPath(path, key, false);
       } else {
         deleteDirectoryTree(path, key);
@@ -331,7 +364,8 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
    */
   private void queueForDeletion(final String key,
       boolean isDirMarker) throws IOException {
-    LOG.debug("Adding object to delete: \"{}\"", key);
+    LOG.debug("Adding {} to delete: \"{}\"",
+        isDirMarker ? "dir marker" : "file", key);
     keys.add(new DeleteEntry(key, isDirMarker));
     if (keys.size() == pageSize) {
       submitNextBatch();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DeleteOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DeleteOperation.java
@@ -145,8 +145,10 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
    * @param recursive recursive delete?
    * @param callbacks callback provider
    * @param pageSize size of delete pages
-   * @param dirOperationsPurgeUploads Do directory operations purge pending uploads?
-   * @param deleteNonEmptyDirectoryEnabled use single delete for non-empty dirs when supported
+   * @param dirOperationsPurgeUploads Do directory operations purge pending
+   *        uploads?
+   * @param deleteNonEmptyDirectoryEnabled use single delete for non-empty dirs
+   *        when supported
    */
   public DeleteOperation(final StoreContext context,
       final S3AFileStatus status,
@@ -327,8 +329,8 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
       maybeAwaitCompletion(deleteFuture);
       uploadsAborted = waitForCompletionIgnoringExceptions(abortUploads);
     }
-    LOG.debug("Delete \"{}\" completed; deleted {} objects and aborted {} uploads", path,
-        filesDeleted, uploadsAborted.orElse(0L));
+    LOG.debug("Delete \"{}\" completed; deleted {} objects and aborted {} uploads",
+        path, filesDeleted, uploadsAborted.orElse(0L));
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.fs.Options.CreateFileOptionKeys.FS_OPTION_CREATE
 import static org.apache.hadoop.fs.Options.CreateFileOptionKeys.FS_OPTION_CREATE_IN_CLOSE;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_STANDARD_OPTIONS;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_ENABLED;
+import static org.apache.hadoop.fs.s3a.Constants.DELETE_NON_EMPTY_DIRECTORY_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_OPERATIONS_PURGE_UPLOADS;
 import static org.apache.hadoop.fs.s3a.Constants.ENABLE_MULTI_DELETE;
 import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
@@ -298,6 +299,7 @@ public final class InternalConstants {
           STORE_CAPABILITY_MULTIPART_UPLOAD_ENABLED,
           STORE_CAPABILITY_S3_EXPRESS_STORAGE,
           FS_S3A_CREATE_PERFORMANCE_ENABLED,
+          DELETE_NON_EMPTY_DIRECTORY_ENABLED,
           DIRECTORY_OPERATIONS_PURGE_UPLOADS,
           ENABLE_MULTI_DELETE));
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -162,9 +162,9 @@ the directory path, and returning them as the listing.
 1. When renaming a directory, taking such a listing and asking S3 to copying the
 individual objects to new objects with the destination filenames.
 1. When deleting a directory, taking such a listing and deleting the entries in
-batches.
-1. When renaming or deleting directories, taking such a listing and working
-on the individual files.
+batches. Some S3-compatible endpoints support deleting non-empty directories
+with a single request. See [How S3A deletes directories](#delete) for details.
+1. When renaming, taking such a listing and working on the individual files.
 
 
 Here are some of the consequences:
@@ -568,9 +568,19 @@ Here are some the S3A properties for use in production.
 <property>
   <name>fs.s3a.multiobjectdelete.enable</name>
   <value>true</value>
-  <description>When enabled, multiple single-object delete requests are replaced by
+  <description>When true, multiple single-object delete requests are replaced by
     a single 'delete multiple objects'-request, reducing the number of requests.
     Beware: legacy S3-compatible object stores might not support this request.
+  </description>
+</property>
+
+<property>
+  <name>fs.s3a.delete.non-empty-directory.enabled</name>
+  <value>false</value>
+  <description>When true, recursive deletion of a non-empty directory uses a single delete
+    request for the directory key (prefix) instead of listing and deleting contained
+    objects first. Only enable this for S3-compatible endpoints that support
+    deleting non-empty directories (path prefix) in one request.
   </description>
 </property>
 
@@ -1712,6 +1722,21 @@ rate.
 
 The best practise for using this option is to disable multipart purges in
 normal use of S3A, enabling only in manual/scheduled housekeeping operations.
+
+## <a name="delete"></a>How S3A deletes directories
+
+The S3A client deletes directories (prefixes) by listing all contained files (objects with
+matching prefix), then deleting those files (objects) in bulk delete requests, and finally
+deleting the (then) empty directory itself. The time taken for this deletion is proportional
+to the number of files (objects) in the directory.
+
+When `fs.s3a.delete.non-empty-directory.enabled=true`, only one delete request is sent for
+the directory (prefix). The S3 endpoint has to support this feature. Depending on the
+S3 endpoint implementation of this feature, deletes might be synchronous or
+asynchronous.
+
+The [VAST S3 endpoint](https://kb.vastdata.com/documentation/docs/using-trash-folder-for-s3-objects-6)
+supports such deletes.
 
 ## <a name="metrics"></a>Metrics
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADeleteNonEmptyDirectoryCapability.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADeleteNonEmptyDirectoryCapability.java
@@ -53,7 +53,8 @@ public class ITestS3ADeleteNonEmptyDirectoryCapability extends
 
   /**
    * Test that when the option is enabled, the capability is true.
-   * Creates a new S3AFileSystem with the option set and verifies the capability.
+   * Creates a new S3AFileSystem with the option set and verifies the
+   * capability.
    */
   @Test
   public void testCapabilityWhenEnabled() throws Throwable {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADeleteNonEmptyDirectoryCapability.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADeleteNonEmptyDirectoryCapability.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hadoop.fs.s3a.Constants.DELETE_NON_EMPTY_DIRECTORY_ENABLED;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+
+/**
+ * Test that fs.s3a.delete.non-empty-directory.enabled is reflected in
+ * hasPathCapability(DELETE_NON_EMPTY_DIRECTORY_ENABLED). HADOOP-19801.
+ */
+@IntegrationTest
+public class ITestS3ADeleteNonEmptyDirectoryCapability extends
+    AbstractS3ATestBase {
+
+  /**
+   * Test that when the option is disabled (default), the capability is false.
+   */
+  @Test
+  public void testCapabilityDisabledByDefault() throws Throwable {
+    try (S3AFileSystem fs = createCapabilityTestFileSystem(false)) {
+      Assertions.assertThat(fs.hasPathCapability(new Path("/"),
+          DELETE_NON_EMPTY_DIRECTORY_ENABLED))
+          .describedAs("path capability when option not set")
+          .isFalse();
+    }
+  }
+
+  /**
+   * Test that when the option is enabled, the capability is true.
+   * Creates a new S3AFileSystem with the option set and verifies the capability.
+   */
+  @Test
+  public void testCapabilityWhenEnabled() throws Throwable {
+    try (S3AFileSystem fs = createCapabilityTestFileSystem(true)) {
+      Assertions.assertThat(fs.hasPathCapability(new Path("/"),
+          DELETE_NON_EMPTY_DIRECTORY_ENABLED))
+          .describedAs("path capability when option enabled")
+          .isTrue();
+    }
+  }
+
+  private S3AFileSystem createCapabilityTestFileSystem(
+      final boolean enabled) throws Exception {
+    Configuration conf = new Configuration(getFileSystem().getConf());
+    removeBaseAndBucketOverrides(getTestBucketName(conf), conf,
+        DELETE_NON_EMPTY_DIRECTORY_ENABLED);
+    disableFilesystemCaching(conf);
+    conf.setBoolean(DELETE_NON_EMPTY_DIRECTORY_ENABLED, enabled);
+    S3AFileSystem fs = new S3AFileSystem();
+    fs.initialize(getFileSystem().getUri(), conf);
+    return fs;
+  }
+}


### PR DESCRIPTION
### Summary

Adds `fs.s3a.delete.non-empty-directory.enabled` so S3A can use a single delete request for a non-empty directory key instead of recursively listing and deleting child objects first. This PR is now scoped only to that delete behavior for S3-compatible endpoints that support it.

### Change

- **Constants.java**: add `fs.s3a.delete.non-empty-directory.enabled` and its default.
- **InternalConstants.java**: expose the config through S3A path capability reporting.
- **S3AFileSystem.java**: read the config during initialization, thread it into delete handling, and surface it via `hasPathCapability()`.
- **DeleteOperation.java**: when the option is enabled, use a single delete request for non-empty directories instead of recursive object listing and bulk delete.
- **ITestS3ADeleteNonEmptyDirectoryCapability.java**: add a capability-focused integration test for the new behavior toggle.
- **index.md**: document the new option and keep the PR scoped to delete behavior only.

### Evidence it works

- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -Dmaven.repo.local=/tmp/codex-m2 test -pl hadoop-tools/hadoop-aws -am -Dtest=TestAwsClientConfig -DskipTests=false`
  - Passed locally on the rebased branch (`TestAwsClientConfig`, 9 tests, 0 failures).

### JIRA

Fixes HADOOP-19801

### For code changes:

- [x] The title starts with the corresponding JIRA issue ID.
- [ ] Object storage integration tests and endpoint declaration: Integration testing against a supporting endpoint remains outstanding.
- [x] No new dependencies are introduced.
- [x] No LICENSE or NOTICE updates are needed for this diff.

### AI Tooling

Contains content generated by Codex.

- [x] AI-generated content is disclosed.
- [x] Use follows https://www.apache.org/legal/generative-tooling.html.

### Current validation boundary (2026-09-19)

The earlier `TestAwsClientConfig` result above checks client configuration; it does not validate single-request directory deletion. No supporting endpoint and current deletion result have been established in this repair run. Real endpoint integration testing and endpoint disclosure remain required before claiming that behavior is validated.

### How was this patch tested?

Earlier commands above are historical evidence, where present. Current rebase validation passed `git diff --check`; fresh hosted CI is running. Focused Java validation is reported separately when complete.

### Remaining integration dependency

The documented VAST use case also needs the request-scoped header support split into #8417 at reviewer request. That PR is still open; this branch does not add the header itself. The April 10 review reported that enabling the deletion flag alone leaves directories behind, while a global header breaks non-delete requests. Preserve the agreed split and verify the combined configuration against a supporting endpoint before treating the VAST path as ready.

### Documentation follow-up (2026-09-19)

Head `04579ead` clarifies the VAST request-header prerequisite and warns against attaching a delete-only header globally. This is a documentation change after the rebase; `git diff --check` passes. Site rendering and endpoint integration were not run.
