### PR TITLE
HADOOP-19837. Bump org.apache.zookeeper:zookeeper from 3.8.4 to 3.8.6 in hadoop-project

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -406,7 +406,7 @@ org.apache.sshd:sshd-core:2.11.0
 org.apache.sshd:sshd-sftp:2.11.0
 org.apache.solr:solr-solrj:8.11.2
 org.apache.yetus:audience-annotations:0.5.0
-org.apache.zookeeper:zookeeper:3.8.4
+org.apache.zookeeper:zookeeper:3.8.6
 org.codehaus.jettison:jettison:1.5.4
 org.conscrypt:conscrypt-openjdk-uber:2.5.2
 org.eclipse.jetty:jetty-annotations:9.4.58.v20250814

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -112,7 +112,7 @@
     <hadoop-thirdparty-shaded-protobuf-prefix>${hadoop-thirdparty-shaded-prefix}.protobuf</hadoop-thirdparty-shaded-protobuf-prefix>
     <hadoop-thirdparty-shaded-guava-prefix>${hadoop-thirdparty-shaded-prefix}.com.google.common</hadoop-thirdparty-shaded-guava-prefix>
 
-    <zookeeper.version>3.8.4</zookeeper.version>
+    <zookeeper.version>3.8.6</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.6.1</dnsjava.version>


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19837. Bump org.apache.zookeeper:zookeeper from 3.8.4 to 3.8.6 in hadoop-project

### How was this patch tested?
UT benchmark