### PR TITLE
HDFS-17813. NameCache promotes wrong object reference on threshold crossing

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
@@ -108,7 +108,7 @@ class NameCache<K> {
       if (useCount != null) {
         useCount.increment();
         if (useCount.get() >= useThreshold) {
-          promote(name);
+          promote(name, useCount);
         }
         return useCount.value;
       }
@@ -147,9 +147,9 @@ class NameCache<K> {
   }
   
   /** Promote a frequently used name to the cache */
-  private void promote(final K name) {
+  private void promote(final K name, final UseCount useCount) {
     transientMap.remove(name);
-    cache.put(name, name);
+    cache.put(name, useCount.value);
     lookups += useThreshold;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameCache.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.server.namenode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,36 @@ public class TestNameCache {
     for (String s : notMatching) {
       verifyNameReuse(cache, s, false);
     }
+  }
+
+  @Test
+  public void testPromotionPreservesObjectIdentity() throws Exception {
+    // Use a threshold of 2 so a name is promoted after two puts
+    NameCache<String> cache = new NameCache<>(2);
+
+    // Construct a String whose identity we can track — use new String() so it
+    // is never interned and is a distinct heap object.
+    String original = new String("testfile");
+
+    // First put: enters the transient map; useCount.value = original
+    String returned1 = cache.put(original);
+    // Not yet promoted; returns null on first insertion
+    assertNull(returned1);
+
+    // Second put with an equal-but-distinct String — this crosses the threshold
+    // and triggers promotion.  The returned value must be the original object.
+    String duplicate = new String("testfile");
+    String returned2 = cache.put(duplicate);
+    // put() returns useCount.value, which must be the original object
+    assertSame(original, returned2,
+        "put() after promotion must return the original cached object, not the caller's argument");
+
+    // After promotion the name is in the main cache.  A subsequent put()
+    // (even after initialized()) must also hand back the same reference.
+    cache.initialized();
+    String returned3 = cache.put(new String("testfile"));
+    assertSame(original, returned3,
+        "cache.get() after initialized() must return the original cached object");
   }
 
   private void verifyNameReuse(NameCache<String> cache, String s, boolean reused) {


### PR DESCRIPTION
## Problem

In `NameCache.put()`, when a name's use count crosses the promotion threshold, the cache was populated with the caller's `name` argument rather than the original `useCount.value` that was stored in the transient map:

```java
// Before (buggy)
cache.put(name, name);
```

This means after promotion the cache holds a different object reference than what was stored before promotion. Any caller that held a reference to the pre-promotion value now has a stale reference, and two distinct `String` objects exist for what should be a single cached identity — wasting memory and breaking reference equality.

## Fix

Pass `useCount` into the `promote()` helper and store `useCount.value` instead:

```java
// After
cache.put(name, useCount.value);
```

This preserves the original object reference across the promotion boundary.

## Testing

- Added `TestNameCache#testPromotionPreservesObjectIdentity`: creates a `NameCache` with threshold 2, inserts a non-interned `String`, triggers promotion, and uses `assertSame` to verify the returned reference is identical before and after promotion.
- Test passes locally.