### PR TITLE
HDFS-17876. Add null check for tracer in NameNode.stop() to avoid NPE…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1257,7 +1257,9 @@ public class NameNode extends ReconfigurableBase implements
       }
     }
     started.set(false);
-    tracer.close();
+    if (tracer != null) {
+      tracer.close();
+    }
   }
 
   synchronized boolean isStopRequested() {


### PR DESCRIPTION
## Summary

NameNode.stop() called tracer.close() without a null check. If the NameNode is stopped before tracer is initialized (e.g. exception in parent constructor, or stopAtException() during failed startup), this caused an NPE at line 1116 and obscured the original failure.

## Change

- **NameNode.java**: In stop(), guard tracer.close() with `if (tracer != null)` so shutdown completes without NPE when tracer was never set.
- **TestNameNodeReconfigure.java**: Added testStopWithNullTracerDoesNotThrow() which sets tracer to null via reflection and calls stop(); verifies no NPE (HDFS-17876).

## JIRA

Fixes HDFS-17876
