### PR TITLE
HDFS-17844. Namenode ID collision detection incorrectly rejects same-namenode export paths.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/DFSClientCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/DFSClientCache.java
@@ -172,13 +172,17 @@ class DFSClientCache {
         LOG.info("Added export: {} FileSystem URI: {} with namenodeId: {}",
             exportPath, exportPath, namenodeId);
         namenodeUriMap.put(namenodeId, exportURI);
-      } else {
-        // if the nnid already exists, it better be the for the same namenode
+      } else if (!exportURI.getAuthority().equals(value.getAuthority())) {
+        // different namenode authorities hashed to the same namenodeId — real collision
         String msg = String.format("FS:%s, Namenode ID collision for path:%s "
                 + "nnid:%s uri being added:%s existing uri:%s", fs.getScheme(),
             exportPath, namenodeId, exportURI, value);
         LOG.error(msg);
         throw new FileSystemException(msg);
+      } else {
+        // same namenode authority (multiple export paths on the same namenode) — safe
+        LOG.debug("Export path: {} maps to an already-registered namenode URI: {}"
+            + " with namenodeId: {}", exportPath, exportURI, namenodeId);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestDFSClientCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestDFSClientCache.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hdfs.DFSClient;
+import org.apache.hadoop.hdfs.nfs.conf.NfsConfigKeys;
 import org.apache.hadoop.hdfs.nfs.conf.NfsConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
@@ -101,6 +102,24 @@ public class TestDFSClientCache {
     assertThat(ugiResult.getRealUser()).isEqualTo(currentUserUgi);
     assertThat(ugiResult.getAuthenticationMethod()).isEqualTo(
         UserGroupInformation.AuthenticationMethod.PROXY);
+  }
+
+  /**
+   * HDFS-17844: Multiple export paths pointing to the same namenode should
+   * not trigger a false namenode ID collision error.  Before the fix,
+   * prepareAddressMap() threw FileSystemException whenever the same namenodeId
+   * was seen a second time, even if both paths resolved to the same namenode
+   * authority.
+   */
+  @Test
+  public void testMultipleExportPointsSameNamenode() throws IOException {
+    NfsConfiguration conf = new NfsConfiguration();
+    conf.set(FileSystem.FS_DEFAULT_NAME_KEY, "hdfs://localhost");
+    // Two export paths on the same namenode produce the same namenodeId
+    // because getNamenodeId() is based solely on the host:port address.
+    // The cache constructor must not throw a FileSystemException.
+    conf.setStrings(NfsConfigKeys.DFS_NFS_EXPORT_POINT_KEY, "/path1", "/path2");
+    new DFSClientCache(conf);
   }
 
   private static boolean isDfsClientClose(DFSClient c) {


### PR DESCRIPTION
### Problem
When multiple NFS export paths are configured on the same HDFS namenode (e.g., `/path1` and `/path2` both served by `hdfs://namenode:8020`), the `DFSClientCache` constructor throws a `FileSystemException` with the message "Namenode ID collision". This causes the NFS gateway to fail startup even though the configuration is valid.

The root symptom was a flaky test (`testViewFsMultipleExportPoint`) that failed with:
```
Namenode ID collision for path:/hdfs2 nnid:2130740544
uri being added:hdfs://localhost:34111/
existing uri:hdfs://localhost:34111/
```

### Root Cause
`DFSClientCache.prepareAddressMap()` uses `Nfs3Utils.getNamenodeId()` to map each export path to a namenode ID, where the ID is derived from the namenode's `InetSocketAddress.hashCode()`. When two export paths resolve to the **same namenode** (same host and port), they produce the same namenode ID. The existing code incorrectly treats any duplicate namenode ID as a collision and throws an error, even when both paths point to the same namenode authority.

The check should only fail when two **different** namenode authorities (different host:port) hash to the same ID — a true hash collision — not when the same namenode is referenced by multiple export paths.

### Fix
Changed the collision check in `prepareAddressMap()` from "throw on any duplicate namenodeId" to "throw only when the conflicting entries have different URI authorities (host:port)". When the authorities match, the duplicate is logged at DEBUG level and skipped safely.

### Testing
Added `testMultipleExportPointsSameNamenode()` to `TestDFSClientCache` which configures two export paths (`/path1` and `/path2`) on the same HDFS namenode and verifies the `DFSClientCache` constructor completes without throwing. Before the fix this test would fail with `FileSystemException`.

JIRA: https://issues.apache.org/jira/browse/HDFS-17844