### PR TITLE
HDFS-17850. Reject append() when newGS equals current generation stamp.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1410,7 +1410,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       // The other reason is that an "append" is occurring to this block.
 
       // check the validity of the parameter
-      if (newGS < b.getGenerationStamp()) {
+      if (newGS <= b.getGenerationStamp()) {
         throw new IOException("The new generation stamp " + newGS +
             " should be greater than the replica " + b + "'s generation stamp");
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -2121,6 +2121,54 @@ public class TestFsDatasetImpl {
     }
   }
 
+  /**
+   * HDFS-17850: Verify that append() rejects a newGS equal to the replica's
+   * current generation stamp.  A client bug that reuses the same GS should
+   * fail immediately rather than silently corrupting the replica state.
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testAppendRejectsSameGenerationStamp() throws Exception {
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1).build();
+    try {
+      cluster.waitActive();
+      BlockReaderTestUtil util = new BlockReaderTestUtil(cluster,
+          new HdfsConfiguration(conf));
+      Path path = new Path("/testAppendSameGS");
+      util.writeFile(path, 1);
+      String bpid = cluster.getNameNode().getNamesystem().getBlockPoolId();
+      DataNode dn = cluster.getDataNodes().get(0);
+      FsDatasetImpl dnFSDataset = (FsDatasetImpl) dn.getFSDataset();
+      LocatedBlock blk = util.getFileBlocks(path, 512).get(0);
+      ExtendedBlock block = blk.getBlock();
+      long currentGS = block.getGenerationStamp();
+
+      // newGS == currentGS must be rejected (HDFS-17850 fix)
+      try {
+        dnFSDataset.append(block, currentGS, block.getNumBytes());
+        fail("Expected IOException when newGS equals current generation stamp");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("should be greater than"),
+            "Unexpected error message: " + e.getMessage());
+      }
+
+      // newGS < currentGS must also be rejected (pre-existing behaviour)
+      try {
+        dnFSDataset.append(block, currentGS - 1, block.getNumBytes());
+        fail("Expected IOException when newGS is less than current generation stamp");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("should be greater than"),
+            "Unexpected error message: " + e.getMessage());
+      }
+
+      // newGS > currentGS must succeed
+      dnFSDataset.append(block, currentGS + 1, block.getNumBytes());
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
   @Test
   @Timeout(value = 30)
   public void testAppend() {


### PR DESCRIPTION
## Summary

Fixes a subtle bug where `FsDatasetImpl.append()` accepted a `newGS` equal to the replica's current generation stamp. The invariant for any append is that the new generation stamp must be *strictly* greater than the existing one; allowing `newGS == currentGS` permits a misbehaving client to re-use the same GS and corrupt replica state silently.

### Changes
- `FsDatasetImpl.java`: Change `newGS < b.getGenerationStamp()` to `newGS <= b.getGenerationStamp()` (one character change).
- `TestFsDatasetImpl.java`: Add `testAppendRejectsSameGenerationStamp` which asserts:
  - `newGS == currentGS` throws IOException
  - `newGS < currentGS` throws IOException (pre-existing behavior)
  - `newGS > currentGS` succeeds (pre-existing behavior)

## Test plan
- [ ] `TestFsDatasetImpl#testAppendRejectsSameGenerationStamp` passes locally ✅
- [ ] Full module build passes (`mvn package -pl hadoop-hdfs-project/hadoop-hdfs -am -DskipTests`) ✅