### PR TITLE
Hadoop-19801. Allow to skip recursive file deletion for non-empty directory

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1868,6 +1868,17 @@ public final class Constants {
       ChecksumSupport.NONE;
 
   /**
+   * Indicates the S3 endpoint is capable of deleting directories that are not empty.
+   * Usually, a non-empty directory is deleted by listing all contained files (objects),
+   * then deleting those files in bulk delete operations, and finally deleting the
+   * (then) empty directory itself. Setting this option to true will only request the
+   * deletion of the directory itself. The S3 endpoint has to support this feature.
+   * value:{@value}
+   */
+  public static final String DELETE_NON_EMPTY_DIRECTORY_ENABLED =
+          "fs.s3a.delete.non-empty-directory.enabled";
+
+  /**
    * Send a {@code Content-MD5 header} with every request.
    * This is required when performing some operations with third party stores
    * For example: bulk delete).

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DeleteOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DeleteOperation.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.fs.s3a.Constants;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.MoreExecutors;
@@ -50,6 +51,16 @@ import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.submit;
 
 /**
  * Implementation of the delete() operation.
+ * A non-empty directory, as well as a directory where its emptiness
+ * is unknown, is deleted by listing all contained files (or objects
+ * with matching key prefix), then deleting those files (objects) in
+ * bulk delete requests, and finally deleting the (then) empty
+ * directory itself.
+ * <p>
+ * When "fs.s3a.delete.non-empty-directory.enabled" is true, only
+ * one delete request is send for the directory (key prefix). The
+ * S3 endpoint has to support this feature.
+ * <p>
  * This issues only one bulk delete at a time,
  * intending to update S3Guard after every request succeeded.
  * Now that S3Guard has been removed, it
@@ -65,7 +76,6 @@ import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.submit;
  * Any exploration of options here MUST be done with performance
  * measurements taken from test runs in EC2 against local S3 stores,
  * so as to ensure network latencies do not skew the results.
-
  */
 public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
 
@@ -167,6 +177,16 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
   /**
    * Delete a file or directory tree.
    * <p>
+   * A non-empty directory, as well as a directory where its emptiness
+   * is unknown, is deleted by listing all contained files (or objects
+   * with matching key prefix), then deleting those files (objects) in
+   * bulk delete requests, and finally deleting the (then) empty
+   * directory itself.
+   * <p>
+   * When "fs.s3a.delete.non-empty-directory.enabled" is true, only
+   * one delete request is send for the directory (key prefix). The
+   * S3 endpoint has to support this feature.
+   * <p>
    * This call does not create any fake parent directory; that is
    * left to the caller.
    * The actual delete call is done in a separate thread.
@@ -221,13 +241,26 @@ public class DeleteOperation extends ExecutingStoreOperation<Boolean> {
       if (!recursive && status.isEmptyDirectory() == Tristate.FALSE) {
         throw new PathIsNotEmptyDirectoryException(path.toString());
       }
-      if (status.isEmptyDirectory() == Tristate.TRUE) {
-        LOG.debug("deleting empty directory {}", path);
+      boolean deleteNonEmptyDirectory =
+          context.getConfiguration().getBoolean(Constants.DELETE_NON_EMPTY_DIRECTORY_ENABLED, false);
+      if (deleteNonEmptyDirectory) {
+        LOG.debug("can delete non-empty directories");
+      }
+      if (status.isEmptyDirectory() == Tristate.TRUE || deleteNonEmptyDirectory) {
+        if (status.isEmptyDirectory() == Tristate.TRUE) {
+          LOG.debug("deleting empty directory {}", path);
+        } else if(status.isEmptyDirectory() == Tristate.FALSE) {
+          LOG.debug("deleting non-empty directory {}", path);
+        } else {
+          LOG.debug("deleting directory {}", path);
+        }
         deleteObjectAtPath(path, key, false);
       } else {
+        if(status.isEmptyDirectory() == Tristate.FALSE) {
+          LOG.debug("recursively deleting non-empty directory {}", path);
+        }
         deleteDirectoryTree(path, key);
       }
-
     } else {
       // simple file.
       LOG.debug("deleting simple file {}", path);

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -162,9 +162,9 @@ the directory path, and returning them as the listing.
 1. When renaming a directory, taking such a listing and asking S3 to copying the
 individual objects to new objects with the destination filenames.
 1. When deleting a directory, taking such a listing and deleting the entries in
-batches.
-1. When renaming or deleting directories, taking such a listing and working
-on the individual files.
+batches. Some S3-compatible endpoints support deleting non-empty directories
+with a single request. See [How S3A deletes directories](#delete) for details.
+1. When renaming, taking such a listing and working on the individual files.
 
 
 Here are some of the consequences:
@@ -571,6 +571,17 @@ Here are some the S3A properties for use in production.
   <description>When enabled, multiple single-object delete requests are replaced by
     a single 'delete multiple objects'-request, reducing the number of requests.
     Beware: legacy S3-compatible object stores might not support this request.
+  </description>
+</property>
+
+<property>
+  <name>fs.s3a.delete.non-empty-directory.enabled</name>
+  <value>false</value>
+  <description>Indicates the S3 endpoint is capable of deleting directories that are not empty.
+    Usually, a non-empty directory is deleted by listing all contained files (objects),
+    then deleting those files in bulk delete operations, and finally deleting the
+    (then) empty directory itself. Setting this option to true will only request the
+    deletion of the directory itself. The S3 endpoint has to support this feature.
   </description>
 </property>
 
@@ -1711,6 +1722,20 @@ rate.
 
 The best practise for using this option is to disable multipart purges in
 normal use of S3A, enabling only in manual/scheduled housekeeping operations.
+
+## <a name="delete"></a>How S3A deletes directories
+
+The S3A client deletes directories (prefixes) by listing all contained files (objects with
+matching prefix), then deleting those files (objects) in bulk delete requests, and finally
+deleting the (then) empty directory itself. The time taken for this deletion is proportional
+to the number of files (objects) in the directory.
+
+When `fs.s3a.delete.non-empty-directory.enabled=true`, only one delete request is sent for
+the directory (prefix). The S3 endpoint has to support this feature. Depending on the
+S3 endpoint implementation of this feature, deletes might be synchronous or asynchronous.
+
+The [VAST S3 endpoint](https://kb.vastdata.com/documentation/docs/using-trash-folder-for-s3-objects-6)
+supports such deletes.
 
 ## <a name="metrics"></a>Metrics
 


### PR DESCRIPTION
### Description of PR
This adds option `fs.s3a.delete.non-empty-directory.enabled`. When true, only one delete request is sent for the directory (key prefix). The S3 endpoint has to support this feature.

This is useful for S3 endpoints that support deletion of path prefixes (non-empty directories).

### How was this patch tested?
Ran `./bin/hadoop fs -rm` against an S3 endpoint. The logging showed the expected behaviour.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling
No AI tooling used.