### PR TITLE
YARN-11939. UT TestAuxServices breaking on Clover

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -448,6 +448,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.openclover</groupId>
+        <artifactId>clover-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Disable OpenClover for **/TestAuxServices.java in the hadoop-yarn-server-nodemanager, as OpenClover implementation in the  UT TestAuxServices breaks on Java 17

Hadoop currently uses clover-maven-plugin.version 4.4.1. (no Java 17 support).

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In OpenClover 4.5. Java 17 is experimental as of the latest release:https://openclover.org/doc/openclover-4.5.2-release-notes.html

There was an earlier suggestion to use Jacoco instead of Unit Test.

[HADOOP-15190](https://issues.apache.org/jira/browse/HADOOP-15190) “Use Jacoco to generate Unit Test coverage reports”

### How was this patch tested?
Manually tested on my local machine if UT runs OK with Java 17 after the exlusion:

java -version
export JAVA_HOME=$(/usr/libexec/java_home -v 17)        
cd hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager
mvn clean clover:setup test -Dtest=TestAuxServices


### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html