### PR TITLE
HADOOP-19838. Support parsing environment variables in the Configuration class.

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -391,6 +391,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
       <scope>runtime</scope>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -245,6 +245,8 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
   private boolean restrictSystemProps = restrictSystemPropsDefault;
   private boolean allowNullValueProperties = false;
 
+  private static final String HADOOP_CLIENT_OPTS = "HADOOP_CLIENT_OPTS";
+
   private static class Resource {
     private final Object resource;
     private final String name;
@@ -2934,6 +2936,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     if (properties == null) {
       properties = new Properties();
       loadProps(properties, 0, true);
+      loadOtherProps(properties);
     }
     return properties;
   }
@@ -2963,6 +2966,63 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
             }
           }
         }
+      }
+    }
+  }
+
+  /**
+   * Loads configuration properties from both environment variables.
+   *
+   * @param props the object containing the loaded properties.
+   */
+  private void loadOtherProps(Properties props) {
+    loadEnvironmentVariables(props);
+  }
+
+  /**
+   * Loads Hadoop configuration properties from the "HADOOP_CLIENT_OPTS" environment variable.
+   * <p>
+   * This method extracts {@code -Dkey=value or -D key=value} style strings from the value of the
+   * {@code HADOOP_CLIENT_OPTS} environment variable.
+   * <p>
+   * <b>Example:</b> Given {@code hdfs-site.xml}: key: dfs.client.socket-timeout, value: 60000,
+   * Setting the environment variable:
+   * <pre>{@code export HADOOP_CLIENT_OPTS="-Xmx1g -Ddfs.client.socket-timeout=30000"}</pre>
+   * will extract {@code dfs.client.socket-timeout=30000} and override the XML files at runtime.
+   * <p>
+   * <b>String format:</b>
+   * <ul>
+   *   <li>{@code -Dkey=value}</li>
+   *   <li>{@code -D key=value}</li>
+   * </ul>
+   *
+   * @param props the object containing the loaded properties.
+   */
+  private void loadEnvironmentVariables(Properties props) {
+    String hadoopClientOpts = System.getenv(HADOOP_CLIENT_OPTS);
+    if (hadoopClientOpts == null || hadoopClientOpts.trim().isEmpty()) {
+      return;
+    }
+    String[] tokens = hadoopClientOpts.trim().split("\\s+");
+    for (int i = 0; i < tokens.length; i++) {
+      String token = tokens[i];
+      if (token == null) {
+        continue;
+      }
+      String keyValueStr = null;
+      if (token.equals("-D")) {
+        if (i < tokens.length - 1 && tokens[i + 1].contains("=")) {
+          keyValueStr = tokens[++i];
+        }
+      } else if (token.startsWith("-D") && token.contains("=")) {
+        keyValueStr = token;
+      }
+      if (keyValueStr != null) {
+        String rawPair = keyValueStr.startsWith("-D") ? keyValueStr.substring(2) : keyValueStr;
+        int eqIndex = rawPair.indexOf('=');
+        String key = rawPair.substring(0, eqIndex);
+        String value = rawPair.substring(eqIndex + 1).trim();
+        loadProperty(props, "env", key, value, false, new String[] {"env-property"});
       }
     }
   }

--- a/hadoop-common-project/hadoop-common/src/site/markdown/UnixShellGuide.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/UnixShellGuide.md
@@ -26,8 +26,18 @@ Apache Hadoop has many environment variables that control various aspects of the
 
 This environment variable is used for all end-user, non-daemon operations.  It can be used to set any Java options as well as any Apache Hadoop options via a system property definition. For example:
 
+Set the client socket timeout via dfs.client.socket-timeout
 ```bash
-HADOOP_CLIENT_OPTS="-Xmx1g -Dhadoop.socks.server=localhost:4000" hadoop fs -ls /tmp
+export HADOOP_CLIENT_OPTS="-Xmx1g -Ddfs.client.socket-timeout=30000"
+
+hadoop fs -ls hdfs://localhost:8020/tmp
+```
+
+Define the default filesystem via fs.defaultFS
+```bash
+export HADOOP_CLIENT_OPTS="-Xmx1g -Dfs.defaultFS=hdfs://localhost:8020/"
+
+hadoop fs -ls /tmp
 ```
 
 will increase the memory and send this command via a SOCKS proxy server.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
@@ -52,6 +52,8 @@ import static java.util.concurrent.TimeUnit.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +64,7 @@ import static org.apache.hadoop.conf.StorageUnit.GB;
 import static org.apache.hadoop.conf.StorageUnit.KB;
 import static org.apache.hadoop.conf.StorageUnit.MB;
 import static org.apache.hadoop.conf.StorageUnit.TB;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2763,5 +2766,29 @@ public class TestConfiguration {
     Thread.sleep(1000); //give enough time for threads to run
 
     assertFalse(exceptionOccurred.get(), "ConcurrentModificationException occurred");
+  }
+
+  @Test
+  public void testLoadEnvironmentVariables() throws Exception {
+    // Test valid configurations: both "-Dkey=value" and "-D key=value" formats
+    SystemLambda.withEnvironmentVariable("HADOOP_CLIENT_OPTS",
+            "-Ddfs.client.socket-timeout=30000 -D dfs.datanode.socket.write.timeout=240000")
+        .execute(() -> {
+          Configuration configuration = new Configuration();
+          assertThat(configuration.get("dfs.client.socket-timeout")).isEqualTo("30000");
+          assertThat(configuration.get("dfs.datanode.socket.write.timeout")).isEqualTo("240000");
+        });
+    // Test invalid configurations: "-X" formats should be ignored
+    SystemLambda.withEnvironmentVariable("HADOOP_CLIENT_OPTS",
+            "-Xdfs.client.socket-timeout=30000 -X dfs.datanode.socket.write.timeout=240000")
+        .execute(() -> {
+          Configuration configuration = new Configuration();
+          assertThat(configuration.get("dfs.client.socket-timeout")).isNull();
+          assertThat(configuration.get("dfs.datanode.socket.write.timeout")).isNull();
+        });
+    // There are no environment variables
+    Configuration configuration = new Configuration();
+    assertThat(configuration.get("dfs.client.socket-timeout")).isNull();
+    assertThat(configuration.get("dfs.datanode.socket.write.timeout")).isNull();
   }
 }

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -240,6 +240,8 @@
     <yarnpkg.version>v1.22.5</yarnpkg.version>
     <apache-ant.version>1.10.13</apache-ant.version>
     <jmh.version>1.20</jmh.version>
+    <system-rules.version>1.18.0</system-rules.version>
+    <system-lambda.version>1.2.1</system-lambda.version>
   </properties>
 
   <dependencyManagement>
@@ -1212,7 +1214,7 @@
       <dependency>
         <groupId>com.github.stefanbirkner</groupId>
         <artifactId>system-rules</artifactId>
-        <version>1.18.0</version>
+        <version>${system-rules.version}</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -1223,6 +1225,12 @@
             <artifactId>hamcrest-core</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-lambda</artifactId>
+        <version>${system-lambda.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19838

#### Problem
Currently, Hadoop shell startup scripts only append **"HADOOP_CLIENT_OPTS"** as JVM arguments before the main class. This prevents users from transparently configuring client-side generic config (such as fs.defaultFS, dfs.client.socket-timeout, dfs.replication) via environment variables.

The examples provided in the doc at this link (https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/UnixShellGuide.html#HADOOP_CLIENT_OPTS) fail to take effect in actual practice.

These generic options must be parsed by GenericOptionsParser class, which only processes arguments passed after the main class. As a result, users have to manually add -D/-conf parameters to every single command execution, which is inconvenient and breaks the expected transparent configuration experience, for example:

```shell 
hadoop fs -Dfs.defaultFS=hdfs://127.0.0.1:8020/ -ls -d /
```

#### Solution
Support parsing configuration items from **"HADOOP_CLIENT_OPTS"** in the Configuration class. The keys used here are exactly the same as those in Hadoop configuration.

#### Benefits
For AI algorithm training scenarios, tuning parameters is required to address training efficiency. With this feature enabled, users no longer need to modify any related code.

### How was this patch tested?
Add UT & HDFS Shell

#### environment variables
```shell
export HADOOP_CLIENT_OPTS="-Xmx100m -Dfs.defaultFS=hdfs://127.0.0.1:8020/"

hadoop fs -ls -d /
```