### PR TITLE
HDFS-17892 RBF: permit not released during invokeConcurrent if getOrderedNamenodes throws an exception

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1644,10 +1644,12 @@ public class RouterRpcClient {
         this.router.getRouterClientMetrics().incInvokedConcurrent(m);
       }
 
-      return getRemoteResults(method, timeOutMs, controller, orderedLocations, callables);
-    } finally {
+    } catch (IOException e) {
       releasePermit(CONCURRENT_NS, ugi, method, controller);
+      throw e;
     }
+
+    return getRemoteResults(method, timeOutMs, controller, orderedLocations, callables);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1599,51 +1599,55 @@ public class RouterRpcClient {
     // transfer originCall & callerContext to worker threads of executor.
     final Call originCall = Server.getCurCall().get();
     final CallerContext originContext = CallerContext.getCurrent();
-    for (final T location : locations) {
-      String nsId = location.getNameserviceId();
-      boolean isObserverRead = isObserverReadEligible(nsId, m);
-      final List<? extends FederationNamenodeContext> namenodes =
-          getOrderedNamenodes(nsId, isObserverRead);
-      final Class<?> proto = method.getProtocol();
-      final Object[] paramList = method.getParams(location);
-      if (standby) {
-        // Call the objectGetter to all NNs (including standby)
-        for (final FederationNamenodeContext nn : namenodes) {
-          String nnId = nn.getNamenodeId();
-          final List<FederationNamenodeContext> nnList =
-              Collections.singletonList(nn);
-          T nnLocation = location;
-          if (location instanceof RemoteLocation) {
-            nnLocation = (T)new RemoteLocation(nsId, nnId, location.getDest());
+    try{
+      for (final T location : locations) {
+        String nsId = location.getNameserviceId();
+        boolean isObserverRead = isObserverReadEligible(nsId, m);
+        final List<? extends FederationNamenodeContext> namenodes =
+            getOrderedNamenodes(nsId, isObserverRead);
+        final Class<?> proto = method.getProtocol();
+        final Object[] paramList = method.getParams(location);
+        if (standby) {
+          // Call the objectGetter to all NNs (including standby)
+          for (final FederationNamenodeContext nn : namenodes) {
+            String nnId = nn.getNamenodeId();
+            final List<FederationNamenodeContext> nnList =
+                Collections.singletonList(nn);
+            T nnLocation = location;
+            if (location instanceof RemoteLocation) {
+              nnLocation = (T)new RemoteLocation(nsId, nnId, location.getDest());
+            }
+            orderedLocations.add(nnLocation);
+            callables.add(
+                () -> {
+                  transferThreadLocalContext(originCall, originContext);
+                  return invokeMethod(
+                      ugi, nnList, isObserverRead, proto, m, paramList);
+                });
           }
-          orderedLocations.add(nnLocation);
+        } else {
+          // Call the objectGetter in order of nameservices in the NS list
+          orderedLocations.add(location);
           callables.add(
               () -> {
                 transferThreadLocalContext(originCall, originContext);
                 return invokeMethod(
-                    ugi, nnList, isObserverRead, proto, m, paramList);
+                    ugi, namenodes, isObserverRead, proto, m, paramList);
               });
         }
-      } else {
-        // Call the objectGetter in order of nameservices in the NS list
-        orderedLocations.add(location);
-        callables.add(
-            () -> {
-              transferThreadLocalContext(originCall, originContext);
-              return invokeMethod(
-                  ugi, namenodes, isObserverRead, proto, m, paramList);
-            });
       }
-    }
 
-    if (rpcMonitor != null) {
-      rpcMonitor.proxyOp();
-    }
-    if (this.router.getRouterClientMetrics() != null) {
-      this.router.getRouterClientMetrics().incInvokedConcurrent(m);
-    }
+      if (rpcMonitor != null) {
+        rpcMonitor.proxyOp();
+      }
+      if (this.router.getRouterClientMetrics() != null) {
+        this.router.getRouterClientMetrics().incInvokedConcurrent(m);
+      }
 
-    return getRemoteResults(method, timeOutMs, controller, orderedLocations, callables);
+      return getRemoteResults(method, timeOutMs, controller, orderedLocations, callables);
+    } finally {
+      releasePermit(CONCURRENT_NS, ugi, method, controller);
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -215,19 +215,20 @@ public class TestRouterHandlersFairness {
     // Use renewLease test invokeConcurrent.
     Collection<RemoteLocation> locations = new ArrayList<>();
     locations.add(new RemoteLocation("ns0", "/", "/"));
+    locations.add(new RemoteLocation("ns1", "/", "/"));
     RemoteMethod renewLease = new RemoteMethod(
         "renewLease",
         new Class[]{java.lang.String.class, java.util.List.class},
         new Object[]{null, null});
     availablePermits =
-        rpcClient.getRouterRpcFairnessPolicyController().getAvailablePermits("ns0");
+        rpcClient.getRouterRpcFairnessPolicyController().getAvailablePermits(CONCURRENT_NS);
     LambdaTestUtils.intercept(IOException.class,  () -> {
       LOG.info("Use renewLease test invokeConcurrent.");
       rpcClient.invokeConcurrent(locations, renewLease);
     });
-    // Ensure that the semaphore is not acquired.
+    // Ensure that the concurrent semaphore is released.
     assertEquals(availablePermits,
-        rpcClient.getRouterRpcFairnessPolicyController().getAvailablePermits("ns0"));
+        rpcClient.getRouterRpcFairnessPolicyController().getAvailablePermits(CONCURRENT_NS));
   }
 
   /**


### PR DESCRIPTION
JIRA: [HDFS-17892](https://issues.apache.org/jira/browse/HDFS-17892)

### Description of PR
After [HDFS-17265](https://issues.apache.org/jira/browse/HDFS-17265), we either move acquirePermit after getOrderedNamenodes or wrap getOrderedNamenodes in a try-finally block so that the permit can be released if getOrderedNamenodes throws an exception.

However, the behavior of the latest trunk (a178eb7) has regressed, where we don't handle the permit release anymore.

The test failed to detect this problem because it only use 1 locations. In invokeConcurrent, the execution flows into invokeSingle where the exception is correctly handled using this branch

```
else if (locations.size() == 1 && timeOutMs <= 0){      
    // Shortcut, just one call       
    return invokeSingle(locations.iterator().next(), method);     
}
```

In this patch, I've fixed the invokeConcurrent and the test to reflect this behavior.

### How was this patch tested?
```
mvn -pl hadoop-hdfs-project/hadoop-hdfs-rbf -am -Dtest=TestRouterHandlersFairness#testReleasedWhenExceptionOccurs test
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html