### PR TITLE
HDFS-17803. Compute correct checksum type when file is empty.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32CastagnoliFileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
 import org.apache.hadoop.fs.Options.ChecksumCombineMode;
+import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.hdfs.protocol.BlockChecksumOptions;
 import org.apache.hadoop.hdfs.protocol.BlockChecksumType;
@@ -240,14 +241,24 @@ final class FileChecksumHelper {
        * magic entry that matches what previous hdfs versions return.
        */
       if (locatedBlocks == null || locatedBlocks.isEmpty()) {
-        // Explicitly specified here in case the default DataOutputBuffer
-        // buffer length value is changed in future. This matters because the
-        // fixed value 32 has to be used to repeat the magic value for previous
-        // HDFS version.
-        final int lenOfZeroBytes = 32;
-        byte[] emptyBlockMd5 = new byte[lenOfZeroBytes];
-        MD5Hash fileMD5 = MD5Hash.digest(emptyBlockMd5);
-        fileChecksum =  new MD5MD5CRC32GzipFileChecksum(0, 0, fileMD5);
+        if (combineMode == ChecksumCombineMode.COMPOSITE_CRC) {
+          // For COMPOSITE_CRC mode return a zero CRC with the client's
+          // configured checksum type rather than a legacy MD5MD5CRC value.
+          ChecksumOpt checksumOpt = client.getConf().getDefaultChecksumOpt();
+          fileChecksum = new CompositeCrcFileChecksum(
+              0, checksumOpt.getChecksumType(), checksumOpt.getBytesPerChecksum());
+        } else {
+          // MD5MD5CRC mode: return the magic empty entry that matches what
+          // previous HDFS versions return for backward compatibility.
+          // Explicitly specified here in case the default DataOutputBuffer
+          // buffer length value is changed in future. This matters because the
+          // fixed value 32 has to be used to repeat the magic value for previous
+          // HDFS version.
+          final int lenOfZeroBytes = 32;
+          byte[] emptyBlockMd5 = new byte[lenOfZeroBytes];
+          MD5Hash fileMD5 = MD5Hash.digest(emptyBlockMd5);
+          fileChecksum = new MD5MD5CRC32GzipFileChecksum(0, 0, fileMD5);
+        }
       } else {
         checksumBlocks();
         fileChecksum = makeFinalResult();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestGetFileChecksum.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestGetFileChecksum.java
@@ -17,18 +17,24 @@
  */
 package org.apache.hadoop.hdfs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CompositeCrcFileChecksum;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.MD5MD5CRC32FileChecksum;
+import org.apache.hadoop.fs.Options.ChecksumCombineMode;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestGetFileChecksum {
   private static final int BLOCKSIZE = 1024;
@@ -91,5 +97,46 @@ public class TestGetFileChecksum {
   public void testGetFileChecksum() throws Exception {
     testGetFileChecksum(new Path("/foo"), BLOCKSIZE / 4);
     testGetFileChecksum(new Path("/bar"), BLOCKSIZE / 4 - 1);
+  }
+
+  /**
+   * HDFS-17803: Verify that getFileChecksum() on an empty file returns the
+   * correct checksum type matching the configured combine mode.
+   * Previously COMPOSITE_CRC mode always returned MD5MD5CRC for empty files.
+   */
+  @Test
+  @Timeout(60)
+  public void testEmptyFileChecksumType() throws Exception {
+    // --- COMPOSITE_CRC mode ---
+    Configuration crcConf = new Configuration(conf);
+    crcConf.set(HdfsClientConfigKeys.DFS_CHECKSUM_COMBINE_MODE_KEY,
+        ChecksumCombineMode.COMPOSITE_CRC.name());
+    try (MiniDFSCluster crcCluster = new MiniDFSCluster.Builder(crcConf)
+        .numDataNodes(REPLICATION).build()) {
+      crcCluster.waitActive();
+      DistributedFileSystem crcDfs = crcCluster.getFileSystem();
+      Path emptyFile = new Path("/emptyCompositeCrc");
+      crcDfs.create(emptyFile).close();
+      FileChecksum checksum = crcDfs.getFileChecksum(emptyFile);
+      assertEquals(CompositeCrcFileChecksum.class, checksum.getClass(),
+          "Expected CompositeCrcFileChecksum for empty file in COMPOSITE_CRC mode, got: "
+              + checksum.getClass().getSimpleName());
+    }
+
+    // --- MD5MD5CRC mode (legacy) ---
+    Configuration md5Conf = new Configuration(conf);
+    md5Conf.set(HdfsClientConfigKeys.DFS_CHECKSUM_COMBINE_MODE_KEY,
+        ChecksumCombineMode.MD5MD5CRC.name());
+    try (MiniDFSCluster md5Cluster = new MiniDFSCluster.Builder(md5Conf)
+        .numDataNodes(REPLICATION).build()) {
+      md5Cluster.waitActive();
+      DistributedFileSystem md5Dfs = md5Cluster.getFileSystem();
+      Path emptyFile = new Path("/emptyMd5");
+      md5Dfs.create(emptyFile).close();
+      FileChecksum checksum = md5Dfs.getFileChecksum(emptyFile);
+      assertTrue(checksum instanceof MD5MD5CRC32FileChecksum,
+          "Expected MD5MD5CRC32FileChecksum for empty file in MD5MD5CRC mode, got: "
+              + checksum.getClass().getSimpleName());
+    }
   }
 }


### PR DESCRIPTION
## Summary

`DistributedFileSystem.getFileChecksum()` on an empty (zero-byte) file always returned an `MD5MD5CRC32GzipFileChecksum` value, even when the client was configured with `dfs.checksum.combine.mode=COMPOSITE_CRC`. This was misleading and inconsistent with what non-empty files return in the same mode.

### Root Cause
In `FileChecksumHelper.FileChecksumComputer.compute()`, the empty-file fast path unconditionally constructed an `MD5MD5CRC32GzipFileChecksum` without checking `combineMode`.

### Fix
Check `combineMode` in the empty-file path:
- **`COMPOSITE_CRC`**: return `CompositeCrcFileChecksum(crc=0, configuredChecksumType, configuredBytesPerCrc)` using the client's configured `ChecksumOpt`.
- **`MD5MD5CRC`**: retain the existing backward-compatible magic value (`MD5MD5CRC32GzipFileChecksum(0, 0, md5OfZeros)`) to avoid breaking existing tools.

### Changes
- `FileChecksumHelper.java`: split the empty-file branch on `combineMode`.
- `TestGetFileChecksum.java`: add `testEmptyFileChecksumType` verifying both modes return the expected `FileChecksum` subclass for a zero-byte file.

## Test plan
- [ ] `TestGetFileChecksum#testEmptyFileChecksumType` passes locally ✅
- [ ] Full module build passes (`mvn package ... -DskipTests`) ✅