### PR TITLE
HDFS-17639. hasStorageType() allocates array unnecessarily on every call

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -310,11 +310,13 @@ public class DatanodeDescriptor extends DatanodeInfo {
   }
 
   public EnumSet<StorageType> getStorageTypes() {
-    EnumSet<StorageType> storageTypes = EnumSet.noneOf(StorageType.class);
-    for (DatanodeStorageInfo dsi : getStorageInfos()) {
-      storageTypes.add(dsi.getStorageType());
+    synchronized (storageMap) {
+      EnumSet<StorageType> storageTypes = EnumSet.noneOf(StorageType.class);
+      for (DatanodeStorageInfo dsi : storageMap.values()) {
+        storageTypes.add(dsi.getStorageType());
+      }
+      return storageTypes;
     }
-    return storageTypes;
   }
 
   public StorageReport[] getStorageReports() {
@@ -1136,9 +1138,16 @@ public class DatanodeDescriptor extends DatanodeInfo {
   }
 
   public boolean hasStorageType(StorageType type) {
-    for (DatanodeStorageInfo dnStorage : getStorageInfos()) {
-      if (dnStorage.getStorageType() == type) {
-        return true;
+    // Iterate storageMap.values() directly under the lock instead of calling
+    // getStorageInfos() which acquires the lock a second time and allocates a
+    // new array.  On clusters with many storages per DataNode this matters
+    // because hasStorageType() is called frequently (block placement, heartbeat
+    // processing, topology updates) — HDFS-17639.
+    synchronized (storageMap) {
+      for (DatanodeStorageInfo dnStorage : storageMap.values()) {
+        if (dnStorage.getStorageType() == type) {
+          return true;
+        }
       }
     }
     return false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeDescriptor.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo.AddBlockResult;
@@ -81,5 +83,49 @@ public class TestDatanodeDescriptor {
     // remove second block
     assertTrue(BlocksMap.removeBlock(dd, blk1));
     assertEquals(0, dd.numBlocks());
+  }
+
+  /**
+   * HDFS-17639: hasStorageType() previously called getStorageInfos() which
+   * acquired storageMap lock and allocated a new array on every call.  The fix
+   * iterates storageMap.values() directly under the lock.  This test verifies
+   * correctness: hasStorageType() and getStorageTypes() must accurately reflect
+   * which types are present after storages are injected.
+   */
+  @Test
+  public void testHasStorageTypeAndGetStorageTypes() {
+    DatanodeDescriptor dd = DFSTestUtil.getLocalDatanodeDescriptor();
+
+    // Before any storage is injected, no type should be present.
+    assertFalse(dd.hasStorageType(StorageType.DISK),
+        "No DISK storage expected before injection");
+    assertFalse(dd.hasStorageType(StorageType.SSD),
+        "No SSD storage expected before injection");
+    assertTrue(dd.getStorageTypes().isEmpty(),
+        "getStorageTypes() should be empty before injection");
+
+    // Inject a DISK storage.
+    DatanodeStorageInfo diskStorage = DFSTestUtil.createDatanodeStorageInfo(
+        "storage-disk", "127.0.0.1", "/rack1", "host1",
+        StorageType.DISK, null);
+    dd.injectStorage(diskStorage);
+
+    assertTrue(dd.hasStorageType(StorageType.DISK),
+        "DISK storage should be present after injection");
+    assertFalse(dd.hasStorageType(StorageType.SSD),
+        "SSD storage should still be absent");
+    EnumSet<StorageType> types = dd.getStorageTypes();
+    assertTrue(types.contains(StorageType.DISK));
+    assertEquals(1, types.size());
+
+    // Inject an SSD storage.
+    DatanodeStorageInfo ssdStorage = DFSTestUtil.createDatanodeStorageInfo(
+        "storage-ssd", "127.0.0.1", "/rack1", "host1",
+        StorageType.SSD, null);
+    dd.injectStorage(ssdStorage);
+
+    assertTrue(dd.hasStorageType(StorageType.DISK));
+    assertTrue(dd.hasStorageType(StorageType.SSD));
+    assertEquals(2, dd.getStorageTypes().size());
   }
 }


### PR DESCRIPTION
## Problem

`DatanodeDescriptor.hasStorageType()` delegates to `getStorageInfos()` which:
1. Acquires the `storageMap` lock
2. Copies all storage values into a new `DatanodeStorageInfo[]` array
3. Releases the lock
4. Returns the array

`hasStorageType()` then iterates the returned array. This means every call allocates a new array and acquires the lock twice (the second time is reentrant since callers like `injectStorage()` already hold the lock). The same pattern exists in `getStorageTypes()`.

On large clusters with many storages per DataNode, `hasStorageType()` is called frequently — during block placement, heartbeat processing, and topology updates — making this allocation and double-lock pattern a measurable source of lock contention and GC pressure.

## Fix

In both `hasStorageType()` and `getStorageTypes()`, iterate `storageMap.values()` directly under a single `synchronized (storageMap)` block, eliminating the array allocation entirely. Callers that already hold the lock (e.g. `injectStorage()`, `updateStorage()`) benefit from Java's reentrant semantics — a single lock acquisition instead of two.

## Testing

Added `TestDatanodeDescriptor#testHasStorageTypeAndGetStorageTypes`:
- Creates a `DatanodeDescriptor` and verifies no type is present before any storage is injected
- Injects a DISK storage and asserts `hasStorageType(DISK)` returns true and `hasStorageType(SSD)` returns false
- Injects an SSD storage and asserts both types are now present via both `hasStorageType()` and `getStorageTypes()`

```
Tests run: 1, Failures: 0, Errors: 0
testHasStorageTypeAndGetStorageTypes — PASSED (0.058s)
```