### PR TITLE
MAPREDUCE-7538. Make MapReduce Application Master class configurable in YARNRunner

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/main/java/org/apache/hadoop/mapred/YARNRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/main/java/org/apache/hadoop/mapred/YARNRunner.java
@@ -503,7 +503,9 @@ public class YARNRunner implements ClientProtocol {
       }
     }
 
-    vargs.add(MRJobConfig.APPLICATION_MASTER_CLASS);
+    String amClass = jobConf.get("yarn.app.mapreduce.am",
+        MRJobConfig.APPLICATION_MASTER_CLASS);
+    vargs.add(amClass);
     vargs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +
         Path.SEPARATOR + ApplicationConstants.STDOUT);
     vargs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +


### PR DESCRIPTION
### Description of PR
See [MAPREDUCE-7538](https://issues.apache.org/jira/browse/MAPREDUCE-7538)

### How was this patch tested?
Tested with Hadoop 3.4.3 and Celeborn 0.6.2 and Nutch 1.23-SNAPSHOT. Nutch MapReduce smoke tests were run.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html