### PR TITLE
HDFS-17850. Reject append when new generation stamp equals or is less…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1410,7 +1410,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       // The other reason is that an "append" is occurring to this block.
 
       // check the validity of the parameter
-      if (newGS < b.getGenerationStamp()) {
+      if (newGS <= b.getGenerationStamp()) {
         throw new IOException("The new generation stamp " + newGS +
             " should be greater than the replica " + b + "'s generation stamp");
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -2122,6 +2122,46 @@ public class TestFsDatasetImpl {
     }
   }
 
+  /**
+   * HDFS-17850: append() must reject newGS equal to or less than the replica's
+   * generation stamp to avoid corrupt replica state from misbehaving clients.
+   */
+  @Test
+  @Timeout(value = 30)
+  public void testAppendRejectsSameOrLowerGenerationStamp() throws Exception {
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    try {
+      cluster.waitActive();
+      BlockReaderTestUtil util = new BlockReaderTestUtil(cluster,
+          new HdfsConfiguration(conf));
+      Path path = new Path("/testFile");
+      util.writeFile(path, 1);
+      String bpid = cluster.getNameNode().getNamesystem().getBlockPoolId();
+      DataNode dn = cluster.getDataNodes().get(0);
+      FsDatasetImpl dnFSDataset = (FsDatasetImpl) dn.getFSDataset();
+      List<ReplicaInfo> replicaInfos = dnFSDataset.getFinalizedBlocks(bpid);
+      assertEquals(1, replicaInfos.size());
+      LocatedBlock blk = util.getFileBlocks(path, 512).get(0);
+      ExtendedBlock block = blk.getBlock();
+      long blockLen = replicaInfos.get(0).getNumBytes();
+
+      // newGS == current GS must throw
+      LambdaTestUtils.intercept(IOException.class, "should be greater than the replica",
+          () -> dnFSDataset.append(block, block.getGenerationStamp(), blockLen));
+
+      // newGS < current GS must throw
+      LambdaTestUtils.intercept(IOException.class, "should be greater than the replica",
+          () -> dnFSDataset.append(block, block.getGenerationStamp() - 1, blockLen));
+
+      // newGS > current GS must succeed
+      ReplicaHandler h = dnFSDataset.append(block, block.getGenerationStamp() + 1,
+          blockLen);
+      h.close();
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
   @Test
   @Timeout(value = 30)
   public void testAppend() {


### PR DESCRIPTION
### Summary

When using a third-party HDFS client, if the client does not update the generation stamp (GS) correctly on append, the DataNode previously accepted `newGS == currentGS`, which can lead to corrupted replica state. This change requires the new generation stamp to be **strictly greater** than the replica's current generation stamp: append now rejects both `newGS < currentGS` (existing) and `newGS == currentGS` (new), so misbehaving clients cannot silently corrupt replica state.

### Change

- **FsDatasetImpl.java**: In `append(ExtendedBlock b, long newGS, long expectedBlockLen)`, change the validity check from `newGS < b.getGenerationStamp()` to `newGS <= b.getGenerationStamp()`, so that equal generation stamps are also rejected with the same IOException message.
- **TestFsDatasetImpl.java**: Add `testAppendRejectsSameOrLowerGenerationStamp()`: create a file, get the finalized block, then assert that `append(block, block.getGenerationStamp(), blockLen)` and `append(block, block.getGenerationStamp() - 1, blockLen)` throw IOException with "should be greater than the replica", and that `append(block, block.getGenerationStamp() + 1, blockLen)` succeeds (HDFS-17850).

### JIRA

Fixes HDFS-17850

### For code changes:

- [x] The title starts with the corresponding JIRA issue ID.
- [ ] Object storage integration tests and endpoint declaration: Not applicable: this PR does not change an object-store connector.
- [x] No new dependencies are introduced.
- [x] No LICENSE or NOTICE updates are needed for this diff.

### AI Tooling

Contains content generated by Codex.

- [x] AI-generated content is disclosed.
- [x] Use follows https://www.apache.org/legal/generative-tooling.html.

### How was this patch tested?

Earlier commands above are historical evidence, where present. Current rebase validation passed `git diff --check`; fresh hosted CI is running. Focused Java validation is reported separately when complete.

### Validated repair head `bc2fe171` (2026-09-19)

`TestFsDatasetImpl#testAppendRejectsSameOrLowerGenerationStamp` passed: 1 test, 0 failures, 0 errors, 0 skipped. The selected reactor finished successfully in a Java 17/Maven 3.9.15 container with GNU stat and bounded memory (`MAVEN_OPTS=-Xmx1024m`, test heap 1536 MB).

`mvn -B -ntp -pl hadoop-hdfs-project/hadoop-hdfs -am -Dtest=TestFsDatasetImpl#testAppendRejectsSameOrLowerGenerationStamp -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false "-Dmaven-surefire-plugin.argLine=-Xmx1536m -Xss4m" test`

Full TestFsDatasetImpl class first attempt was killed by Docker OOM (exit137), narrowed to direct regression under bounded heap. Full-class success is not claimed.
