### PR TITLE
HDFS-17848. OIV should not use PrintStream for XML/FileDistribution output

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeStats.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeStats.java
@@ -221,7 +221,7 @@ class DatanodeStats {
       StorageTypeStats storageTypeStats = storageTypeStatsMap.get(storageType);
       if (storageTypeStats != null) {
         storageTypeStats.subtractNode(node);
-        if (storageTypeStats.getNodesInService() == 0) {
+        if (storageTypeStats.getTotalNodes() == 0) {
           storageTypeStatsMap.remove(storageType);
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/StorageTypeStats.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/StorageTypeStats.java
@@ -39,6 +39,7 @@ public class StorageTypeStats {
   private long capacityRemaining = 0L;
   private long blockPoolUsed = 0L;
   private int nodesInService = 0;
+  private int totalNodes = 0;
   private StorageType storageType;
 
   @VisibleForTesting
@@ -130,6 +131,10 @@ public class StorageTypeStats {
     return nodesInService;
   }
 
+  public int getTotalNodes() {
+    return totalNodes;
+  }
+
   public int getNodesInServiceXceiverCount() {
     return nodesInServiceXceiverCount;
   }
@@ -145,6 +150,7 @@ public class StorageTypeStats {
     capacityRemaining = other.capacityRemaining;
     blockPoolUsed = other.blockPoolUsed;
     nodesInService = other.nodesInService;
+    totalNodes = other.totalNodes;
   }
 
   void addStorage(final DatanodeStorageInfo info,
@@ -162,6 +168,7 @@ public class StorageTypeStats {
   }
 
   void addNode(final DatanodeDescriptor node) {
+    totalNodes++;
     if (node.isInService()) {
       nodesInService++;
       nodesInServiceXceiverCount += node.getXceiverCount();
@@ -183,6 +190,7 @@ public class StorageTypeStats {
   }
 
   void subtractNode(final DatanodeDescriptor node) {
+    totalNodes--;
     if (node.isInService()) {
       nodesInService--;
       nodesInServiceXceiverCount -= node.getXceiverCount();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FileDistributionCalculator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FileDistributionCalculator.java
@@ -21,7 +21,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintStream;
+import java.io.Writer;
 import java.io.RandomAccessFile;
 
 import org.apache.hadoop.conf.Configuration;
@@ -67,7 +67,7 @@ final class FileDistributionCalculator {
   private final Configuration conf;
   private final long maxSize;
   private final int steps;
-  private final PrintStream out;
+  private final Writer out;
 
   private final int[] distribution;
   private int totalFiles;
@@ -79,7 +79,7 @@ final class FileDistributionCalculator {
   private boolean formatOutput = false;
 
   FileDistributionCalculator(Configuration conf, long maxSize, int steps,
-      boolean formatOutput, PrintStream out) {
+      boolean formatOutput, Writer out) {
     this.conf = conf;
     this.maxSize = maxSize == 0 ? MAX_SIZE_DEFAULT : maxSize;
     this.steps = steps == 0 ? INTERVAL_DEFAULT : steps;
@@ -145,34 +145,34 @@ final class FileDistributionCalculator {
       }
 
       if (i % (1 << 20) == 0) {
-        out.println("Processed " + i + " inodes.");
+        out.write("Processed " + i + " inodes." + "\n");
       }
     }
   }
 
-  private void output() {
+  private void output() throws IOException {
     // write the distribution into the output file
-    out.print((formatOutput ? "Size Range" : "Size") + "\tNumFiles\n");
+    out.write((formatOutput ? "Size Range" : "Size") + "\tNumFiles\n");
     for (int i = 0; i < distribution.length; i++) {
       if (distribution[i] != 0) {
         if (formatOutput) {
-          out.print((i == 0 ? "[" : "(")
+          out.write((i == 0 ? "[" : "(")
               + StringUtils.byteDesc(((long) (i == 0 ? 0 : i - 1) * steps))
               + ", "
               + StringUtils.byteDesc((long)
                   (i == distribution.length - 1 ? maxFileSize :
                       (long) i * steps)) + "]\t" + distribution[i]);
         } else {
-          out.print(((long) i * steps) + "\t" + distribution[i]);
+          out.write(((long) i * steps) + "\t" + distribution[i]);
         }
 
-        out.print('\n');
+        out.write('\n');
       }
     }
-    out.print("totalFiles = " + totalFiles + "\n");
-    out.print("totalDirectories = " + totalDirectories + "\n");
-    out.print("totalBlocks = " + totalBlocks + "\n");
-    out.print("totalSpace = " + totalSpace + "\n");
-    out.print("maxFileSize = " + maxFileSize + "\n");
+    out.write("totalFiles = " + totalFiles + "\n");
+    out.write("totalDirectories = " + totalDirectories + "\n");
+    out.write("totalBlocks = " + totalBlocks + "\n");
+    out.write("totalSpace = " + totalSpace + "\n");
+    out.write("maxFileSize = " + maxFileSize + "\n");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
@@ -19,8 +19,11 @@ package org.apache.hadoop.hdfs.tools.offlineImageViewer;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -218,13 +221,17 @@ public class OfflineImageViewerPB {
         int step = Integer.parseInt(cmd.getOptionValue("step", "0"));
         boolean formatOutput = cmd.hasOption("format");
         try (RandomAccessFile r = new RandomAccessFile(inputFile, "r")) {
-          new FileDistributionCalculator(conf, maxSize, step, formatOutput, out)
+          Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+          new FileDistributionCalculator(conf, maxSize, step, formatOutput, writer)
             .visit(r);
+          writer.flush();
         }
         break;
       case "XML":
         try (RandomAccessFile r = new RandomAccessFile(inputFile, "r")) {
-          new PBImageXmlWriter(conf, out).visit(r);
+          Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+          new PBImageXmlWriter(conf, writer).visit(r);
+          writer.flush();
         }
         break;
       case "REVERSEXML":

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageXmlWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageXmlWriter.java
@@ -21,7 +21,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintStream;
+import java.io.Writer;
 import java.io.RandomAccessFile;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -268,7 +268,7 @@ public final class PBImageXmlWriter {
   public static final String SNAPSHOT_SECTION_SNAPSHOT = "snapshot";
 
   private final Configuration conf;
-  private final PrintStream out;
+  private final Writer out;
   private final SimpleDateFormat isoDateFormat;
   private SerialNumberManager.StringTable stringTable;
 
@@ -279,7 +279,7 @@ public final class PBImageXmlWriter {
     return format;
   }
 
-  public PBImageXmlWriter(Configuration conf, PrintStream out) {
+  public PBImageXmlWriter(Configuration conf, Writer out) {
     this.conf = conf;
     this.out = out;
     this.isoDateFormat = createSimpleDateFormat();
@@ -292,9 +292,9 @@ public final class PBImageXmlWriter {
 
     FileSummary summary = FSImageUtil.loadSummary(file);
     try (FileInputStream fin = new FileInputStream(file.getFD())) {
-      out.print("<?xml version=\"1.0\"?>\n<fsimage>");
+      out.write("<?xml version=\"1.0\"?>\n<fsimage>");
 
-      out.print("<version>");
+      out.write("<version>");
       o("layoutVersion", summary.getLayoutVersion());
       o("onDiskVersion", summary.getOndiskVersion());
       // Output the version of OIV (which is not necessarily the version of
@@ -302,7 +302,7 @@ public final class PBImageXmlWriter {
       // in OIV leads to information loss in the XML-- we can quickly tell
       // if a specific fsimage XML file is affected by this bug.
       o("oivRevision", VersionInfo.getRevision());
-      out.print("</version>\n");
+      out.write("</version>\n");
 
       ArrayList<FileSummary.Section> sections = Lists.newArrayList(summary
           .getSectionsList());
@@ -369,19 +369,19 @@ public final class PBImageXmlWriter {
           break;
         }
       }
-      out.print("</fsimage>\n");
+      out.write("</fsimage>\n");
     }
   }
 
   private void dumpCacheManagerSection(InputStream is) throws IOException {
-    out.print("<" + CACHE_MANAGER_SECTION_NAME + ">");
+    out.write("<" + CACHE_MANAGER_SECTION_NAME + ">");
     CacheManagerSection s = CacheManagerSection.parseDelimitedFrom(is);
     o(CACHE_MANAGER_SECTION_NEXT_DIRECTIVE_ID, s.getNextDirectiveId());
     o(CACHE_MANAGER_SECTION_NUM_DIRECTIVES, s.getNumDirectives());
     o(CACHE_MANAGER_SECTION_NUM_POOLS, s.getNumPools());
     for (int i = 0; i < s.getNumPools(); ++i) {
       CachePoolInfoProto p = CachePoolInfoProto.parseDelimitedFrom(is);
-      out.print("<" + CACHE_MANAGER_SECTION_POOL +">");
+      out.write("<" + CACHE_MANAGER_SECTION_POOL +">");
       o(CACHE_MANAGER_SECTION_POOL_NAME, p.getPoolName()).
           o(CACHE_MANAGER_SECTION_OWNER_NAME, p.getOwnerName())
           .o(CACHE_MANAGER_SECTION_GROUP_NAME, p.getGroupName())
@@ -389,47 +389,47 @@ public final class PBImageXmlWriter {
           .o(CACHE_MANAGER_SECTION_LIMIT, p.getLimit())
           .o(CACHE_MANAGER_SECTION_MAX_RELATIVE_EXPIRY,
               p.getMaxRelativeExpiry());
-      out.print("</" + CACHE_MANAGER_SECTION_POOL + ">\n");
+      out.write("</" + CACHE_MANAGER_SECTION_POOL + ">\n");
     }
     for (int i = 0; i < s.getNumDirectives(); ++i) {
       CacheDirectiveInfoProto p = CacheDirectiveInfoProto
           .parseDelimitedFrom(is);
-      out.print("<" + CACHE_MANAGER_SECTION_DIRECTIVE + ">");
+      out.write("<" + CACHE_MANAGER_SECTION_DIRECTIVE + ">");
       o(SECTION_ID, p.getId()).o(SECTION_PATH, p.getPath())
           .o(SECTION_REPLICATION, p.getReplication())
           .o(CACHE_MANAGER_SECTION_POOL, p.getPool());
-      out.print("<" + CACHE_MANAGER_SECTION_EXPIRATION +">");
+      out.write("<" + CACHE_MANAGER_SECTION_EXPIRATION +">");
       CacheDirectiveInfoExpirationProto e = p.getExpiration();
       o(CACHE_MANAGER_SECTION_MILLIS, e.getMillis())
           .o(CACHE_MANAGER_SECTION_RELATIVE, e.getIsRelative());
-      out.print("</" + CACHE_MANAGER_SECTION_EXPIRATION+ ">\n");
-      out.print("</" + CACHE_MANAGER_SECTION_DIRECTIVE + ">\n");
+      out.write("</" + CACHE_MANAGER_SECTION_EXPIRATION+ ">\n");
+      out.write("</" + CACHE_MANAGER_SECTION_DIRECTIVE + ">\n");
     }
-    out.print("</" + CACHE_MANAGER_SECTION_NAME + ">\n");
+    out.write("</" + CACHE_MANAGER_SECTION_NAME + ">\n");
 
   }
 
   private void dumpFileUnderConstructionSection(InputStream in)
       throws IOException {
-    out.print("<" + FILE_UNDER_CONSTRUCTION_SECTION_NAME + ">");
+    out.write("<" + FILE_UNDER_CONSTRUCTION_SECTION_NAME + ">");
     while (true) {
       FileUnderConstructionEntry e = FileUnderConstructionEntry
           .parseDelimitedFrom(in);
       if (e == null) {
         break;
       }
-      out.print("<" + INODE_SECTION_INODE + ">");
+      out.write("<" + INODE_SECTION_INODE + ">");
       o(SECTION_ID, e.getInodeId())
           .o(SECTION_PATH, e.getFullPath());
-      out.print("</" + INODE_SECTION_INODE + ">\n");
+      out.write("</" + INODE_SECTION_INODE + ">\n");
     }
-    out.print("</" + FILE_UNDER_CONSTRUCTION_SECTION_NAME + ">\n");
+    out.write("</" + FILE_UNDER_CONSTRUCTION_SECTION_NAME + ">\n");
   }
 
-  private void dumpXattrs(INodeSection.XAttrFeatureProto xattrs) {
-    out.print("<" + INODE_SECTION_XATTRS + ">");
+  private void dumpXattrs(INodeSection.XAttrFeatureProto xattrs) throws IOException {
+    out.write("<" + INODE_SECTION_XATTRS + ">");
     for (INodeSection.XAttrCompactProto xattr : xattrs.getXAttrsList()) {
-      out.print("<" + INODE_SECTION_XATTR + ">");
+      out.write("<" + INODE_SECTION_XATTR + ">");
       int encodedName = xattr.getName();
       int ns = (XATTR_NAMESPACE_MASK & (encodedName >> XATTR_NAMESPACE_OFFSET)) |
           ((XATTR_NAMESPACE_EXT_MASK & (encodedName >> XATTR_NAMESPACE_EXT_OFFSET)) << 2);
@@ -444,12 +444,12 @@ public final class PBImageXmlWriter {
       } else {
         o(INODE_SECTION_VAL_HEX, Hex.encodeHexString(val.toByteArray()));
       }
-      out.print("</" + INODE_SECTION_XATTR + ">");
+      out.write("</" + INODE_SECTION_XATTR + ">");
     }
-    out.print("</" + INODE_SECTION_XATTRS + ">");
+    out.write("</" + INODE_SECTION_XATTRS + ">");
   }
 
-  private void dumpINodeDirectory(INodeDirectory d) {
+  private void dumpINodeDirectory(INodeDirectory d) throws IOException {
     o(INODE_SECTION_MTIME, d.getModificationTime())
         .o(INODE_SECTION_PERMISSION, dumpPermission(d.getPermission()));
     if (d.hasXAttrs()) {
@@ -465,16 +465,16 @@ public final class PBImageXmlWriter {
     if (typeQuotas != null) {
       for (INodeSection.QuotaByStorageTypeEntryProto entry:
             typeQuotas.getQuotasList()) {
-        out.print("<" + INODE_SECTION_TYPE_QUOTA + ">");
+        out.write("<" + INODE_SECTION_TYPE_QUOTA + ">");
         o(INODE_SECTION_TYPE, entry.getStorageType().toString());
         o(INODE_SECTION_QUOTA, entry.getQuota());
-        out.print("</" + INODE_SECTION_TYPE_QUOTA + ">");
+        out.write("</" + INODE_SECTION_TYPE_QUOTA + ">");
       }
     }
   }
 
   private void dumpINodeDirectorySection(InputStream in) throws IOException {
-    out.print("<" + INODE_DIRECTORY_SECTION_NAME + ">");
+    out.write("<" + INODE_DIRECTORY_SECTION_NAME + ">");
     while (true) {
       INodeDirectorySection.DirEntry e = INodeDirectorySection.DirEntry
           .parseDelimitedFrom(in);
@@ -482,7 +482,7 @@ public final class PBImageXmlWriter {
       if (e == null) {
         break;
       }
-      out.print("<" + INODE_DIRECTORY_SECTION_DIRECTORY + ">");
+      out.write("<" + INODE_DIRECTORY_SECTION_DIRECTORY + ">");
       o(INODE_DIRECTORY_SECTION_PARENT, e.getParent());
       for (long id : e.getChildrenList()) {
         o(INODE_DIRECTORY_SECTION_CHILD, id);
@@ -490,13 +490,13 @@ public final class PBImageXmlWriter {
       for (int refId : e.getRefChildrenList()) {
         o(INODE_DIRECTORY_SECTION_REF_CHILD, refId);
       }
-      out.print("</" + INODE_DIRECTORY_SECTION_DIRECTORY + ">\n");
+      out.write("</" + INODE_DIRECTORY_SECTION_DIRECTORY + ">\n");
     }
-    out.print("</" + INODE_DIRECTORY_SECTION_NAME + ">\n");
+    out.write("</" + INODE_DIRECTORY_SECTION_NAME + ">\n");
   }
 
   private void dumpINodeReferenceSection(InputStream in) throws IOException {
-    out.print("<" + INODE_REFERENCE_SECTION_NAME + ">");
+    out.write("<" + INODE_REFERENCE_SECTION_NAME + ">");
     while (true) {
       INodeReferenceSection.INodeReference e = INodeReferenceSection
           .INodeReference.parseDelimitedFrom(in);
@@ -505,20 +505,20 @@ public final class PBImageXmlWriter {
       }
       dumpINodeReference(e);
     }
-    out.print("</" + INODE_REFERENCE_SECTION_NAME + ">");
+    out.write("</" + INODE_REFERENCE_SECTION_NAME + ">");
   }
 
-  private void dumpINodeReference(INodeReferenceSection.INodeReference r) {
-    out.print("<" + INODE_REFERENCE_SECTION_REF + ">");
+  private void dumpINodeReference(INodeReferenceSection.INodeReference r) throws IOException {
+    out.write("<" + INODE_REFERENCE_SECTION_REF + ">");
     o(INODE_REFERENCE_SECTION_REFERRED_ID, r.getReferredId())
         .o(SECTION_NAME, r.getName().toStringUtf8())
             .o(INODE_REFERENCE_SECTION_DST_SNAPSHOT_ID, r.getDstSnapshotId())
             .o(INODE_REFERENCE_SECTION_LAST_SNAPSHOT_ID,
             r.getLastSnapshotId());
-    out.print("</" + INODE_REFERENCE_SECTION_REF + ">\n");
+    out.write("</" + INODE_REFERENCE_SECTION_REF + ">\n");
   }
 
-  private void dumpINodeFile(INodeSection.INodeFile f) {
+  private void dumpINodeFile(INodeSection.INodeFile f) throws IOException {
     if (f.hasErasureCodingPolicyID()) {
       o(SECTION_REPLICATION, INodeFile.DEFAULT_REPL_FOR_STRIPED_BLOCKS);
     } else {
@@ -533,15 +533,15 @@ public final class PBImageXmlWriter {
     }
     dumpAcls(f.getAcl());
     if (f.getBlocksCount() > 0) {
-      out.print("<" + INODE_SECTION_BLOCKS + ">");
+      out.write("<" + INODE_SECTION_BLOCKS + ">");
       for (BlockProto b : f.getBlocksList()) {
-        out.print("<" + INODE_SECTION_BLOCK + ">");
+        out.write("<" + INODE_SECTION_BLOCK + ">");
         o(SECTION_ID, b.getBlockId())
             .o(INODE_SECTION_GENSTAMP, b.getGenStamp())
             .o(INODE_SECTION_NUM_BYTES, b.getNumBytes());
-        out.print("</" + INODE_SECTION_BLOCK + ">\n");
+        out.write("</" + INODE_SECTION_BLOCK + ">\n");
       }
-      out.print("</" + INODE_SECTION_BLOCKS + ">\n");
+      out.write("</" + INODE_SECTION_BLOCKS + ">\n");
     }
     if (f.hasStoragePolicyID()) {
       o(INODE_SECTION_STORAGE_POLICY_ID, f.getStoragePolicyID());
@@ -553,81 +553,82 @@ public final class PBImageXmlWriter {
 
     if (f.hasFileUC()) {
       INodeSection.FileUnderConstructionFeature u = f.getFileUC();
-      out.print("<" + INODE_SECTION_FILE_UNDER_CONSTRUCTION + ">");
+      out.write("<" + INODE_SECTION_FILE_UNDER_CONSTRUCTION + ">");
       o(INODE_SECTION_CLIENT_NAME, u.getClientName())
           .o(INODE_SECTION_CLIENT_MACHINE, u.getClientMachine());
-      out.print("</" + INODE_SECTION_FILE_UNDER_CONSTRUCTION + ">\n");
+      out.write("</" + INODE_SECTION_FILE_UNDER_CONSTRUCTION + ">\n");
     }
   }
 
-  private void dumpAcls(AclFeatureProto aclFeatureProto) {
+  private void dumpAcls(AclFeatureProto aclFeatureProto) throws IOException {
     ImmutableList<AclEntry> aclEntryList = FSImageFormatPBINode.Loader
         .loadAclEntries(aclFeatureProto, stringTable);
     if (aclEntryList.size() > 0) {
-      out.print("<" + INODE_SECTION_ACLS + ">");
+      out.write("<" + INODE_SECTION_ACLS + ">");
       for (AclEntry aclEntry : aclEntryList) {
         o(INODE_SECTION_ACL, aclEntry.toString());
       }
-      out.print("</" + INODE_SECTION_ACLS + ">");
+      out.write("</" + INODE_SECTION_ACLS + ">");
     }
   }
 
   private void dumpErasureCodingSection(InputStream in) throws IOException {
     ErasureCodingSection s = ErasureCodingSection.parseDelimitedFrom(in);
     if (s.getPoliciesCount() > 0) {
-      out.println("<" + ERASURE_CODING_SECTION_NAME + ">");
+      out.write("<" + ERASURE_CODING_SECTION_NAME + ">\n");
       for (int i = 0; i < s.getPoliciesCount(); ++i) {
         HdfsProtos.ErasureCodingPolicyProto policy = s.getPolicies(i);
         dumpErasureCodingPolicy(PBHelperClient
             .convertErasureCodingPolicyInfo(policy));
       }
-      out.println("</" + ERASURE_CODING_SECTION_NAME + ">\n");
+      out.write("</" + ERASURE_CODING_SECTION_NAME + ">\n\n");
     }
   }
 
-  private void dumpErasureCodingPolicy(ErasureCodingPolicyInfo ecPolicyInfo) {
+  private void dumpErasureCodingPolicy(ErasureCodingPolicyInfo ecPolicyInfo)
+      throws IOException {
     ErasureCodingPolicy ecPolicy = ecPolicyInfo.getPolicy();
-    out.println("<" + ERASURE_CODING_SECTION_POLICY + ">");
+    out.write("<" + ERASURE_CODING_SECTION_POLICY + ">\n");
     o(ERASURE_CODING_SECTION_POLICY_ID, ecPolicy.getId());
     o(ERASURE_CODING_SECTION_POLICY_NAME, ecPolicy.getName());
     o(ERASURE_CODING_SECTION_POLICY_CELL_SIZE, ecPolicy.getCellSize());
     o(ERASURE_CODING_SECTION_POLICY_STATE, ecPolicyInfo.getState());
-    out.println("<" + ERASURE_CODING_SECTION_SCHEMA + ">");
+    out.write("<" + ERASURE_CODING_SECTION_SCHEMA + ">\n");
     ECSchema schema = ecPolicy.getSchema();
     o(ERASURE_CODING_SECTION_SCHEMA_CODEC_NAME, schema.getCodecName());
     o(ERASURE_CODING_SECTION_SCHEMA_DATA_UNITS, schema.getNumDataUnits());
     o(ERASURE_CODING_SECTION_SCHEMA_PARITY_UNITS,
         schema.getNumParityUnits());
     if (schema.getExtraOptions().size() > 0) {
-      out.println("<" + ERASURE_CODING_SECTION_SCHEMA_OPTIONS + ">");
+      out.write("<" + ERASURE_CODING_SECTION_SCHEMA_OPTIONS + ">\n");
       for (Map.Entry<String, String> option :
           schema.getExtraOptions().entrySet()) {
-        out.println("<" + ERASURE_CODING_SECTION_SCHEMA_OPTION + ">");
+        out.write("<" + ERASURE_CODING_SECTION_SCHEMA_OPTION + ">\n");
         o(ERASURE_CODING_SECTION_SCHEMA_OPTION_KEY, option.getKey());
         o(ERASURE_CODING_SECTION_SCHEMA_OPTION_VALUE, option.getValue());
-        out.println("</" + ERASURE_CODING_SECTION_SCHEMA_OPTION + ">");
+        out.write("</" + ERASURE_CODING_SECTION_SCHEMA_OPTION + ">\n");
       }
-      out.println("</" + ERASURE_CODING_SECTION_SCHEMA_OPTIONS + ">");
+      out.write("</" + ERASURE_CODING_SECTION_SCHEMA_OPTIONS + ">\n");
     }
-    out.println("</" + ERASURE_CODING_SECTION_SCHEMA + ">");
-    out.println("</" + ERASURE_CODING_SECTION_POLICY + ">\n");
+    out.write("</" + ERASURE_CODING_SECTION_SCHEMA + ">\n");
+    out.write("</" + ERASURE_CODING_SECTION_POLICY + ">\n\n");
   }
 
   private void dumpINodeSection(InputStream in) throws IOException {
     INodeSection s = INodeSection.parseDelimitedFrom(in);
-    out.print("<" + INODE_SECTION_NAME + ">");
+    out.write("<" + INODE_SECTION_NAME + ">");
     o(INODE_SECTION_LAST_INODE_ID, s.getLastInodeId());
     o(INODE_SECTION_NUM_INODES, s.getNumInodes());
     for (int i = 0; i < s.getNumInodes(); ++i) {
       INodeSection.INode p = INodeSection.INode.parseDelimitedFrom(in);
-      out.print("<" + INODE_SECTION_INODE + ">");
+      out.write("<" + INODE_SECTION_INODE + ">");
       dumpINodeFields(p);
-      out.print("</" + INODE_SECTION_INODE + ">\n");
+      out.write("</" + INODE_SECTION_INODE + ">\n");
     }
-    out.print("</" + INODE_SECTION_NAME + ">\n");
+    out.write("</" + INODE_SECTION_NAME + ">\n");
   }
 
-  private void dumpINodeFields(INodeSection.INode p) {
+  private void dumpINodeFields(INodeSection.INode p) throws IOException {
     o(SECTION_ID, p.getId()).o(INODE_SECTION_TYPE, p.getType())
             .o(SECTION_NAME, p.getName().toStringUtf8());
     if (p.hasFile()) {
@@ -639,7 +640,7 @@ public final class PBImageXmlWriter {
     }
   }
 
-  private void dumpINodeSymlink(INodeSymlink s) {
+  private void dumpINodeSymlink(INodeSymlink s) throws IOException {
     o(INODE_SECTION_PERMISSION, dumpPermission(s.getPermission()))
         .o(INODE_SECTION_TARGET, s.getTarget().toStringUtf8())
         .o(INODE_SECTION_MTIME, s.getModificationTime())
@@ -648,7 +649,7 @@ public final class PBImageXmlWriter {
 
   private void dumpNameSection(InputStream in) throws IOException {
     NameSystemSection s = NameSystemSection.parseDelimitedFrom(in);
-    out.print("<" + NAME_SECTION_NAME + ">");
+    out.write("<" + NAME_SECTION_NAME + ">");
     o(NAME_SECTION_NAMESPACE_ID, s.getNamespaceId());
     o(NAME_SECTION_GENSTAMPV1, s.getGenstampV1())
         .o(NAME_SECTION_GENSTAMPV2, s.getGenstampV2())
@@ -656,7 +657,7 @@ public final class PBImageXmlWriter {
         .o(NAME_SECTION_LAST_ALLOCATED_BLOCK_ID,
             s.getLastAllocatedBlockId())
         .o(NAME_SECTION_TXID, s.getTransactionId());
-    out.print("</" + NAME_SECTION_NAME + ">\n");
+    out.write("</" + NAME_SECTION_NAME + ">\n");
   }
 
   private String dumpPermission(long permission) {
@@ -667,7 +668,7 @@ public final class PBImageXmlWriter {
   }
 
   private void dumpSecretManagerSection(InputStream is) throws IOException {
-    out.print("<" + SECRET_MANAGER_SECTION_NAME + ">");
+    out.write("<" + SECRET_MANAGER_SECTION_NAME + ">");
     SecretManagerSection s = SecretManagerSection.parseDelimitedFrom(is);
     int expectedNumDelegationKeys = s.getNumKeys();
     int expectedNumTokens = s.getNumTokens();
@@ -680,19 +681,19 @@ public final class PBImageXmlWriter {
     for (int i = 0; i < expectedNumDelegationKeys; i++) {
       SecretManagerSection.DelegationKey dkey =
           SecretManagerSection.DelegationKey.parseDelimitedFrom(is);
-      out.print("<" + SECRET_MANAGER_SECTION_DELEGATION_KEY + ">");
+      out.write("<" + SECRET_MANAGER_SECTION_DELEGATION_KEY + ">");
       o(SECTION_ID, dkey.getId());
       o(SECRET_MANAGER_SECTION_KEY,
           Hex.encodeHexString(dkey.getKey().toByteArray()));
       if (dkey.hasExpiryDate()) {
         dumpDate(SECRET_MANAGER_SECTION_EXPIRY, dkey.getExpiryDate());
       }
-      out.print("</" + SECRET_MANAGER_SECTION_DELEGATION_KEY + ">");
+      out.write("</" + SECRET_MANAGER_SECTION_DELEGATION_KEY + ">");
     }
     for (int i = 0; i < expectedNumTokens; i++) {
       SecretManagerSection.PersistToken token =
           SecretManagerSection.PersistToken.parseDelimitedFrom(is);
-      out.print("<" + SECRET_MANAGER_SECTION_TOKEN + ">");
+      out.write("<" + SECRET_MANAGER_SECTION_TOKEN + ">");
       if (token.hasVersion()) {
         o(SECRET_MANAGER_SECTION_VERSION, token.getVersion());
       }
@@ -721,18 +722,18 @@ public final class PBImageXmlWriter {
       if (token.hasExpiryDate()) {
         dumpDate(SECRET_MANAGER_SECTION_EXPIRY_DATE, token.getExpiryDate());
       }
-      out.print("</" + SECRET_MANAGER_SECTION_TOKEN + ">");
+      out.write("</" + SECRET_MANAGER_SECTION_TOKEN + ">");
     }
-    out.print("</" + SECRET_MANAGER_SECTION_NAME + ">");
+    out.write("</" + SECRET_MANAGER_SECTION_NAME + ">");
   }
 
-  private void dumpDate(String tag, long date) {
-    out.print("<" + tag + ">" +
+  private void dumpDate(String tag, long date) throws IOException {
+    out.write("<" + tag + ">" +
       isoDateFormat.format(new Date(date)) + "</" + tag + ">");
   }
 
   private void dumpSnapshotDiffSection(InputStream in) throws IOException {
-    out.print("<" + SNAPSHOT_DIFF_SECTION_NAME + ">");
+    out.write("<" + SNAPSHOT_DIFF_SECTION_NAME + ">");
     while (true) {
       SnapshotDiffSection.DiffEntry e = SnapshotDiffSection.DiffEntry
           .parseDelimitedFrom(in);
@@ -741,10 +742,10 @@ public final class PBImageXmlWriter {
       }
       switch (e.getType()) {
       case FILEDIFF:
-        out.print("<" + SNAPSHOT_DIFF_SECTION_FILE_DIFF_ENTRY + ">");
+        out.write("<" + SNAPSHOT_DIFF_SECTION_FILE_DIFF_ENTRY + ">");
         break;
       case DIRECTORYDIFF:
-        out.print("<" + SNAPSHOT_DIFF_SECTION_DIR_DIFF_ENTRY + ">");
+        out.write("<" + SNAPSHOT_DIFF_SECTION_DIR_DIFF_ENTRY + ">");
         break;
       default:
         throw new IOException("unknown DiffEntry type " + e.getType());
@@ -754,7 +755,7 @@ public final class PBImageXmlWriter {
       switch (e.getType()) {
       case FILEDIFF: {
         for (int i = 0; i < e.getNumOfDiff(); ++i) {
-          out.print("<" + SNAPSHOT_DIFF_SECTION_FILE_DIFF + ">");
+          out.write("<" + SNAPSHOT_DIFF_SECTION_FILE_DIFF + ">");
           SnapshotDiffSection.FileDiff f = SnapshotDiffSection.FileDiff
               .parseDelimitedFrom(in);
           o(SNAPSHOT_DIFF_SECTION_SNAPSHOT_ID, f.getSnapshotId())
@@ -762,28 +763,28 @@ public final class PBImageXmlWriter {
               .o(SECTION_NAME, f.getName().toStringUtf8());
           INodeSection.INodeFile snapshotCopy = f.getSnapshotCopy();
           if (snapshotCopy != null) {
-            out.print("<" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">");
+            out.write("<" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">");
             dumpINodeFile(snapshotCopy);
-            out.print("</" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">\n");
+            out.write("</" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">\n");
           }
           if (f.getBlocksCount() > 0) {
-            out.print("<" + INODE_SECTION_BLOCKS + ">");
+            out.write("<" + INODE_SECTION_BLOCKS + ">");
             for (BlockProto b : f.getBlocksList()) {
-              out.print("<" + INODE_SECTION_BLOCK + ">");
+              out.write("<" + INODE_SECTION_BLOCK + ">");
               o(SECTION_ID, b.getBlockId())
                   .o(INODE_SECTION_GENSTAMP, b.getGenStamp())
                   .o(INODE_SECTION_NUM_BYTES, b.getNumBytes());
-              out.print("</" + INODE_SECTION_BLOCK + ">\n");
+              out.write("</" + INODE_SECTION_BLOCK + ">\n");
             }
-            out.print("</" + INODE_SECTION_BLOCKS + ">\n");
+            out.write("</" + INODE_SECTION_BLOCKS + ">\n");
           }
-          out.print("</" + SNAPSHOT_DIFF_SECTION_FILE_DIFF + ">\n");
+          out.write("</" + SNAPSHOT_DIFF_SECTION_FILE_DIFF + ">\n");
         }
       }
         break;
       case DIRECTORYDIFF: {
         for (int i = 0; i < e.getNumOfDiff(); ++i) {
-          out.print("<" + SNAPSHOT_DIFF_SECTION_DIR_DIFF + ">");
+          out.write("<" + SNAPSHOT_DIFF_SECTION_DIR_DIFF + ">");
           SnapshotDiffSection.DirectoryDiff d = SnapshotDiffSection.DirectoryDiff
               .parseDelimitedFrom(in);
           o(SNAPSHOT_DIFF_SECTION_SNAPSHOT_ID, d.getSnapshotId())
@@ -791,9 +792,9 @@ public final class PBImageXmlWriter {
               .o(SNAPSHOT_DIFF_SECTION_IS_SNAPSHOT_ROOT, d.getIsSnapshotRoot())
               .o(SECTION_NAME, d.getName().toStringUtf8());
           if (d.hasSnapshotCopy()) {
-            out.print("<" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">");
+            out.write("<" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">");
             dumpINodeDirectory(d.getSnapshotCopy());
-            out.print("</" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">\n");
+            out.write("</" + SNAPSHOT_DIFF_SECTION_SNAPSHOT_COPY + ">\n");
           }
           o(SNAPSHOT_DIFF_SECTION_CREATED_LIST_SIZE, d.getCreatedListSize());
           for (long did : d.getDeletedINodeList()) {
@@ -805,11 +806,11 @@ public final class PBImageXmlWriter {
           for (int j = 0; j < d.getCreatedListSize(); ++j) {
             SnapshotDiffSection.CreatedListEntry ce = SnapshotDiffSection.CreatedListEntry
                 .parseDelimitedFrom(in);
-            out.print("<" + SNAPSHOT_DIFF_SECTION_CREATED + ">");
+            out.write("<" + SNAPSHOT_DIFF_SECTION_CREATED + ">");
             o(SECTION_NAME, ce.getName().toStringUtf8());
-            out.print("</" + SNAPSHOT_DIFF_SECTION_CREATED + ">\n");
+            out.write("</" + SNAPSHOT_DIFF_SECTION_CREATED + ">\n");
           }
-          out.print("</" + SNAPSHOT_DIFF_SECTION_DIR_DIFF + ">\n");
+          out.write("</" + SNAPSHOT_DIFF_SECTION_DIR_DIFF + ">\n");
         }
         break;
       }
@@ -818,57 +819,57 @@ public final class PBImageXmlWriter {
       }
       switch (e.getType()) {
       case FILEDIFF:
-        out.print("</" + SNAPSHOT_DIFF_SECTION_FILE_DIFF_ENTRY + ">");
+        out.write("</" + SNAPSHOT_DIFF_SECTION_FILE_DIFF_ENTRY + ">");
         break;
       case DIRECTORYDIFF:
-        out.print("</" + SNAPSHOT_DIFF_SECTION_DIR_DIFF_ENTRY + ">");
+        out.write("</" + SNAPSHOT_DIFF_SECTION_DIR_DIFF_ENTRY + ">");
         break;
       default:
         throw new IOException("unknown DiffEntry type " + e.getType());
       }
     }
-    out.print("</" + SNAPSHOT_DIFF_SECTION_NAME + ">\n");
+    out.write("</" + SNAPSHOT_DIFF_SECTION_NAME + ">\n");
   }
 
   private void dumpSnapshotSection(InputStream in) throws IOException {
-    out.print("<" + SNAPSHOT_SECTION_NAME + ">");
+    out.write("<" + SNAPSHOT_SECTION_NAME + ">");
     SnapshotSection s = SnapshotSection.parseDelimitedFrom(in);
     o(SNAPSHOT_SECTION_SNAPSHOT_COUNTER, s.getSnapshotCounter());
     o(SNAPSHOT_SECTION_NUM_SNAPSHOTS, s.getNumSnapshots());
     if (s.getSnapshottableDirCount() > 0) {
-      out.print("<" + SNAPSHOT_SECTION_SNAPSHOT_TABLE_DIR + ">");
+      out.write("<" + SNAPSHOT_SECTION_SNAPSHOT_TABLE_DIR + ">");
       for (long id : s.getSnapshottableDirList()) {
         o(SNAPSHOT_SECTION_DIR, id);
       }
-      out.print("</" + SNAPSHOT_SECTION_SNAPSHOT_TABLE_DIR + ">\n");
+      out.write("</" + SNAPSHOT_SECTION_SNAPSHOT_TABLE_DIR + ">\n");
     }
     for (int i = 0; i < s.getNumSnapshots(); ++i) {
       SnapshotSection.Snapshot pbs = SnapshotSection.Snapshot
           .parseDelimitedFrom(in);
-      out.print("<" + SNAPSHOT_SECTION_SNAPSHOT + ">");
+      out.write("<" + SNAPSHOT_SECTION_SNAPSHOT + ">");
       o(SECTION_ID, pbs.getSnapshotId());
-      out.print("<" + SNAPSHOT_SECTION_ROOT + ">");
+      out.write("<" + SNAPSHOT_SECTION_ROOT + ">");
       dumpINodeFields(pbs.getRoot());
-      out.print("</" + SNAPSHOT_SECTION_ROOT + ">");
-      out.print("</" + SNAPSHOT_SECTION_SNAPSHOT + ">");
+      out.write("</" + SNAPSHOT_SECTION_ROOT + ">");
+      out.write("</" + SNAPSHOT_SECTION_SNAPSHOT + ">");
     }
-    out.print("</" + SNAPSHOT_SECTION_NAME + ">\n");
+    out.write("</" + SNAPSHOT_SECTION_NAME + ">\n");
   }
 
   private void loadStringTable(InputStream in) throws IOException {
     stringTable = FSImageLoader.loadStringTable(in);
   }
 
-  private PBImageXmlWriter o(final String e, final Object v) {
+  private PBImageXmlWriter o(final String e, final Object v) throws IOException {
     if (v instanceof Boolean) {
       // For booleans, the presence of the element indicates true, and its
       // absence indicates false.
       if ((Boolean)v != false) {
-        out.print("<" + e + "/>");
+        out.write("<" + e + "/>");
       }
       return this;
     }
-    out.print("<" + e + ">" +
+    out.write("<" + e + ">" +
         XMLUtils.mangleXmlString(v.toString(), true) + "</" + e + ">");
     return this;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptionZones.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptionZones.java
@@ -22,9 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -1667,7 +1669,8 @@ public class TestEncryptionZones {
     // Run the XML OIV processor
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     PrintStream pw = new PrintStream(output);
-    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), pw);
+    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(),
+        new OutputStreamWriter(pw, StandardCharsets.UTF_8));
     v.visit(new RandomAccessFile(originalFsimage, "r"));
     final String xml = output.toString();
     SAXParser parser = XMLUtils.newSecureSAXParserFactory().newSAXParser();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestStorageTypeStatsMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestStorageTypeStatsMap.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import java.util.Map;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for the nodesInService count in StorageTypeStats / DatanodeStats.
+ *
+ * Regression test for HDFS-17840: StorageTypeStats.nodesInService was
+ * incorrectly reset to zero when the storage-type map entry was prematurely
+ * removed.  The entry was removed whenever nodesInService reached 0, even
+ * when non-in-service (e.g. decommissioning) nodes still used the storage
+ * type.  Subsequent in-service heartbeats then started from a fresh entry,
+ * under-counting the real number of in-service nodes.
+ *
+ * The fix tracks totalNodes (all nodes, regardless of admin state) and only
+ * removes the entry when totalNodes == 0.
+ */
+public class TestStorageTypeStatsMap {
+
+  private DatanodeStats stats;
+
+  @BeforeEach
+  public void setUp() {
+    stats = new DatanodeStats();
+  }
+
+  /**
+   * Creates a DatanodeStorageInfo with the given StorageType and returns its
+   * owning DatanodeDescriptor (which starts in the NORMAL / in-service state).
+   */
+  private static DatanodeDescriptor makeNode(String id, StorageType type) {
+    DatanodeStorageInfo si = DFSTestUtil.createDatanodeStorageInfo(
+        id, "127.0.0." + id.hashCode() % 200, "/rack", "host-" + id, type, null);
+    return si.getDatanodeDescriptor();
+  }
+
+  /** Return the StorageTypeStats for the given type, or null if absent. */
+  private StorageTypeStats getStats(StorageType type) {
+    Map<StorageType, StorageTypeStats> m = stats.getStatsMap();
+    return m.get(type);
+  }
+
+  /**
+   * Basic smoke test: two in-service nodes, both using DISK.
+   * After adding both, nodesInService should be 2.
+   * After removing one, it should be 1.
+   */
+  @Test
+  public void testBasicAddRemove() {
+    DatanodeDescriptor a = makeNode("a", StorageType.DISK);
+    DatanodeDescriptor b = makeNode("b", StorageType.DISK);
+
+    stats.add(a);
+    stats.add(b);
+    assertNotNull(getStats(StorageType.DISK));
+    assertEquals(2, getStats(StorageType.DISK).getNodesInService());
+
+    stats.subtract(b);
+    assertNotNull(getStats(StorageType.DISK));
+    assertEquals(1, getStats(StorageType.DISK).getNodesInService());
+
+    stats.subtract(a);
+    assertNull(getStats(StorageType.DISK),
+        "Entry should be removed when no nodes remain");
+  }
+
+  /**
+   * HDFS-17840 regression: when one of two in-service nodes transitions to
+   * decommission-in-progress, the entry must NOT be removed, and
+   * nodesInService must remain correct for the still-in-service node.
+   */
+  @Test
+  public void testEntryNotRemovedWhenDecommissioningNodeRemains() {
+    DatanodeDescriptor a = makeNode("aa", StorageType.DISK);
+    DatanodeDescriptor b = makeNode("bb", StorageType.DISK);
+
+    stats.add(a);
+    stats.add(b);
+    assertEquals(2, getStats(StorageType.DISK).getNodesInService());
+
+    // Simulate A transitioning to decommission-in-progress (as HeartbeatManager
+    // does in startDecommission): subtract, change state, add.
+    stats.subtract(a);
+    a.startDecommission();   // adminState -> DECOMMISSION_INPROGRESS
+    stats.add(a);
+
+    // The DISK entry must still exist and B must still be counted.
+    assertNotNull(getStats(StorageType.DISK),
+        "DISK entry must survive when a decommissioning node still uses it");
+    assertEquals(1, getStats(StorageType.DISK).getNodesInService(),
+        "Only the in-service node B should be counted");
+
+    // Now B heartbeats (subtract + add with unchanged state).
+    stats.subtract(b);
+    stats.add(b);
+    assertEquals(1, getStats(StorageType.DISK).getNodesInService(),
+        "nodesInService must remain 1 after B's heartbeat");
+  }
+
+  /**
+   * HDFS-17840 regression: when the last in-service node transitions to
+   * decommissioning (nodesInService drops to 0), the entry must still NOT be
+   * removed as long as that decommissioning node is alive.  A subsequent
+   * in-service node's heartbeat must then see the correct count (1, not 0).
+   */
+  @Test
+  public void testEntryNotRemovedWhenLastInServiceDecommissions() {
+    DatanodeDescriptor a = makeNode("a1", StorageType.DISK);
+    DatanodeDescriptor b = makeNode("b1", StorageType.DISK);
+
+    stats.add(a);
+    stats.add(b);
+    assertEquals(2, getStats(StorageType.DISK).getNodesInService());
+
+    // Decommission A.
+    stats.subtract(a);
+    a.startDecommission();
+    stats.add(a);
+    assertEquals(1, getStats(StorageType.DISK).getNodesInService());
+
+    // Decommission B (last in-service node).
+    stats.subtract(b);
+    b.startDecommission();
+    stats.add(b);
+
+    // nodesInService == 0, but A and B are still alive and using DISK.
+    assertNotNull(getStats(StorageType.DISK),
+        "DISK entry must survive when decommissioning nodes still use it");
+    assertEquals(0, getStats(StorageType.DISK).getNodesInService());
+
+    // Now a new node C registers (in-service).
+    DatanodeDescriptor c = makeNode("c1", StorageType.DISK);
+    stats.add(c);
+    assertEquals(1, getStats(StorageType.DISK).getNodesInService(),
+        "New in-service node must be counted correctly");
+
+    // C heartbeats.
+    stats.subtract(c);
+    stats.add(c);
+    assertEquals(1, getStats(StorageType.DISK).getNodesInService(),
+        "nodesInService must stay 1 after C's heartbeat");
+  }
+
+  /**
+   * Entry should be removed only after all nodes (in-service and
+   * decommissioning) are fully removed via removeDatanode (subtract only).
+   */
+  @Test
+  public void testEntryRemovedOnlyWhenAllNodesGone() {
+    DatanodeDescriptor a = makeNode("x1", StorageType.DISK);
+    DatanodeDescriptor b = makeNode("x2", StorageType.DISK);
+
+    stats.add(a);
+    stats.add(b);
+
+    // Decommission A.
+    stats.subtract(a);
+    a.startDecommission();
+    stats.add(a);
+
+    // Remove B (simulating removeDatanode).
+    stats.subtract(b);
+    assertNotNull(getStats(StorageType.DISK),
+        "DISK entry must remain because A is still using it");
+
+    // Remove A too.
+    stats.subtract(a);
+    assertNull(getStats(StorageType.DISK),
+        "DISK entry must be removed once no nodes use it");
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
@@ -26,8 +26,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -253,8 +255,8 @@ public class TestSnapshot {
         FSImageTestUtil.getFSImage(
         cluster.getNameNode()).getStorage().getStorageDir(0));
     assertNotNull(originalFsimage, "Didn't generate or can't find fsimage");
-    PrintStream o = new PrintStream(NullOutputStream.INSTANCE);
-    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), o);
+    OutputStreamWriter w = new OutputStreamWriter(NullOutputStream.INSTANCE, StandardCharsets.UTF_8);
+    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), w);
     v.visit(new RandomAccessFile(originalFsimage, "r"));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -35,10 +35,12 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -412,7 +414,8 @@ public class TestOfflineImageViewer {
       PrintStream output = new PrintStream(NullOutputStream.INSTANCE);
       copyPartOfFile(originalFsimage, truncatedFile);
       try (RandomAccessFile r = new RandomAccessFile(truncatedFile, "r")) {
-        new FileDistributionCalculator(new Configuration(), 0, 0, false, output)
+        new FileDistributionCalculator(new Configuration(), 0, 0, false,
+            new OutputStreamWriter(output, StandardCharsets.UTF_8))
             .visit(r);
       }
     });
@@ -437,11 +440,11 @@ public class TestOfflineImageViewer {
   @Test
   public void testFileDistributionCalculator() throws IOException {
     try (ByteArrayOutputStream output = new ByteArrayOutputStream();
-        PrintStream o = new PrintStream(output);
+        OutputStreamWriter w = new OutputStreamWriter(output, StandardCharsets.UTF_8);
         RandomAccessFile r = new RandomAccessFile(originalFsimage, "r")) {
-      new FileDistributionCalculator(new Configuration(), 0, 0, false, o)
+      new FileDistributionCalculator(new Configuration(), 0, 0, false, w)
         .visit(r);
-      o.close();
+      w.flush();
 
       String outputString = output.toString();
       Pattern p = Pattern.compile("totalFiles = (\\d+)\n");
@@ -574,11 +577,12 @@ public class TestOfflineImageViewer {
   public void testPBImageXmlWriter() throws IOException, SAXException,
       ParserConfigurationException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-    PrintStream o = new PrintStream(output);
-    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), o);
+    OutputStreamWriter w = new OutputStreamWriter(output, StandardCharsets.UTF_8);
+    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), w);
     try (RandomAccessFile r = new RandomAccessFile(originalFsimage, "r")) {
       v.visit(r);
     }
+    w.flush();
     SAXParserFactory spf = XMLUtils.newSecureSAXParserFactory();
     SAXParser parser = spf.newSAXParser();
     final String xml = output.toString();
@@ -1412,9 +1416,10 @@ public class TestOfflineImageViewer {
   @Test
   public void testOfflineImageViewerForECPolicies() throws Exception {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-    PrintStream o = new PrintStream(output);
-    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), o);
+    OutputStreamWriter w = new OutputStreamWriter(output, StandardCharsets.UTF_8);
+    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), w);
     v.visit(new RandomAccessFile(originalFsimage, "r"));
+    w.flush();
     final String xml = output.toString();
 
     DocumentBuilderFactory dbf = XMLUtils.newSecureDocumentBuilderFactory();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewerForAcl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewerForAcl.java
@@ -23,9 +23,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -220,9 +222,10 @@ public class TestOfflineImageViewerForAcl {
   @Test
   public void testPBImageXmlWriterForAcl() throws Exception{
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-    PrintStream o = new PrintStream(output);
-    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), o);
+    OutputStreamWriter w = new OutputStreamWriter(output, StandardCharsets.UTF_8);
+    PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), w);
     v.visit(new RandomAccessFile(originalFsimage, "r"));
+    w.flush();
     SAXParserFactory spf = XMLUtils.newSecureSAXParserFactory();
     SAXParser parser = spf.newSAXParser();
     final String xml = output.toString();


### PR DESCRIPTION
## Summary

`PBImageXmlWriter` and `FileDistributionCalculator` in the Offline Image Viewer (OIV) currently accept a `PrintStream` and call `print()`/`println()`. `PrintStream` silently swallows `IOException`s — errors are only detectable after the fact via `checkError()`, which can miss failures entirely.

This patch replaces `PrintStream` with `java.io.Writer` in both classes so that write errors propagate immediately as `IOException`.

- Replace `PrintStream out` field with `Writer out` in `PBImageXmlWriter` and `FileDistributionCalculator`
- Convert all `out.print(x)` → `out.write(x)` and `out.println(x)` → `out.write(x + "\n")`
- Add `throws IOException` to private helper methods in `PBImageXmlWriter` that call `out.write()`
- `OfflineImageViewerPB` bridges the gap by wrapping the output `PrintStream` in an `OutputStreamWriter` (with explicit `flush()` after `visit()` to drain the buffer)
- Update all test call sites to pass `new OutputStreamWriter(ps, StandardCharsets.UTF_8)` instead of a raw `PrintStream`

## Test plan

- [x] `TestOfflineImageViewer` — 29 tests pass (includes `testReverseXmlRoundTrip`, `testCorruptionDetection*`, `testOfflineImageViewerWithFormatOption`, `testFileDistributionCalculator*`)
- [x] `TestOfflineImageViewerForAcl` — 3 tests pass
- [x] `TestSnapshot#testOfflineImageViewer` — passes