### PR TITLE
HDFS-17872. Propagate tolerancePercentage to DataNode in DiskBalancer…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/command/PlanCommand.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/command/PlanCommand.java
@@ -250,11 +250,16 @@ public class PlanCommand extends Command {
   }
 
   /**
-   * Sets user specified plan parameters.
+   * Sets user specified plan parameters (bandwidth, maxError, tolerancePercent).
+   * tolerancePercent is read from config so the plan propagated to the DataNode
+   * uses the same value (HDFS-17872).
    *
    * @param plans - list of plans.
    */
   private void setPlanParams(List<NodePlan> plans) {
+    int tolerancePercent = getConf().getInt(
+        DFSConfigKeys.DFS_DISK_BALANCER_BLOCK_TOLERANCE,
+        DFSConfigKeys.DFS_DISK_BALANCER_BLOCK_TOLERANCE_DEFAULT);
     for (NodePlan plan : plans) {
       for (Step step : plan.getVolumeSetPlans()) {
         if (this.bandwidth > 0) {
@@ -264,6 +269,10 @@ public class PlanCommand extends Command {
         if (this.maxError > 0) {
           LOG.debug("Setting max error to {}", this.maxError);
           step.setMaxDiskErrors(this.maxError);
+        }
+        if (tolerancePercent > 0) {
+          LOG.debug("Setting tolerance percent to {}", tolerancePercent);
+          step.setTolerancePercent(tolerancePercent);
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/planner/TestNodePlan.java
@@ -43,6 +43,29 @@ public class TestNodePlan {
     assertThat(NodePlan.parseJson(json)).isNotNull();
   }
 
+  /**
+   * HDFS-17872: Plan steps must carry tolerancePercent so the DataNode receives
+   * it. Verify serialization round-trip preserves tolerance percent.
+   */
+  @Test
+  public void testPlanStepTolerancePercentInJson() throws IOException {
+    NodePlan nodePlan = new NodePlan("datanode1", 50070);
+    MoveStep moveStep = new MoveStep();
+    moveStep.setBandwidth(100);
+    moveStep.setBytesToMove(1024);
+    moveStep.setIdealStorage(0.5);
+    moveStep.setMaxDiskErrors(5);
+    moveStep.setTolerancePercent(15);
+    moveStep.setVolumeSetID("volumeSetId");
+    nodePlan.addStep(moveStep);
+    String json = nodePlan.toJson();
+    NodePlan parsed = NodePlan.parseJson(json);
+    assertThat(parsed.getVolumeSetPlans()).hasSize(1);
+    assertThat(parsed.getVolumeSetPlans().get(0).getTolerancePercent())
+        .describedAs("tolerancePercent should be propagated in plan JSON")
+        .isEqualTo(15);
+  }
+
   @Test
   public void testNodePlanWithDisallowedStep() throws Exception {
     NodePlan nodePlan = new NodePlan("datanode1234", 1234);


### PR DESCRIPTION
### Summary

`dfs.disk.balancer.block.tolerance.percent` is documented and used on the DataNode when executing a plan, but the plan command did not set tolerance percentage on plan steps. So the value sent to the DataNode was effectively the step default (0) unless the DataNode fell back to its own config. This change reads the config in the plan command and sets `tolerancePercent` on each step so the plan propagated to the DataNode uses the same value.

### Change

- **PlanCommand.java**: In `setPlanParams()`, read `dfs.disk.balancer.block.tolerance.percent` from configuration (default 10) and call `step.setTolerancePercent(tolerancePercent)` for each step in each plan. So generated plans include tolerance and the DataNode receives it (it already uses `step.getTolerancePercent()` when building work items).
- **TestNodePlan.java**: Add `testPlanStepTolerancePercentInJson()`: build a NodePlan with a MoveStep that has `setTolerancePercent(15)`, serialize to JSON, parse back, and assert the step’s `getTolerancePercent()` is 15 (HDFS-17872).

### JIRA

Fixes HDFS-17872

### For code changes:

- [x] The title starts with the corresponding JIRA issue ID.
- [ ] Object storage integration tests and endpoint declaration: Not applicable: this PR does not change an object-store connector.
- [x] No new dependencies are introduced.
- [x] No LICENSE or NOTICE updates are needed for this diff.

### AI Tooling

Contains content generated by Codex.

- [x] AI-generated content is disclosed.
- [x] Use follows https://www.apache.org/legal/generative-tooling.html.

### How was this patch tested?

Earlier commands above are historical evidence, where present. Current rebase validation passed `git diff --check`; fresh hosted CI is running. Focused Java validation is reported separately when complete.

### Validated repair head `08c0451b` (2026-09-19)

The five `TestNodePlan` tests pass in a Java 17/Maven 3.9.15 container; these cover plan serialization and do not add a new end-to-end DiskBalancer proof.

`mvn -B -ntp -pl hadoop-hdfs-project/hadoop-hdfs -am -Dtest=TestNodePlan -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test`

The reactor completed successfully and Surefire reported 5 tests, 0 failures, 0 errors, 0 skipped. `git diff --check` also passes. Hosted CI for this head remains separate.
