### PR TITLE
HDFS-17684. Add LocalBytesRead and LocalBytesWritten metrics to DataNode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -80,6 +80,10 @@ public class DataNodeMetrics {
   MutableCounterLong remoteBytesRead;
   @Metric("Bytes written by remote client")
   MutableCounterLong remoteBytesWritten;
+  @Metric("Bytes read by local client")
+  MutableCounterLong localBytesRead;
+  @Metric("Bytes written by local client")
+  MutableCounterLong localBytesWritten;
 
   // RamDisk metrics on read/write
   @Metric MutableCounterLong ramDiskBlocksWrite;
@@ -457,6 +461,7 @@ public class DataNodeMetrics {
   public void incrWritesFromClient(boolean local, long size) {
     if(local) {
       writesFromLocalClient.incr();
+      localBytesWritten.incr(size);
     } else {
       writesFromRemoteClient.incr();
       remoteBytesWritten.incr(size);
@@ -464,9 +469,9 @@ public class DataNodeMetrics {
   }
 
   public void incrReadsFromClient(boolean local, long size) {
-
     if (local) {
       readsFromLocalClient.incr();
+      localBytesRead.incr(size);
     } else {
       readsFromRemoteClient.incr();
       remoteBytesRead.incr(size);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -821,6 +821,41 @@ public class TestDataNodeMetrics {
     }
   }
 
+  /**
+   * HDFS-17684: LocalBytesRead and LocalBytesWritten metrics must be
+   * incremented when local clients read and write data on the same host as
+   * the DataNode.  The corresponding remote metrics must remain zero.
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testLocalBytesMetrics() throws IOException {
+    Configuration conf = new HdfsConfiguration();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1).build()) {
+      cluster.waitActive();
+      FileSystem fs = cluster.getFileSystem();
+
+      final Path testFile = new Path("/test-local-bytes.dat");
+      final int fileSize = 512;
+
+      // Write a file — triggers incrWritesFromClient(local=true, size).
+      DFSTestUtil.createFile(fs, testFile, fileSize, (short) 1, 0L);
+      // Read it back — triggers incrReadsFromClient(local=true, size).
+      DFSTestUtil.readFile(fs, testFile);
+
+      DataNode dn = cluster.getDataNodes().get(0);
+      MetricsRecordBuilder rb = getMetrics(dn.getMetrics().name());
+
+      // Local bytes must be non-zero.
+      assertCounterGt("LocalBytesWritten", 0L, rb);
+      assertCounterGt("LocalBytesRead", 0L, rb);
+
+      // Remote bytes must stay zero (no remote clients in this test).
+      assertCounter("RemoteBytesWritten", 0L, rb);
+      assertCounter("RemoteBytesRead", 0L, rb);
+    }
+  }
+
   @Test
   public void testDataNodeDatasetLockMetrics() throws IOException {
     Configuration conf = new HdfsConfiguration();


### PR DESCRIPTION
## Summary

`DataNodeMetrics` already tracks `WritesFromLocalClient` / `WritesFromRemoteClient` (count only) and `RemoteBytesRead` / `RemoteBytesWritten` (bytes), but there is no byte-level metric for **local** client reads/writes.

This patch adds two new `MutableCounterLong` metrics:

| Metric | Description |
|---|---|
| `LocalBytesRead` | Bytes read by local (same-host) clients |
| `LocalBytesWritten` | Bytes written by local (same-host) clients |

These are incremented in `incrReadsFromClient(boolean local, long size)` and `incrWritesFromClient(boolean local, long size)` alongside the existing remote-bytes counters, so no call-site changes are required.

## Changes

- `DataNodeMetrics.java` — added `localBytesRead` / `localBytesWritten` fields and updated `incrReadsFromClient` / `incrWritesFromClient` to increment them
- `TestDataNodeMetrics.java` — added `testLocalBytesMetrics` which spins up a `MiniDFSCluster`, writes then reads a file from the local client, and asserts both new counters are positive while the remote-bytes counters remain zero

## Testing

| Test class | Test method | Result | Duration |
|---|---|---|---|
| `TestDataNodeMetrics` | `testLocalBytesMetrics` | PASSED | 2.391 s |