### PR TITLE
HDFS-17805. Separate flushNanos and syncNanos in flushOrSync slow log

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -426,6 +426,7 @@ class BlockReceiver implements Closeable {
    */
   void flushOrSync(boolean isSync, long seqno) throws IOException {
     long flushTotalNanos = 0;
+    long syncTotalNanos = 0;
     long begin = Time.monotonicNow();
     DataNodeFaultInjector.get().delay();
     if (checksumOut != null) {
@@ -433,8 +434,11 @@ class BlockReceiver implements Closeable {
       checksumOut.flush();
       long flushEndNanos = System.nanoTime();
       if (isSync) {
+        long syncStartNanos = flushEndNanos;
         streams.syncChecksumOut();
-        datanode.metrics.addFsyncNanos(System.nanoTime() - flushEndNanos);
+        long syncEndNanos = System.nanoTime();
+        syncTotalNanos += syncEndNanos - syncStartNanos;
+        datanode.metrics.addFsyncNanos(syncEndNanos - syncStartNanos);
       }
       flushTotalNanos += flushEndNanos - flushStartNanos;
     }
@@ -445,7 +449,9 @@ class BlockReceiver implements Closeable {
       if (isSync) {
         long fsyncStartNanos = flushEndNanos;
         streams.syncDataOut();
-        datanode.metrics.addFsyncNanos(System.nanoTime() - fsyncStartNanos);
+        long fsyncEndNanos = System.nanoTime();
+        syncTotalNanos += fsyncEndNanos - fsyncStartNanos;
+        datanode.metrics.addFsyncNanos(fsyncEndNanos - fsyncStartNanos);
       }
       flushTotalNanos += flushEndNanos - flushStartNanos;
     }
@@ -463,8 +469,10 @@ class BlockReceiver implements Closeable {
     if (duration > datanodeSlowLogThresholdMs && LOG.isWarnEnabled()) {
       datanode.metrics.incrSlowFlushOrSyncCount();
       LOG.warn("Slow flushOrSync took " + duration + "ms (threshold="
-          + datanodeSlowLogThresholdMs + "ms), isSync:" + isSync + ", flushTotalNanos="
-          + flushTotalNanos + "ns, volume=" + getVolumeBaseUri()
+          + datanodeSlowLogThresholdMs + "ms), isSync:" + isSync
+          + ", flushNanos=" + flushTotalNanos + "ns"
+          + ", syncNanos=" + syncTotalNanos + "ns"
+          + ", volume=" + getVolumeBaseUri()
           + ", blockId=" + replicaInfo.getBlockId()
           + ", seqno=" + seqno);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverSlowLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverSlowLog.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests for the improved flushOrSync slow-log message (HDFS-17805).
+ *
+ * The fix separates the combined flushTotalNanos into distinct flushNanos and
+ * syncNanos fields in the WARN log, enabling operators to pinpoint whether
+ * latency originates from flush or sync operations.
+ */
+public class TestBlockReceiverSlowLog {
+
+  /**
+   * HDFS-17805: When flushOrSync exceeds the slow-IO threshold the WARN log
+   * must contain both {@code flushNanos=} and {@code syncNanos=} fields so
+   * that operators can distinguish flush latency from sync latency.
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testFlushOrSyncSlowLogContainsSeparateFlushAndSyncNanos()
+      throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    // Set threshold to 0 ms so every flushOrSync call triggers the WARN log.
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_SLOW_IO_WARNING_THRESHOLD_KEY, 0);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+      cluster.waitActive();
+
+      GenericTestUtils.LogCapturer logs =
+          GenericTestUtils.LogCapturer.captureLogs(BlockReceiver.LOG);
+
+      // Write data and hsync to trigger flushOrSync(isSync=true).
+      try (FSDataOutputStream out = cluster.getFileSystem()
+          .create(new Path("/test-slow-log.dat"))) {
+        out.write(new byte[1024]);
+        out.hsync();
+      }
+
+      String captured = logs.getOutput();
+
+      // The improved log must expose flush and sync timings separately.
+      assertTrue(captured.contains("flushNanos="),
+          "Slow flushOrSync log must contain 'flushNanos=' for flush timing. "
+              + "Got: " + captured);
+      assertTrue(captured.contains("syncNanos="),
+          "Slow flushOrSync log must contain 'syncNanos=' for sync timing. "
+              + "Got: " + captured);
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

In `BlockReceiver.flushOrSync()`, flush and sync durations are accumulated into a single `flushTotalNanos` counter. When the total duration exceeds the slow-IO threshold, the WARN log only reports the combined value:

```
Slow flushOrSync took 120ms ..., flushTotalNanos=120000000ns
```

This makes it impossible to tell whether the latency originates from the flush step or the fsync step, hindering production diagnosis.

## Fix

Track flush and sync durations in separate counters (`flushTotalNanos`, `syncTotalNanos`). The slow-IO WARN log now reports them independently:

```
Slow flushOrSync took 120ms ..., flushNanos=5000000ns, syncNanos=115000000ns
```

This lets operators immediately determine whether a bottleneck is in the page-cache flush or the disk fsync.

## Testing

- Added `TestBlockReceiverSlowLog#testFlushOrSyncSlowLogContainsSeparateFlushAndSyncNanos`: starts a single-DN MiniDFSCluster with slow-IO threshold set to 0 ms (triggers the log on every call), writes a file and calls `hsync()`, captures the WARN log output, and asserts both `flushNanos=` and `syncNanos=` are present.
- Test passes locally.