### PR TITLE
HADOOP-18878: deprecate fs.s3a.multipart.purge

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1766,7 +1766,7 @@
 <property>
   <name>fs.s3a.multipart.purge</name>
   <value>false</value>
-  <description>True if you want to purge existing multipart uploads that may not have been
+  <description>Deprecated. True if you want to purge existing multipart uploads that may not have been
     completed/aborted correctly. The corresponding purge age is defined in
     fs.s3a.multipart.purge.age.
     If set, when the filesystem is instantiated then all outstanding uploads
@@ -1780,7 +1780,7 @@
 <property>
   <name>fs.s3a.multipart.purge.age</name>
   <value>24h</value>
-  <description>Minimum age in seconds of multipart uploads to purge
+  <description>Deprecated. Minimum age in seconds of multipart uploads to purge
     on startup if "fs.s3a.multipart.purge" is true
   </description>
 </property>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -704,6 +704,7 @@ public final class Constants {
   public static final String STORAGE_CLASS_GLACIER_INSTANT_RETRIEVAL = "glacier_ir";
 
   // should we try to purge old multipart uploads when starting up
+  @Deprecated
   public static final String PURGE_EXISTING_MULTIPART =
       "fs.s3a.multipart.purge";
   public static final boolean DEFAULT_PURGE_EXISTING_MULTIPART = false;
@@ -711,6 +712,7 @@ public final class Constants {
   /**
    * purge any multipart uploads older than this number of seconds.
    */
+  @Deprecated
   public static final String PURGE_EXISTING_MULTIPART_AGE =
       "fs.s3a.multipart.purge.age";
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -585,7 +585,7 @@ Here are some the S3A properties for use in production.
 <property>
   <name>fs.s3a.multipart.purge</name>
   <value>false</value>
-  <description>True if you want to purge existing multipart uploads that may not have been
+  <description>Deprecated. True if you want to purge existing multipart uploads that may not have been
     completed/aborted correctly. The corresponding purge age is defined in
     fs.s3a.multipart.purge.age.
     If set, when the filesystem is instantiated then all outstanding uploads
@@ -599,7 +599,7 @@ Here are some the S3A properties for use in production.
 <property>
   <name>fs.s3a.multipart.purge.age</name>
   <value>86400</value>
-  <description>Minimum age in seconds of multipart uploads to purge
+  <description>Deprecated. Minimum age in seconds of multipart uploads to purge
     on startup if "fs.s3a.multipart.purge" is true
   </description>
 </property>
@@ -1676,14 +1676,15 @@ intermediate partitions uploaded to S3 —data which will be billed for.
 If an S3A committer job is halted partway through, again, there may be
 many incomplete multipart uploads in the output directory.
 
-These charges can be reduced by enabling `fs.s3a.multipart.purge`,
-and setting a purge time in seconds, such as 24 hours.
+These charges can be reduced by enabling `fs.s3a.multipart.purge`
+(deprecated), and setting a purge time in seconds, such as 24 hours.
 When an S3A FileSystem instance is instantiated with the purge time greater
 than zero, it will, on startup, delete all outstanding partition requests
 older than this time. However, this makes filesystem instantiate slow, especially
 against very large buckets, as a full scan is made.
 
-Consider avoiding this in future.
+For this reason, the option is deprecated and will be removed in a future
+release.
 
 ```xml
 <property>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
@@ -113,7 +113,6 @@ of incomplete uploads.
 
 This can be addressed in two ways
 * Command line: `hadoop s3guard uploads -abort -force \<path>`.
-* With `fs.s3a.multipart.purge` and a purge age set in `fs.s3a.multipart.purge.age`
 * In rename/delete `fs.s3a.directory.operations.purge.uploads = true`.
 
 #### S3Guard uploads command
@@ -126,7 +125,7 @@ hadoop s3guard uploads -abort -force s3a://bucket/
 
 Consult the [S3Guard documentation](s3guard.html) for the full set of parameters.
 
-#### In startup: `fs.s3a.multipart.purge`
+#### Deprecated: `fs.s3a.multipart.purge`
 
 This lists all uploads in a bucket when a filesystem is created and deletes
 all of those above a certain age.
@@ -135,8 +134,7 @@ This can hurt performance on a large bucket, as the purge scans the entire tree,
 and is executed whenever a filesystem is created -which can happen many times during
 hive, spark, distcp jobs.
 
-For this reason, this option may be deleted in future, however it has long been
-available in the S3A client and so guaranteed to work across versions.
+For this reason, this option is deprecated and will be deleted in future.
 
 #### During rename and delete: `fs.s3a.directory.operations.purge.uploads`
 

--- a/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
@@ -59,13 +59,6 @@
   </property>
 
   <property>
-    <name>fs.s3a.bucket.noaa-isd-pds.multipart.purge</name>
-    <value>false</value>
-    <description>Don't try to purge uploads in the read-only bucket, as
-    it will only create log noise.</description>
-  </property>
-
-  <property>
     <name>fs.s3a.bucket.noaa-isd-pds.probe</name>
     <value>0</value>
     <description>Let's postpone existence checks to the first IO operation </description>
@@ -99,13 +92,6 @@
     <name>fs.s3a.bucket.usgs-landsat.requester.pays.enabled</name>
     <value>true</value>
     <description>usgs-landsat requires requester pays enabled</description>
-  </property>
-
-  <property>
-    <name>fs.s3a.bucket.usgs-landsat.multipart.purge</name>
-    <value>false</value>
-    <description>Don't try to purge uploads in the read-only bucket, as
-      it will only create log noise.</description>
   </property>
 
   <property>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
From HADOOP-18878:

> the fs.s3a.multipart.purge option has been in for a long time, to help avoid running up costs from incomplete uploads, especially during testing.
> 
> but
> 
> adds overhead on startup (list + delete)
> dangerous if one client has a very short lifespan; all active s3a committer jobs will be broken
> obsoleted by s3 lifecycle rules
> and "hadoop s3guard uploads" cli.
> proposed: deprecate for the next release, delete after.

### How was this patch tested?

```
 mvn -pl hadoop-tools/hadoop-aws -Dparallel-tests verify
```

1. s3a integration tests run against localstack S3. Some tests fail complaining about secret/access keys which is a quirk of running against that S3 implementation which I haven't root caused yet.
2. Ran against S3 in us-west2 successfully. Default config except credentials (simple type).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [na ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [na ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
