### PR TITLE
HDFS-17630. Avoid PacketReceiver#MAX_PACKET_SIZE Initialized to 0.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -154,6 +154,7 @@ import org.apache.hadoop.hdfs.protocol.SnapshotDiffReportListing;
 import org.apache.hadoop.hdfs.protocol.SnapshotStatus;
 import org.apache.hadoop.hdfs.protocol.datatransfer.DataTransferProtoUtil;
 import org.apache.hadoop.hdfs.protocol.datatransfer.IOStreamPair;
+import org.apache.hadoop.hdfs.protocol.datatransfer.PacketReceiver;
 import org.apache.hadoop.hdfs.protocol.datatransfer.ReplaceDatanodeOnFailure;
 import org.apache.hadoop.hdfs.protocol.datatransfer.Sender;
 import org.apache.hadoop.hdfs.protocol.datatransfer.TrustedChannelResolver;
@@ -324,6 +325,10 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     this.tracer = FsTracer.get(conf);
     this.dfsClientConf = new DfsClientConf(conf);
     this.conf = conf;
+    // Apply the configured max packet size so PacketReceiver uses the right
+    // value; must be done here rather than in PacketReceiver's static
+    // initializer to avoid a circular class-loading deadlock (HDFS-17630).
+    PacketReceiver.setMaxPacketSize(conf);
     this.stats = stats;
     this.socketFactory = NetUtils.getSocketFactory(conf, ClientProtocol.class);
     this.dtpReplaceDatanodeOnFailure = ReplaceDatanodeOnFailure.get(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/PacketReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/PacketReceiver.java
@@ -26,7 +26,6 @@ import java.nio.channels.ReadableByteChannel;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.util.DirectBufferPool;
 import org.apache.hadoop.io.IOUtils;
@@ -47,8 +46,19 @@ public class PacketReceiver implements Closeable {
   /**
    * The max size of any single packet. This prevents OOMEs when
    * invalid data is sent.
+   *
+   * <p>Initialized to the default value to avoid a circular class-loading
+   * deadlock: a static initializer that calls {@code new HdfsConfiguration()}
+   * can trigger URL-based resource loading over HDFS, which in turn
+   * instantiates {@code BlockReaderRemote} before {@code PacketReceiver}
+   * finishes initializing, leaving this field as 0 and causing spurious
+   * {@code IOException: Incorrect value for packet payload size} errors.
+   *
+   * <p>Call {@link #setMaxPacketSize(Configuration)} once a {@link Configuration}
+   * is available (e.g., during DFSClient construction) to apply a custom value.
    */
-  public static final int MAX_PACKET_SIZE;
+  public static volatile int MAX_PACKET_SIZE =
+      HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE_DEFAULT;
 
   static final Logger LOG = LoggerFactory.getLogger(PacketReceiver.class);
 
@@ -77,11 +87,18 @@ public class PacketReceiver implements Closeable {
    */
   private PacketHeader curHeader;
 
-  static {
-    Configuration conf = new HdfsConfiguration();
-    MAX_PACKET_SIZE = conf.getInt(HdfsClientConfigKeys.
-                    DFS_DATA_TRANSFER_MAX_PACKET_SIZE,
-            HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE_DEFAULT);
+  /**
+   * Update {@link #MAX_PACKET_SIZE} from the supplied configuration.
+   * Should be called once during client or server initialization, after the
+   * {@link Configuration} is fully constructed, rather than from a static
+   * initializer.
+   *
+   * @param conf configuration to read from
+   */
+  public static void setMaxPacketSize(Configuration conf) {
+    MAX_PACKET_SIZE = conf.getInt(
+        HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE,
+        HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE_DEFAULT);
   }
 
   public PacketReceiver(boolean useDirectBuffers) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/TestPacketReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/TestPacketReceiver.java
@@ -23,8 +23,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.AppendTestUtil;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -32,12 +35,21 @@ import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 
 public class TestPacketReceiver {
 
   private static final long OFFSET_IN_BLOCK = 12345L;
   private static final int SEQNO = 54321;
+
+  /**
+   * Restore the default MAX_PACKET_SIZE after each test so tests are isolated.
+   */
+  @AfterEach
+  public void restoreDefaultMaxPacketSize() {
+    PacketReceiver.setMaxPacketSize(new HdfsConfiguration());
+  }
 
   private byte[] prepareFakePacket(byte[] data, byte[] sums) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -64,6 +76,41 @@ public class TestPacketReceiver {
   public void testPacketSize() {
     assertEquals(PacketReceiver.MAX_PACKET_SIZE,
             HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE_DEFAULT);
+  }
+
+  /**
+   * Verify that MAX_PACKET_SIZE is initialized to the default constant (not 0)
+   * even before any Configuration-based initialization takes place. This guards
+   * against the circular class-loading deadlock described in HDFS-17630, where
+   * the previous static initializer called {@code new HdfsConfiguration()},
+   * which could re-enter PacketReceiver before it finished initializing and
+   * leave MAX_PACKET_SIZE as 0.
+   */
+  @Test
+  public void testMaxPacketSizeDefaultIsNonZero() {
+    assertNotEquals(0, PacketReceiver.MAX_PACKET_SIZE,
+        "MAX_PACKET_SIZE must not be 0; a zero value causes all block reads "
+            + "to fail with 'Incorrect value for packet payload size'");
+    assertEquals(HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE_DEFAULT,
+        PacketReceiver.MAX_PACKET_SIZE,
+        "MAX_PACKET_SIZE should equal the configured default before any "
+            + "explicit setMaxPacketSize() call");
+  }
+
+  /**
+   * Verify that {@link PacketReceiver#setMaxPacketSize(Configuration)} correctly
+   * reads and applies the configured value, allowing operators to tune the limit
+   * without triggering the class-loading race described in HDFS-17630.
+   */
+  @Test
+  public void testSetMaxPacketSizeFromConfig() {
+    int customSize = 4 * 1024 * 1024; // 4 MB
+    Configuration conf = new Configuration();
+    conf.setInt(HdfsClientConfigKeys.DFS_DATA_TRANSFER_MAX_PACKET_SIZE,
+        customSize);
+    PacketReceiver.setMaxPacketSize(conf);
+    assertEquals(customSize, PacketReceiver.MAX_PACKET_SIZE,
+        "MAX_PACKET_SIZE should reflect the value set in Configuration");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `PacketReceiver.MAX_PACKET_SIZE` was set via a `static { new HdfsConfiguration(); ... }` initializer. When config resources are loaded from HDFS URLs (e.g., during JAR loading via `URLJarFile`), the resulting class-loading chain can instantiate `BlockReaderRemote` before `PacketReceiver` finishes initializing. The JVM then returns the partially-initialized class with `MAX_PACKET_SIZE == 0`, causing every subsequent block read to throw `IOException: Incorrect value for packet payload size`.
- Fix: initialize `MAX_PACKET_SIZE` directly to the compile-time default constant (eliminating the static initializer) and add a static `setMaxPacketSize(Configuration)` method that `DFSClient` calls during construction to apply any operator-configured override. This breaks the circular class-loading dependency while preserving configurability.

## Test plan

- [ ] New tests `TestPacketReceiver#testMaxPacketSizeDefaultIsNonZero` and `TestPacketReceiver#testSetMaxPacketSizeFromConfig` pass
- [ ] All existing `TestPacketReceiver` tests continue to pass