### PR TITLE
HDFS-17890. Avoid slow disks datanode when reading data

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -587,6 +587,14 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   // Whether to enable datanode's stale state detection and usage for writes
   public static final String DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_WRITE_KEY = "dfs.namenode.avoid.write.stale.datanode";
   public static final boolean DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_WRITE_DEFAULT = false;
+  // Slow disk cache rebuild interval
+  public static final String DFS_NAMENODE_SLOW_DISK_CACHE_REBUILD_INTERVAL_KEY =
+          "dfs.namenode.slow.disk.cache.rebuild.interval";
+  public static final String DFS_NAMENODE_SLOW_DISK_CACHE_REBUILD_INTERVAL_DEFAULT = "30s";
+  // Whether to deprioritize slow disk datanodes when returning block locations
+  public static final String DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_KEY =
+          "dfs.namenode.deprioritize.slow.disk.datanode.for.read";
+  public static final boolean DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_DEFAULT = false;
   // enable and disable logging datanode staleness. Disabled by default.
   public static final String DFS_NAMENODE_ENABLE_LOG_STALE_DATANODE_KEY =
       "dfs.namenode.enable.log.stale.datanode";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/SlowDiskTracker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/SlowDiskTracker.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Map;
@@ -80,9 +82,17 @@ public class SlowDiskTracker {
   private final int maxDisksToReport;
   private static final String DATANODE_DISK_SEPARATOR = ":";
   private final long reportGenerationIntervalMs;
+  private final long cacheRebuildIntervalMs;
+  // Whether slow-disk read-path deprioritization is enabled. The read cache
+  // (cachedSlowDisksForRead) is only consumed by the read path when this is
+  // true, so rebuilding it is skipped when the feature is disabled to avoid
+  // spawning an async thread on every heartbeat for nothing.
+  private final boolean deprioritizeEnabled;
 
   private volatile long lastUpdateTime;
+  private volatile long lastCacheRebuildTime;
   private AtomicBoolean isUpdateInProgress = new AtomicBoolean(false);
+  private AtomicBoolean isCacheRebuildInProgress = new AtomicBoolean(false);
 
   /**
    * Information about disks that have been reported as being slow.
@@ -91,6 +101,17 @@ public class SlowDiskTracker {
    * was received.
    */
   private final Map<String, DiskLatency> diskIDLatencyMap;
+
+    /**
+     * Cached slow disk map for efficient read path lookup.
+     *
+     * <p>Key format: {@code IP:PORT:StorageID}.
+     *
+     * <p>Uses a copy-on-write strategy: heartbeat processing only updates
+     * {@code diskIDLatencyMap}; an async thread periodically rebuilds this cache
+     * and atomically swaps the reference.
+     */
+  private volatile Map<String, Double> cachedSlowDisksForRead = Collections.emptyMap();
 
   /**
    * Map of slow disk -> diskOperations it has been reported slow in.
@@ -102,6 +123,7 @@ public class SlowDiskTracker {
   public SlowDiskTracker(Configuration conf, Timer timer) {
     this.timer = timer;
     this.lastUpdateTime = timer.monotonicNow();
+    this.lastCacheRebuildTime = timer.monotonicNow();
     this.diskIDLatencyMap = new ConcurrentHashMap<>();
     this.reportGenerationIntervalMs = conf.getTimeDuration(
         DFSConfigKeys.DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY,
@@ -111,6 +133,23 @@ public class SlowDiskTracker {
         DFSConfigKeys.DFS_DATANODE_MAX_DISKS_TO_REPORT_KEY,
         DFSConfigKeys.DFS_DATANODE_MAX_DISKS_TO_REPORT_DEFAULT);
     this.reportValidityMs = reportGenerationIntervalMs * 3;
+    this.cacheRebuildIntervalMs = conf.getTimeDuration(
+            DFSConfigKeys.DFS_NAMENODE_SLOW_DISK_CACHE_REBUILD_INTERVAL_KEY,
+            DFSConfigKeys.DFS_NAMENODE_SLOW_DISK_CACHE_REBUILD_INTERVAL_DEFAULT,
+            TimeUnit.MILLISECONDS);
+    this.deprioritizeEnabled = conf.getBoolean(
+            DFSConfigKeys.DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_KEY,
+            DFSConfigKeys.DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_DEFAULT);
+
+  }
+
+  /**
+   * Get all valid slow disks for read path lookup.
+   *
+   * @return cached slow disk map with key format "IP:PORT:StorageID"
+   */
+  public Map<String, Double> getAllValidSlowDisks() {
+    return cachedSlowDisksForRead;
   }
 
   @VisibleForTesting
@@ -140,11 +179,66 @@ public class SlowDiskTracker {
 
   }
 
+  /**
+   * Extraction mode for slow disk key formatting.
+   */
+  private enum KeyExtractMode {
+    CACHE_KEY,
+    LEGACY_KEY
+  }
+
+  /**
+   * Extract a formatted key from a slow disk ID.
+   *
+   * <p>The slowDiskID format is "IP:PORT:volumeName|storageID".
+   * CACHE_KEY mode returns "IP:PORT:StorageID" (null if parse fails).
+   * LEGACY_KEY mode returns "IP:PORT:volumeName" (original if parse fails).
+   *
+   * <p>Parsing anchors on the '|' separator (unique in the format) then
+   * scans backwards to the ':' that delimits IP:PORT from the disk info.
+   * This avoids mis-parsing when the volume path contains ':' characters.</p>
+   */
+  private static String extractDiskKey(String slowDiskID, KeyExtractMode mode) {
+    if (slowDiskID == null || slowDiskID.isEmpty()) {
+      return mode == KeyExtractMode.CACHE_KEY ? null : slowDiskID;
+    }
+
+    int pipeIndex = slowDiskID.indexOf('|');
+    if (pipeIndex < 0) {
+      return mode == KeyExtractMode.CACHE_KEY ? null : slowDiskID;
+    }
+
+    // Find the ':' before volumeName by scanning backwards from '|'.
+    // Format: "IP:PORT:volumeName|storageID"
+    //                  ^-- this colon separates addr from disk info
+    int colonBeforeVolume = slowDiskID.lastIndexOf(':', pipeIndex);
+    if (colonBeforeVolume <= 0 || colonBeforeVolume >= pipeIndex) {
+      return mode == KeyExtractMode.CACHE_KEY ? null : slowDiskID;
+    }
+
+    String datanodeAddr = slowDiskID.substring(0, colonBeforeVolume);
+
+    if (mode == KeyExtractMode.CACHE_KEY) {
+      if (pipeIndex >= slowDiskID.length() - 1) {
+        return null;
+      }
+      String storageID = slowDiskID.substring(pipeIndex + 1);
+      return datanodeAddr + ":" + storageID;
+    } else {
+      String volumeName = slowDiskID.substring(colonBeforeVolume + 1, pipeIndex);
+      return datanodeAddr + ":" + volumeName;
+    }
+  }
+
   public void checkAndUpdateReportIfNecessary() {
     // Check if it is time for update
     long now = timer.monotonicNow();
     if (now - lastUpdateTime > reportGenerationIntervalMs) {
       updateSlowDiskReportAsync(now);
+    }
+    if (deprioritizeEnabled
+        && now - lastCacheRebuildTime > cacheRebuildIntervalMs) {
+      rebuildSlowDiskCacheAsync(now);
     }
   }
 
@@ -164,6 +258,52 @@ public class SlowDiskTracker {
         }
       }).start();
     }
+  }
+
+  /**
+   * Asynchronously rebuild the slow disk cache.
+   */
+  private void rebuildSlowDiskCacheAsync(long now) {
+    if (isCacheRebuildInProgress.compareAndSet(false, true)) {
+      lastCacheRebuildTime = now;
+      new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            rebuildSlowDiskCache();
+          } finally {
+            isCacheRebuildInProgress.set(false);
+          }
+        }
+      }).start();
+    }
+  }
+
+  /**
+   * Rebuild the slow disk cache in full (called in an async thread).
+   * Uses a fresh timestamp to avoid stale expiry decisions caused by
+   * thread scheduling delays.
+   */
+  private void rebuildSlowDiskCache() {
+    long now = timer.monotonicNow();
+    Map<String, Double> newCache = new HashMap<>();
+
+    for (Map.Entry<String, DiskLatency> entry : diskIDLatencyMap.entrySet()) {
+      DiskLatency diskLatency = entry.getValue();
+
+      if (now - diskLatency.timestamp >= reportValidityMs) {
+        continue;
+      }
+
+      String cacheKey = extractDiskKey(entry.getKey(), KeyExtractMode.CACHE_KEY);
+      if (cacheKey != null) {
+        newCache.put(cacheKey, diskLatency.getReadLatency());
+      }
+    }
+
+    cachedSlowDisksForRead = newCache;
+
+    LOG.debug("Rebuilt slow disk cache: {} valid slow disks", newCache.size());
   }
 
   /**
@@ -210,6 +350,16 @@ public class SlowDiskTracker {
 
     Double getLatency(DiskOp op) {
       return this.latencyMap.get(op);
+    }
+
+    /**
+     * Return the READ latency if reported, otherwise fall back to max latency.
+     * This is used by the read path cache so that sorting reflects the
+     * operation the client actually cares about.
+     */
+    double getReadLatency() {
+      Double readLatency = latencyMap.get(DiskOp.READ);
+      return readLatency != null ? readLatency : getMaxLatency();
     }
   }
 
@@ -266,7 +416,15 @@ public class SlowDiskTracker {
       if (slowDisksReport.isEmpty()) {
         return null;
       }
-      return WRITER.writeValueAsString(slowDisksReport);
+      // Transform slowDiskID to legacy format (IP:PORT:volumeName)
+      // for backward compatibility with existing JSON consumers.
+      ArrayList<DiskLatency> reportForJson = Lists.newArrayList();
+      for (DiskLatency dl : slowDisksReport) {
+        String legacyID = extractDiskKey(dl.getSlowDiskID(),
+            KeyExtractMode.LEGACY_KEY);
+        reportForJson.add(new DiskLatency(legacyID, dl.latencyMap));
+      }
+      return WRITER.writeValueAsString(reportForJson);
     } catch (JsonProcessingException e) {
       // Failed to serialize. Don't log the exception call stack.
       LOG.debug("Failed to serialize statistics" + e);
@@ -285,17 +443,17 @@ public class SlowDiskTracker {
   }
 
   @VisibleForTesting
-  ArrayList<DiskLatency> getSlowDisksReport() {
+  public ArrayList<DiskLatency> getSlowDisksReport() {
     return this.slowDisksReport;
   }
 
   @VisibleForTesting
-  long getReportValidityMs() {
+  public long getReportValidityMs() {
     return reportValidityMs;
   }
 
   @VisibleForTesting
-  void setReportValidityMs(long reportValidityMs) {
+  public void setReportValidityMs(long reportValidityMs) {
     this.reportValidityMs = reportValidityMs;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeDiskMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeDiskMetrics.java
@@ -122,7 +122,8 @@ public class DataNodeDiskMetrics {
               while (volumeIterator.hasNext()) {
                 FsVolumeSpi volume = volumeIterator.next();
                 DataNodeVolumeMetrics metrics = volume.getMetrics();
-                String volumeName = volume.getBaseURI().getPath();
+                String storageID = volume.getStorageID();
+                String volumeName = volume.getBaseURI().getPath()+ "|" + storageID;
 
                 metadataOpStats.put(volumeName,
                     metrics.getMetadataOperationMean());
@@ -159,7 +160,13 @@ public class DataNodeDiskMetrics {
                   -> Double.compare(o2.getMaxLatency(), o1.getMaxLatency()));
 
               slowDisksToExclude = diskLatencies.stream().limit(maxSlowDisksToExclude)
-                  .map(DiskLatency::getSlowDisk).collect(Collectors.toList());
+                  .map(dl -> {
+                    // Extract pure volume path for FsVolumeList comparison.
+                    // diskKey format: "volumePath|storageID"
+                    String disk = dl.getSlowDisk();
+                    int pipeIdx = disk.indexOf('|');
+                    return pipeIdx >= 0 ? disk.substring(0, pipeIdx) : disk;
+                  }).collect(Collectors.toList());
             }
           }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -98,6 +98,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_REPLICATION_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_REPLICATION_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LISTING_LIMIT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LISTING_LIMIT_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSUtil.isParentEntry;
 
 import java.lang.reflect.Constructor;
@@ -121,6 +123,7 @@ import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState.OBSERVER;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
 
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoStriped;
+import org.apache.hadoop.hdfs.server.blockmanagement.SlowDiskTracker;
 import org.apache.hadoop.hdfs.server.namenode.fgl.FSNLockManager;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotDeletionGc;
@@ -511,6 +514,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   private final boolean isPermissionEnabled;
   private final boolean isStoragePolicyEnabled;
   private final boolean isStoragePolicySuperuserOnly;
+  private final boolean deprioritizeSlowDiskDatanodeForRead;
   private final UserGroupInformation fsOwner;
   private final String supergroup;
   private final boolean standbyShouldCheckpoint;
@@ -912,6 +916,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       this.isStoragePolicySuperuserOnly =
           conf.getBoolean(DFS_STORAGE_POLICY_PERMISSIONS_SUPERUSER_ONLY_KEY,
               DFS_STORAGE_POLICY_PERMISSIONS_SUPERUSER_ONLY_DEFAULT);
+
+      this.deprioritizeSlowDiskDatanodeForRead =
+              conf.getBoolean(DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_KEY,
+                      DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_DEFAULT);
 
       this.snapshotDiffReportLimit =
           conf.getInt(DFS_NAMENODE_SNAPSHOT_DIFF_LISTING_LIMIT,
@@ -2309,7 +2317,103 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
     LocatedBlocks blocks = res.blocks;
     sortLocatedBlocks(clientMachine, blocks);
+
+    // Whether to demote and reorder slow-disk DataNodes depends on the configuration
+    if (deprioritizeSlowDiskDatanodeForRead) {
+      sortLocatedBlocksBySlowDisk(blocks);
+    }
+
     return blocks;
+  }
+
+  /**
+   * Sort LocatedBlocks by slow disk info, moving slow replicas
+   * to the end. This sorting is performed after the network
+   * topology sorting, preserving the topology order of normal
+   * replicas.
+   */
+  private void sortLocatedBlocksBySlowDisk(LocatedBlocks blocks) {
+    if (blocks == null) {
+      return;
+    }
+
+    SlowDiskTracker slowDiskTracker = blockManager.getDatanodeManager()
+        .getSlowDiskTracker();
+    if (slowDiskTracker == null) {
+      return;
+    }
+    Map<String, Double> slowDiskMap = slowDiskTracker.getAllValidSlowDisks();
+
+    if (slowDiskMap.isEmpty()) {
+      return;
+    }
+
+    for (LocatedBlock lb : blocks.getLocatedBlocks()) {
+      // Skip erasure coded blocks: reordering locations without updating
+      // blockIndices and blockTokens would cause data corruption.
+      if (lb instanceof LocatedStripedBlock) {
+        continue;
+      }
+
+      DatanodeInfo[] dnList = lb.getLocations();
+      String[] storageIDs = lb.getStorageIDs();
+
+      if (dnList == null || dnList.length <= 1 || storageIDs == null) {
+        continue;
+      }
+
+      // Use an index array for stable sorting to maintain network topology order
+      Integer[] indices = new Integer[dnList.length];
+      for (int i = 0; i < dnList.length; i++) {
+        indices[i] = i;
+      }
+
+      // Pre-calculate the slow disk key to avoid repeatedly concatenating strings during sorting
+      String[] slowKeys = new String[dnList.length];
+      for (int i = 0; i < dnList.length; i++) {
+        slowKeys[i] = dnList[i].getIpcAddr(false) + ":" + storageIDs[i];
+      }
+
+      Arrays.sort(indices, (i1, i2) -> {
+        String slowKey1 = slowKeys[i1];
+        String slowKey2 = slowKeys[i2];
+
+        boolean slow1 = slowDiskMap.containsKey(slowKey1);
+        boolean slow2 = slowDiskMap.containsKey(slowKey2);
+
+        if (slow1 && !slow2) {
+          return 1;
+        }
+        if (!slow1 && slow2) {
+          return -1;
+        }
+
+        // If all disks are slow disks, sort them by latency
+        if (slow1 && slow2) {
+          Double latency1 = slowDiskMap.get(slowKey1);
+          Double latency2 = slowDiskMap.get(slowKey2);
+          if (latency1 != null && latency2 != null) {
+            return Double.compare(latency1, latency2);
+          }
+        }
+
+        // Maintain the original order (network topology)
+        return Integer.compare(i1, i2);
+      });
+
+      DatanodeInfo[] sortedDN = new DatanodeInfo[dnList.length];
+      String[] sortedStorage = new String[storageIDs.length];
+
+      for (int i = 0; i < indices.length; i++) {
+        sortedDN[i] = dnList[indices[i]];
+        sortedStorage[i] = storageIDs[indices[i]];
+      }
+
+      System.arraycopy(sortedDN, 0, dnList, 0, dnList.length);
+      System.arraycopy(sortedStorage, 0, storageIDs, 0, storageIDs.length);
+
+      lb.updateCachedStorageInfo();
+    }
   }
 
   private void sortLocatedBlocks(String clientMachine, LocatedBlocks blocks) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2411,6 +2411,29 @@
 </property>
 
 <property>
+  <name>dfs.namenode.deprioritize.slow.disk.datanode.for.read</name>
+  <value>false</value>
+  <description>
+    If true, the NameNode will deprioritize slow disk replicas when returning block
+    locations to clients. This tracks slow storage at the disk (StorageID) level rather
+    than the DataNode level, allowing fine-grained read optimization. Slow disks are
+    detected via DataNode heartbeat reports and cached for efficient read path lookup.
+  </description>
+</property>
+
+<property>
+  <name>dfs.namenode.slow.disk.cache.rebuild.interval</name>
+  <value>30s</value>
+  <description>
+    Interval at which the slow disk cache is rebuilt on the NameNode. This setting supports
+    multiple time unit suffixes as described in dfs.heartbeat.interval. If no suffix is
+    specified then milliseconds is assumed. This is independent of the Top-N slow disk report
+    generation interval, allowing separate tuning for cache performance vs. reporting frequency.
+    It is ignored if dfs.namenode.deprioritize.slow.disk.datanode.for.read is false.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.metrics.logger.period.seconds</name>
   <value>600</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSlowDiskBlockLocations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSlowDiskBlockLocations.java
@@ -1,0 +1,536 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.server.blockmanagement.SlowDiskTracker;
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests LocatedBlock sorting logic under slow disk scenarios.
+ * Verifies that replicas on slow disks are moved to the end of the location
+ * list so that clients prefer reading from faster storage.
+ */
+public class TestSlowDiskBlockLocations {
+
+  private static final long OUTLIERS_REPORT_INTERVAL = 1000;
+  private static final int BLOCK_SIZE = 1024 * 1024; // 1MB
+  private static final int FILE_SIZE = 3 * BLOCK_SIZE; // 3 blocks
+  private static final short REPLICATION = 3;
+
+  private Configuration conf;
+  private MiniDFSCluster cluster;
+  private DistributedFileSystem dfs;
+  private NameNode nameNode;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    conf = new HdfsConfiguration();
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    conf.setLong(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1L);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY, 100);
+    conf.setTimeDuration(DFSConfigKeys.DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY,
+        OUTLIERS_REPORT_INTERVAL, TimeUnit.MILLISECONDS);
+    // Configure a short cache rebuild interval for testing
+    conf.setTimeDuration(DFSConfigKeys.DFS_NAMENODE_SLOW_DISK_CACHE_REBUILD_INTERVAL_KEY,
+        OUTLIERS_REPORT_INTERVAL, TimeUnit.MILLISECONDS);
+    // Enable slow disk deprioritization sorting
+    conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_DEPRIORITIZE_SLOW_DISK_DATANODE_FOR_READ_KEY, true);
+
+    // Create a cluster with 3 DataNodes
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(3)
+        .build();
+    cluster.waitActive();
+
+    dfs = cluster.getFileSystem();
+    nameNode = cluster.getNameNode();
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  /**
+   * Test scenario 1: Verify that a slow disk DataNode is moved to the end
+   * of the replica location list.
+   */
+  @Test
+  @Timeout(60)
+  public void testSlowDiskDataNodeMovedToEnd() throws Exception {
+    // 1. Create a test file with multiple replicas
+    Path testFile = new Path("/testSlowDisk");
+    DFSTestUtil.createFile(dfs, testFile, FILE_SIZE, REPLICATION, 0L);
+    DFSTestUtil.waitForReplication(dfs, testFile, REPLICATION, 30000);
+
+    // 2. Get the SlowDiskTracker and extend report validity
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+    slowDiskTracker.setReportValidityMs(OUTLIERS_REPORT_INTERVAL * 100);
+
+    // 3. Report a slow disk on the first DataNode
+    DataNode slowDn = cluster.getDataNodes().get(0);
+    String slowDnIpcAddr = slowDn.getDatanodeId().getIpcAddr(false);
+
+    // Get the full disk key (volumeName|storageID) of the first volume
+    String diskKey = getFirstDiskKey(slowDn);
+    assertNotNull(diskKey, "Disk key should not be null");
+
+    // Simulate slow disk report using the full disk key (volumeName|storageID)
+    slowDn.getDiskMetrics().addSlowDiskForTesting(diskKey,
+        ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 2.5));
+
+    // 4. Wait for the NameNode to receive the slow disk report
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return !slowDiskTracker.getSlowDisksReport().isEmpty();
+      }
+    }, 1000, 10000);
+
+    // 5. Get block locations and verify sorting result
+    LocatedBlocks locsAfter = NameNodeAdapter.getBlockLocations(nameNode,
+        testFile.toString(), 0, FILE_SIZE);
+    List<LocatedBlock> blocksAfter = locsAfter.getLocatedBlocks();
+    assertFalse(blocksAfter.isEmpty(),
+        "Should have at least one block");
+
+    LocatedBlock firstBlockAfter = blocksAfter.get(0);
+    DatanodeInfo[] dnsAfter = firstBlockAfter.getLocations();
+    assertEquals(REPLICATION, dnsAfter.length,
+        "Should have 3 replicas");
+
+    // 6. Verify: slow disk DataNode should be at the last position
+    assertEquals(slowDnIpcAddr,
+        dnsAfter[dnsAfter.length - 1].getIpcAddr(false),
+        "Slow disk DataNode should be at the last position");
+
+    // 7. Verify slow disk DataNode is not in any earlier position
+    for (int i = 0; i < dnsAfter.length - 1; i++) {
+      assertNotEquals(slowDnIpcAddr, dnsAfter[i].getIpcAddr(false),
+          "Slow disk DataNode should not be at position " + i);
+    }
+  }
+
+  /**
+   * Helper method: Get the full disk key (volumeName|storageID) of the first
+   * volume on the given DataNode.
+   */
+  private String getFirstDiskKey(DataNode dn) throws Exception {
+    try (org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi
+            .FsVolumeReferences refs =
+                dn.getFSDataset().getFsVolumeReferences()) {
+      if (refs != null && refs.size() > 0) {
+        String volumeName = refs.get(0).getBaseURI().getPath();
+        String storageID = refs.get(0).getStorageID();
+        return volumeName + "|" + storageID;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Test scenario 2: Verify handling when multiple DataNodes have slow disks.
+   */
+  @Test
+  @Timeout(60)
+  public void testMultipleSlowDiskDataNodes() throws Exception {
+    // 1. Create a test file
+    Path testFile = new Path("/testMultipleSlowDisks");
+    DFSTestUtil.createFile(dfs, testFile, FILE_SIZE, REPLICATION, 0L);
+    DFSTestUtil.waitForReplication(dfs, testFile, REPLICATION, 30000);
+
+    // 2. Configure SlowDiskTracker
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+    slowDiskTracker.setReportValidityMs(OUTLIERS_REPORT_INTERVAL * 100);
+
+    // 3. Report slow disks on the first two DataNodes
+    DataNode slowDn1 = cluster.getDataNodes().get(0);
+    DataNode slowDn2 = cluster.getDataNodes().get(1);
+    DataNode normalDn = cluster.getDataNodes().get(2);
+
+    String slowDnAddr1 = slowDn1.getDatanodeId().getIpcAddr(false);
+    String slowDnAddr2 = slowDn2.getDatanodeId().getIpcAddr(false);
+    String normalDnAddr = normalDn.getDatanodeId().getIpcAddr(false);
+
+    String diskKey1 = getFirstDiskKey(slowDn1);
+    String diskKey2 = getFirstDiskKey(slowDn2);
+
+    slowDn1.getDiskMetrics().addSlowDiskForTesting(diskKey1,
+        ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 2.5));
+    slowDn2.getDiskMetrics().addSlowDiskForTesting(diskKey2,
+        ImmutableMap.of(SlowDiskReports.DiskOp.READ, 3.0));
+
+    // 4. Wait for slow disk reports
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return slowDiskTracker.getSlowDisksReport().size() >= 2;
+      }
+    }, 1000, 10000);
+
+    // 5. Get block locations
+    LocatedBlocks locs = NameNodeAdapter.getBlockLocations(nameNode,
+        testFile.toString(), 0, FILE_SIZE);
+    DatanodeInfo[] dns = locs.getLocatedBlocks().get(0).getLocations();
+
+    // 6. Verify normal DataNode is not at the last position
+    assertNotEquals(normalDnAddr,
+        dns[dns.length - 1].getIpcAddr(false),
+        "Normal DataNode should not be at the last position");
+
+    // 7. Verify the last two positions are slow disk DataNodes
+    Set<String> lastTwoAddrs = new HashSet<>();
+    lastTwoAddrs.add(dns[1].getIpcAddr(false));
+    lastTwoAddrs.add(dns[2].getIpcAddr(false));
+
+    assertTrue(lastTwoAddrs.contains(slowDnAddr1),
+        "Last two should contain slowDn1");
+    assertTrue(lastTwoAddrs.contains(slowDnAddr2),
+        "Last two should contain slowDn2");
+  }
+
+  /**
+   * Test scenario 3: Verify handling when all DataNodes have slow disks.
+   */
+  @Test
+  @Timeout(60)
+  public void testAllSlowDiskDataNodes() throws Exception {
+    // 1. Create a test file
+    Path testFile = new Path("/testAllSlowDisks");
+    DFSTestUtil.createFile(dfs, testFile, FILE_SIZE, REPLICATION, 0L);
+    DFSTestUtil.waitForReplication(dfs, testFile, REPLICATION, 30000);
+
+    // 2. Configure SlowDiskTracker
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+    slowDiskTracker.setReportValidityMs(OUTLIERS_REPORT_INTERVAL * 100);
+
+    // 3. Report slow disks on all DataNodes
+    for (int i = 0; i < 3; i++) {
+      DataNode dn = cluster.getDataNodes().get(i);
+      String diskKey = getFirstDiskKey(dn);
+      dn.getDiskMetrics().addSlowDiskForTesting(diskKey,
+          ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 2.0 + i * 0.5));
+    }
+
+    // 4. Wait for slow disk reports
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return slowDiskTracker.getSlowDisksReport().size() >= 3;
+      }
+    }, 1000, 10000);
+
+    // 5. Get block locations
+    LocatedBlocks locs = NameNodeAdapter.getBlockLocations(nameNode,
+        testFile.toString(), 0, FILE_SIZE);
+    DatanodeInfo[] dns = locs.getLocatedBlocks().get(0).getLocations();
+
+    // 6. Verify all replicas are still returned
+    assertEquals(REPLICATION, dns.length,
+        "Should still return 3 replicas");
+  }
+
+  /**
+   * Test scenario 4: Verify the slow disk cache rebuild mechanism.
+   */
+  @Test
+  @Timeout(60)
+  public void testSlowDiskCacheRebuild() throws Exception {
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+    slowDiskTracker.setReportValidityMs(OUTLIERS_REPORT_INTERVAL * 10);
+
+    // 1. Report a slow disk on the first DataNode
+    DataNode slowDn = cluster.getDataNodes().get(0);
+    String diskKey = getFirstDiskKey(slowDn);
+    slowDn.getDiskMetrics().addSlowDiskForTesting(diskKey,
+        ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 3.0));
+
+    // 2. Wait for heartbeat to deliver data to SlowDiskTracker
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    // Wait for data to reach diskIDLatencyMap
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return !slowDiskTracker.getSlowDisksReport().isEmpty();
+      }
+    }, 500, 10000);
+
+    // Manually trigger cache rebuild
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(500);
+
+    // 3. Verify cache contains the slow disk
+    Map<String, Double> cache1 = slowDiskTracker.getAllValidSlowDisks();
+    assertFalse(cache1.isEmpty(),
+        "Cache should contain slow disks");
+
+    // Extract storageID to build expected cache key
+    String storageID = diskKey.substring(diskKey.indexOf('|') + 1);
+    String expectedCacheKey = slowDn.getDatanodeId().getIpcAddr(false)
+        + ":" + storageID;
+    assertTrue(cache1.containsKey(expectedCacheKey),
+        "Cache should contain the slow disk key");
+
+    // 4. Clear slow disk report (simulate disk recovery)
+    slowDn.getDiskMetrics().getDiskOutliersStats().remove(diskKey);
+
+    // 5. Wait for cache rebuild (entry should still be within validity period)
+    // Ensure we exceed cacheRebuildIntervalMs (1000ms); using > comparison
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL * 2);
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(1000);
+
+    Map<String, Double> cache2 = slowDiskTracker.getAllValidSlowDisks();
+    assertTrue(cache2.containsKey(expectedCacheKey),
+        "Cache should still contain the slow disk (not yet expired)");
+
+    // 6. Wait for expiration
+    slowDiskTracker.setReportValidityMs(100); // Set a very short validity
+    // Wait beyond reportValidityMs(100ms) + cacheRebuildIntervalMs(1000ms)
+    Thread.sleep(1500);
+
+    // Trigger cache rebuild
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(1000);
+
+    Map<String, Double> cache3 = slowDiskTracker.getAllValidSlowDisks();
+    assertFalse(cache3.containsKey(expectedCacheKey),
+        "Cache should no longer contain the expired slow disk");
+  }
+
+  /**
+   * Test scenario 5: Verify the slow disk expiration mechanism.
+   */
+  @Test
+  @Timeout(60)
+  public void testSlowDiskExpiration() throws Exception {
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+
+    // Set a short validity period for testing
+    long shortValidityMs = 2000; // 2 seconds
+    slowDiskTracker.setReportValidityMs(shortValidityMs);
+
+    // 1. Report the first slow disk
+    DataNode slowDn1 = cluster.getDataNodes().get(0);
+    DataNode slowDn2 = cluster.getDataNodes().get(1);
+
+    String diskKey1 = getFirstDiskKey(slowDn1);
+    String diskKey2 = getFirstDiskKey(slowDn2);
+
+    slowDn1.getDiskMetrics().addSlowDiskForTesting(diskKey1,
+        ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 2.5));
+
+    // 2. Wait for heartbeat to deliver data to SlowDiskTracker
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    // Wait for data to reach diskIDLatencyMap
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return !slowDiskTracker.getSlowDisksReport().isEmpty();
+      }
+    }, 500, 10000);
+
+    // Trigger cache rebuild
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(500);
+
+    Map<String, Double> cache1 = slowDiskTracker.getAllValidSlowDisks();
+    int initialSize = cache1.size();
+    assertTrue(initialSize > 0,
+        "Should have at least one slow disk");
+
+    // 3. Immediately add the second slow disk
+    slowDn2.getDiskMetrics().addSlowDiskForTesting(diskKey2,
+        ImmutableMap.of(SlowDiskReports.DiskOp.READ, 3.0));
+
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    // Wait for the second slow disk data to arrive
+    final int expectedSize = initialSize + 1;
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return slowDiskTracker.getSlowDisksReport().size() >= expectedSize;
+      }
+    }, 500, 10000);
+
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(500);
+
+    Map<String, Double> cache2 = slowDiskTracker.getAllValidSlowDisks();
+    assertTrue(cache2.size() >= expectedSize,
+        "Cache size should have increased");
+
+    // 4. Clear slow disk reports to stop heartbeat timestamp refreshes.
+    // Must completely remove the key; setting to null leaves the key
+    // with an empty Map, and the DataNode outlier detector could still
+    // re-detect and re-report the disk.
+    slowDn1.getDiskMetrics().getDiskOutliersStats().remove(diskKey1);
+    slowDn2.getDiskMetrics().getDiskOutliersStats().remove(diskKey2);
+
+    // 5. Wait for slow disk expiration (2s validity)
+    Thread.sleep(2500); // Ensure we exceed validityMs
+
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(1000);
+
+    Map<String, Double> cache3 = slowDiskTracker.getAllValidSlowDisks();
+
+    // Both slow disks should have expired since reports were cleared
+    String storageID1 = diskKey1.substring(diskKey1.indexOf('|') + 1);
+    String storageID2 = diskKey2.substring(diskKey2.indexOf('|') + 1);
+    String cacheKey1 = slowDn1.getDatanodeId().getIpcAddr(false)
+        + ":" + storageID1;
+    String cacheKey2 = slowDn2.getDatanodeId().getIpcAddr(false)
+        + ":" + storageID2;
+
+    assertFalse(cache3.containsKey(cacheKey1),
+        "Slow disk 1 should have expired");
+    assertFalse(cache3.containsKey(cacheKey2),
+        "Slow disk 2 should have expired");
+    assertTrue(cache3.isEmpty(),
+        "All slow disks should have expired");
+  }
+
+  /**
+   * Test scenario 6: Verify cache integration with the read path.
+   */
+  @Test
+  @Timeout(60)
+  public void testCacheIntegrationWithReadPath() throws Exception {
+    // 1. Create a test file
+    Path testFile = new Path("/testCacheIntegration");
+    DFSTestUtil.createFile(dfs, testFile, FILE_SIZE, REPLICATION, 0L);
+    DFSTestUtil.waitForReplication(dfs, testFile, REPLICATION, 30000);
+
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+    slowDiskTracker.setReportValidityMs(OUTLIERS_REPORT_INTERVAL * 100);
+
+    // 2. Report a slow disk
+    DataNode slowDn = cluster.getDataNodes().get(0);
+    String diskKey = getFirstDiskKey(slowDn);
+    String slowDnAddr = slowDn.getDatanodeId().getIpcAddr(false);
+
+    slowDn.getDiskMetrics().addSlowDiskForTesting(diskKey,
+        ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 5.0));
+
+    // 3. Wait for heartbeat processing
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    // Trigger cache rebuild
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+
+    // 4. Verify cache contains the slow disk
+    Map<String, Double> cache = slowDiskTracker.getAllValidSlowDisks();
+    assertFalse(cache.isEmpty(), "Cache should not be empty");
+
+    // 5. Get sorted block locations
+    LocatedBlocks locsAfter = NameNodeAdapter.getBlockLocations(nameNode,
+        testFile.toString(), 0, FILE_SIZE);
+    DatanodeInfo[] dnsAfter =
+        locsAfter.getLocatedBlocks().get(0).getLocations();
+
+    // 6. Verify slow disk DataNode is sorted to the end
+    assertEquals(slowDnAddr,
+        dnsAfter[dnsAfter.length - 1].getIpcAddr(false),
+        "Slow disk DataNode should be at the last position");
+  }
+
+  /**
+   * Test scenario 7: Verify that cache rebuild interval is independent of
+   * report generation interval.
+   */
+  @Test
+  @Timeout(60)
+  public void testIndependentCacheRebuildInterval() throws Exception {
+    SlowDiskTracker slowDiskTracker = nameNode.getNamesystem()
+        .getBlockManager().getDatanodeManager().getSlowDiskTracker();
+
+    // Set a different report validity period
+    slowDiskTracker.setReportValidityMs(5000); // 5 second validity
+
+    // 1. Report a slow disk
+    DataNode slowDn = cluster.getDataNodes().get(0);
+    String diskKey = getFirstDiskKey(slowDn);
+    slowDn.getDiskMetrics().addSlowDiskForTesting(diskKey,
+        ImmutableMap.of(SlowDiskReports.DiskOp.WRITE, 2.0));
+
+    // 2. Wait for initial heartbeat and cache build
+    Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+    slowDiskTracker.checkAndUpdateReportIfNecessary();
+    Thread.sleep(200);
+
+    Map<String, Double> cache1 = slowDiskTracker.getAllValidSlowDisks();
+    int size1 = cache1.size();
+
+    // 3. Trigger multiple checks and observe cache updates
+    for (int i = 0; i < 3; i++) {
+      Thread.sleep(OUTLIERS_REPORT_INTERVAL);
+      slowDiskTracker.checkAndUpdateReportIfNecessary();
+      Thread.sleep(200);
+    }
+
+    // 4. Verify the independent cache update mechanism works
+    assertNotNull(slowDiskTracker.getAllValidSlowDisks(),
+        "getAllValidSlowDisks should return non-null");
+  }
+}


### PR DESCRIPTION
## Summary

When a client requests to read a block, the NameNode returns a list of DataNodes holding the replicas of that block.

The current logic sorts these DataNodes based on network topology (rack awareness, distance), without considering the performance of the underlying storage (disk/volume).

If a block replica resides on a slow or overloaded disk (for example, a hot disk with high latency), its DataNode may still be placed at the top of the sorted list and selected first by the client.

---
## Example

Suppose a block has three replicas located on:

dn1: storage1 (slow disk)

dn2: storage1 (normal disk)

dn3: storage1 (normal disk)

Even if the speed of memory 1 is known to be slow, the client will still prioritize reading in the order returned by the NameNode.

---
## Fix

This PR adds **disk-level slow storage tracking** and **deprioritization** during block location sorting.

### 1. Disk-Level Tracking (`SlowDiskTracker.java`)
- Track slow storage at **StorageID granularity** (not DataNode level).
- Copy-on-Write cache `cachedSlowDisksForRead` to avoid lock contention on read path.
- **Cache key**: `IP:PORT:StorageID` (e.g., `127.0.0.1:50010:DS-xxx`).
- Dual key modes:  
  - **CACHE_KEY**: `IP:PORT:StorageID` for read deprioritization.  
  - **LEGACY_KEY**: `IP:PORT:volumeName` for backward compatibility with Top-N reports.
- Background cache rebuild with configurable interval (default **30s**).
- Automatic expiration of stale entries (`reportValidityMs`).

### 2. Block Location Sorting (`FSNamesystem.java`)
- New method `sortLocatedBlocksBySlowDisk()` reorders replicas **after topology-based sorting**.
- Pre-compute slow keys before sorting to avoid string concatenation in comparator hot path.
- **Stable sort**: preserves network topology order for non-slow replicas.
- Slow replicas sorted by latency (**higher latency → lower priority**).
- Controlled by config:  
  `dfs.namenode.deprioritize.slow.disk.datanode.for.read` (default: **false**).

### 3. Configuration (`DFSConfigKeys.java`)
- `dfs.namenode.slow.disk.cache.rebuild.interval` (default **30s**).  
- Decouples cache rebuild frequency from Top-N report generation interval.  
- Allows independent tuning for large clusters.

### 4. Disk Key Format (`DataNodeDiskMetrics.java`)
- Use `volumeName|storageID` format for slow disk reports.
- Enables `SlowDiskTracker` to extract both **legacy key** (WebUI) and **cache key** (read path).

---

## Test

**Test class**: `TestSlowDiskBlockLocations.java`

### Test Coverage

- ✅ **testDeprioritizeSlowDiskDatanodeForReadEnabled**  
  Verifies that slow disk replicas are moved to the end of location list.  
  Checks block read path integration.

- ✅ **testSlowDiskCacheRebuild**  
  Tests cache population after DataNode reports slow disk.  
  Verifies cache refresh mechanism.

- ✅ **testSlowDiskExpiration**  
  Validates expiration of stale slow disk entries.  
  Confirms cache is cleaned after disk recovery.

- ✅ **testCacheIntegrationWithReadPath**  
  End-to-end test: slow disk report → cache update → block location sorting.  
  Verifies clients avoid slow replicas.

- ✅ **testIndependentCacheRebuildInterval**  
  Tests independent cache rebuild interval configuration.  
  Verifies decoupling from Top-N report generation.

- ✅ **testMultipleSlowDisks**  
  Multiple slow disks across different DataNodes.  
  Validates sorting by latency when all replicas are slow.

- ✅ **testNoSlowDiskReports**  
  Baseline test: no sorting when no slow disks reported.  
  Ensures feature is non-intrusive when disabled.
  
---
### Test Configuration

- `DFS_HEARTBEAT_INTERVAL`: **1s** (fast heartbeat for testing)
- `DFS_NAMENODE_SLOW_DISK_CACHE_REBUILD_INTERVAL`: **1s** (quick cache rebuild)
- `OUTLIERS_REPORT_INTERVAL`: **1s** (rapid slow disk detection)
- Uses `GenericTestUtils.waitFor()` for async operations.
