### PR TITLE
HDFS-17824. Fix DataNode fails to start when dfs.datanode.directoryscan.threads set to 0 or negative value.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
@@ -313,6 +313,14 @@ public class DirectoryScanner implements Runnable {
         conf.getInt(DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_KEY,
             DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_DEFAULT);
 
+    if (threads <= 0) {
+      LOG.warn("Invalid value configured for "
+          + DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_KEY
+          + " ({}), must be greater than 0. Using default ({}).",
+          threads, DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_DEFAULT);
+      threads = DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_DEFAULT;
+    }
+
     reportCompileThreadPool =
         Executors.newFixedThreadPool(threads, new Daemon.DaemonFactory());
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -128,6 +128,34 @@ public class TestDirectoryScanner {
     LazyPersistTestCase.initCacheManipulator();
   }
 
+  /**
+   * HDFS-17824: When dfs.datanode.directoryscan.threads is 0 or negative,
+   * DirectoryScanner should use the default instead of throwing
+   * IllegalArgumentException from Executors.newFixedThreadPool(threads).
+   */
+  @Test
+  @Timeout(value = 30)
+  public void testInvalidDirectoryScanThreadsUsesDefault() throws Exception {
+    Configuration conf = getConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_KEY, 0);
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    try {
+      cluster.waitActive();
+      bpid = cluster.getNamesystem().getBlockPoolId();
+      fds = DataNodeTestUtils.getFSDataset(cluster.getDataNodes().get(0));
+      scanner = new DirectoryScanner(fds, conf);
+      scanner.start();
+      assertTrue(scanner.getRunStatus());
+    } finally {
+      if (scanner != null) {
+        scanner.shutdown();
+      }
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
   /** create a file with a length of <code>fileLen</code>. */
   private List<LocatedBlock> createFile(String fileNamePrefix, long fileLen,
       boolean isLazyPersist) throws IOException {


### PR DESCRIPTION
### Summary

When `dfs.datanode.directoryscan.threads` is set to 0 or a negative value, the DataNode throws `IllegalArgumentException` from `Executors.newFixedThreadPool(threads)` during DirectoryScanner initialization and fails to start. This change validates the config and uses the default (1) when the value is non-positive, with a warning log, so the DataNode starts and the operator sees a clear message.

### Change

- **DirectoryScanner**: After reading `dfs.datanode.directoryscan.threads`, if the value is ≤ 0, log a warning (parameter name, invalid value, default) and set threads to `DFS_DATANODE_DIRECTORYSCAN_THREADS_DEFAULT` (1) before creating the thread pool. Matches the existing pattern used for `reconcile.blocks.batch.size` and `reconcile.blocks.batch.interval` in the same class.
- **TestDirectoryScanner**: New test `testInvalidDirectoryScanThreadsUsesDefault()` — set `directoryscan.threads` to 0, build a minimal cluster, create and start DirectoryScanner; verifies no exception and scanner runs (HDFS-17824).

### JIRA

Fixes HDFS-17824
