### PR TITLE
HDFS-17179. DFSInputStream should report CorruptMetaHeaderException a…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -73,6 +73,7 @@ import org.apache.hadoop.hdfs.protocol.datatransfer.InvalidEncryptionKeyExceptio
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.hdfs.security.token.block.InvalidBlockTokenException;
 import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
+import org.apache.hadoop.hdfs.server.datanode.CorruptMetaHeaderException;
 import org.apache.hadoop.hdfs.server.datanode.ReplicaNotFoundException;
 import org.apache.hadoop.hdfs.shortcircuit.ClientMmap;
 import org.apache.hadoop.hdfs.util.IOUtilsClient;
@@ -804,6 +805,12 @@ public class DFSInputStream extends FSInputStream
         retryCurrentNode = false;
         // we want to remember which block replicas we have tried
         corruptedBlocks.addCorruptedBlock(getCurrentBlock(), currentNode);
+      } catch (CorruptMetaHeaderException cme) {
+        DFSClient.LOG.warn("Found corrupt block meta header for "
+            + getCurrentBlock() + " from " + currentNode + ": " + cme.getMessage());
+        ioe = cme;
+        retryCurrentNode = false;
+        corruptedBlocks.addCorruptedBlock(getCurrentBlock(), currentNode);
       } catch (IOException e) {
         String msg = String.format("Failed to read block %s for file %s from datanode %s. "
                 + "Exception is %s. Retry with the current or next available datanode.",
@@ -829,7 +836,17 @@ public class DFSInputStream extends FSInputStream
       } else {
         addToLocalDeadNodes(currentNode);
         dfsClient.addNodeToDeadNodeDetector(this, currentNode);
-        sourceFound = seekToNewSource(pos);
+        try {
+          sourceFound = seekToNewSource(pos);
+        } catch (IOException seekEx) {
+          // If the root cause was corrupt block metadata, surface that so
+          // callers see CorruptMetaHeaderException (HDFS-17179). Otherwise
+          // they would only see "No live nodes" from blockSeekTo.
+          if (isOrCausedByCorruptMetaHeader(ioe)) {
+            throw ioe;
+          }
+          throw seekEx;
+        }
       }
       if (!sourceFound) {
         throw ioe;
@@ -1163,6 +1180,20 @@ public class DFSInputStream extends FSInputStream
     return errMsgr.toString();
   }
 
+  /**
+   * Returns true if the given exception is or has a cause that is
+   * CorruptMetaHeaderException (e.g. when the only replica failed due to
+   * corrupt block metadata).
+   */
+  private static boolean isOrCausedByCorruptMetaHeader(Throwable t) {
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      if (cur instanceof CorruptMetaHeaderException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   protected void fetchBlockByteRange(LocatedBlock block, long start, long end, ByteBuffer buf,
       CorruptedBlocks corruptedBlocks, final Map<InetSocketAddress, List<IOException>> exceptionMap)
       throws IOException {
@@ -1255,6 +1286,14 @@ public class DFSInputStream extends FSInputStream
             + datanode.info;
         DFSClient.LOG.warn(msg);
         // we want to remember what we have tried
+        corruptedBlocks.addCorruptedBlock(block.getBlock(), datanode.info);
+        addToLocalDeadNodes(datanode.info);
+        throw new IOException(msg);
+      } catch (CorruptMetaHeaderException e) {
+        String msg = "fetchBlockByteRange(). Got corrupt meta header for "
+            + src + " at " + block.getBlock() + " from " + datanode.info + ": "
+            + e.getMessage();
+        DFSClient.LOG.warn(msg);
         corruptedBlocks.addCorruptedBlock(block.getBlock(), datanode.info);
         addToLocalDeadNodes(datanode.info);
         throw new IOException(msg);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCorruptMetadataFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCorruptMetadataFile.java
@@ -34,9 +34,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.RandomAccessFile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests to ensure that a block is not read successfully from a datanode
@@ -114,6 +116,56 @@ public class TestCorruptMetadataFile {
     }, 100, 5000);
 
     raFile.close();
+  }
+
+  /**
+   * HDFS-17179: When the client receives CorruptMetaHeaderException during
+   * a block read, it should report the block to the NameNode so the block
+   * is marked corrupt and can be re-replicated.
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testReportCorruptMetaHeaderToNameNode() throws Exception {
+    cluster = clusterBuilder.build();
+    cluster.waitActive();
+    FileSystem fs = cluster.getFileSystem();
+    Path filePath = new Path("testCorruptMetaReport.dat");
+    FSDataOutputStream out = fs.create(filePath, (short) 1);
+    out.write(1);
+    out.hflush();
+    out.close();
+
+    ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, filePath);
+    File metadataFile = cluster.getBlockMetadataFile(0, block);
+
+    // Corrupt meta file: 7 bytes invalid header so header parse throws
+    // CorruptMetaHeaderException when DN serves the block.
+    try (RandomAccessFile raFile = new RandomAccessFile(metadataFile, "rw")) {
+      raFile.setLength(0);
+      raFile.write("1234567".getBytes());
+    }
+
+    // Client read should get an IOException (CorruptMetaHeaderException, or
+    // "No live nodes" when the only replica was marked dead due to corrupt meta).
+    try (FSDataInputStream in = fs.open(filePath)) {
+      in.readByte();
+    } catch (IOException e) {
+      String msg = e.getMessage() != null ? e.getMessage() : "";
+      boolean expected = msg.contains("corrupt") || msg.contains("meta")
+          || msg.contains("No live nodes")
+          || e.getCause() instanceof CorruptMetaHeaderException;
+      assertTrue(expected,
+          "Expected IOException related to corrupt meta or no live nodes: " + e.getMessage());
+    }
+
+    // Block should be reported to NN and marked corrupt
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return cluster.getNameNode().getNamesystem()
+            .getBlockManager().getCorruptBlocks() == 1;
+      }
+    }, 100, 5000);
   }
 
   /**


### PR DESCRIPTION
### Summary

When a block read fails with `CorruptMetaHeaderException` (e.g. corrupt or too-short block meta file on the DataNode), DFSInputStream did not add the block to the corrupted set or report it to the NameNode, unlike `ChecksumException`. Corrupt blocks were therefore not invalidated or re-replicated. This change treats `CorruptMetaHeaderException` the same as `ChecksumException` in the client read path so the block is reported to the NameNode and can be re-replicated.

### Change

- **DFSInputStream**: Import `CorruptMetaHeaderException`. In `readBuffer()` (block read loop), add a `catch (CorruptMetaHeaderException)` that logs, adds the block to `corruptedBlocks`, and sets `retryCurrentNode = false`, mirroring the existing `ChecksumException` handling. In `actualGetFromOneDataNode()` (fetchBlockByteRange), add a `catch (CorruptMetaHeaderException)` that logs, adds the block to `corruptedBlocks`, marks the datanode dead, and throws an `IOException`, mirroring the `ChecksumException` handling.
- **TestCorruptMetadataFile**: Add `testReportCorruptMetaHeaderToNameNode()`: create a file, corrupt the block meta file with an invalid 7-byte header, read from the client (expect IOException), then wait until the NameNode’s corrupt block count is 1 (HDFS-17179).

### JIRA

Fixes HDFS-17179

### For code changes:

- [x] The title starts with the corresponding JIRA issue ID.
- [ ] Object storage integration tests and endpoint declaration: Not applicable: this PR does not change an object-store connector.
- [x] No new dependencies are introduced.
- [x] No LICENSE or NOTICE updates are needed for this diff.

### AI Tooling

Contains content generated by Codex.

- [x] AI-generated content is disclosed.
- [x] Use follows https://www.apache.org/legal/generative-tooling.html.

### How was this patch tested?

Earlier commands above are historical evidence, where present. Current rebase validation passed `git diff --check`; fresh hosted CI is running. Focused Java validation is reported separately when complete.

### Validated repair head `ea07181e` (2026-09-19)

`TestCorruptMetadataFile#testReportCorruptMetaHeaderToNameNode` passed: 1 test, 0 failures, 0 errors, 0 skipped. The selected reactor finished successfully in a Java 17/Maven 3.9.15 container with GNU stat and bounded memory (`MAVEN_OPTS=-Xmx1024m`, test heap 1536 MB).

`mvn -B -ntp -pl hadoop-hdfs-project/hadoop-hdfs -am -Dtest=TestCorruptMetadataFile#testReportCorruptMetaHeaderToNameNode -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false "-Dmaven-surefire-plugin.argLine=-Xmx1536m -Xss4m" test`
