### PR TITLE
HDFS-17842. RBF: Unable to delete files under trash path.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -529,6 +529,13 @@ public class MountTableResolver
     String path = RouterAdmin.normalizeFileSystemPath(str);
     if (isTrashPath(path)) {
       path = subtractTrashCurrentPath(path);
+      if (path.isEmpty()) {
+        // The path is exactly the trash Current/checkpoint directory itself
+        // (e.g. /user/alice/.Trash/Current). There are no mount points under
+        // it in the RBF sense, so return null to allow operations such as
+        // recursive delete to proceed normally.
+        return null;
+      }
     }
     readLock.lock();
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -531,10 +531,10 @@ public class MountTableResolver
       path = subtractTrashCurrentPath(path);
       if (path.isEmpty()) {
         // The path is exactly the trash Current/checkpoint directory itself
-        // (e.g. /user/alice/.Trash/Current). There are no mount points under
-        // it in the RBF sense, so return null to allow operations such as
-        // recursive delete to proceed normally.
-        return null;
+        // (e.g. /user/alice/.Trash/Current). Use "/" so the subMap covers all
+        // mount points, letting the router fan out to every sub-cluster for
+        // operations like listStatus on the trash root.
+        path = "/";
       }
     }
     readLock.lock();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -363,6 +363,51 @@ public class TestRouterTrash {
         "/.Trash/Current"));
   }
 
+  /**
+   * Test that deleting .Trash/Current and .Trash/checkpoint directories
+   * via the router works correctly (HDFS-17842).
+   * Before the fix, getMountPoints() on a trash-current path would incorrectly
+   * return all mount points after subtracting the trash prefix down to an
+   * empty string, causing AccessControlException in delete().
+   */
+  @Test
+  public void testDeleteTrashCurrentAndCheckpoint() throws Exception {
+    MountTable addEntry = MountTable.newInstance(MOUNT_POINT,
+        Collections.singletonMap(ns0, MOUNT_POINT));
+    assertTrue(addMountTable(addEntry));
+
+    DFSClient client = nnContext.getClient();
+    client.setOwner("/", TEST_USER, TEST_USER);
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(TEST_USER);
+
+    client = nnContext.getClient(ugi);
+    client.mkdirs(MOUNT_POINT, new FsPermission("777"), true);
+    client.create(FILE, true);
+
+    Configuration routerConf = routerContext.getConf();
+    FileSystem fs = DFSTestUtil.getFileSystemAs(ugi, routerConf);
+    Trash trash = new Trash(fs, routerConf);
+    assertTrue(trash.moveToTrash(new Path(FILE)));
+
+    // Verify the file is in .Trash/Current
+    Path trashCurrentPath = new Path(TRASH_ROOT + CURRENT);
+    assertTrue(fs.exists(trashCurrentPath));
+
+    // Deleting .Trash/Current should succeed (HDFS-17842)
+    assertTrue(fs.delete(trashCurrentPath, true));
+    assertFalse(fs.exists(trashCurrentPath));
+
+    // Re-create a file and move to trash again
+    client.create(FILE, true);
+    assertTrue(trash.moveToTrash(new Path(FILE)));
+    assertTrue(fs.exists(trashCurrentPath));
+
+    // Deleting .Trash itself should also succeed
+    Path trashRootPath = new Path(TRASH_ROOT);
+    assertTrue(fs.delete(trashRootPath, true));
+    assertFalse(fs.exists(trashRootPath));
+  }
+
   @Test
   public void testSubtractTrashCurrentPath() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -133,9 +133,11 @@ public class TestRouterTrash {
 
   @AfterEach
   public void clearFile() throws IOException {
-    FileStatus[] fileStatuses = nnFs.listStatus(new Path("/"));
-    for (FileStatus file : fileStatuses) {
+    for (FileStatus file : nnFs.listStatus(new Path("/"))) {
       nnFs.delete(file.getPath(), true);
+    }
+    for (FileStatus file : nnFs1.listStatus(new Path("/"))) {
+      nnFs1.delete(file.getPath(), true);
     }
   }
 


### PR DESCRIPTION
### Problem
After HDFS-17263, deleting `.Trash/Current/` or `.Trash/<checkpoint>/` via the RBF router fails with:

    The operation is not allowed because there are mount points: <mount-points> under the path: /user/alice/.Trash/Current

However, deleting `.Trash/` itself succeeds. The regression was introduced by HDFS-17263 which removed the trailing `/` from the `isTrashPath` regex pattern.

### Root Cause
`RouterClientProtocol.delete()` calls `getLocationsForPath(src, failIfLocked=true)`, which calls `MountTableResolver.getMountPoints(src)`. When `src` is a trash-current path like `/user/alice/.Trash/Current`, `getMountPoints` detects it as a trash path via `isTrashPath()`, subtracts the trash prefix via `subtractTrashCurrentPath()`, and gets an empty string `""`. The code then queries the mount table tree with `subMap("", ""+MAX_VALUE)`, which returns **all** mount table entries. `FileSubclusterResolver.getMountPoints("", allKeys)` therefore returns a non-null list of all mount point names, causing `getLocationsForPath` to throw `AccessControlException`.

Before HDFS-17263, `isTrashPath` required a trailing `/`, so `.Trash/Current` (without trailing slash) was not recognized as a trash path and `getMountPoints` would correctly look for mount points directly under `.Trash/Current` — finding none.

### Fix
In `MountTableResolver.getMountPoints()`, after applying `subtractTrashCurrentPath()`, if the resulting path is empty (meaning the input was exactly the trash Current or checkpoint directory with no sub-path), return `null` immediately. An empty result means the path is the trash checkpoint directory itself, which never hosts RBF mount points.

### Testing
Added `testDeleteTrashCurrentAndCheckpoint()` to `TestRouterTrash` which:
1. Moves a file to trash via the router
2. Verifies that `fs.delete(.Trash/Current, recursive=true)` succeeds
3. Verifies that `fs.delete(.Trash, recursive=true)` also succeeds

JIRA: https://issues.apache.org/jira/browse/HDFS-17842