### PR TITLE
HADOOP-19845. Add Intel ISA-L installation to RockyLinux 8 Dockerfile

### DIFF
--- a/dev-support/docker/Dockerfile_rockylinux_8
+++ b/dev-support/docker/Dockerfile_rockylinux_8
@@ -118,6 +118,7 @@ RUN pkg-resolver/install-boost.sh rockylinux:8
 RUN pkg-resolver/install-spotbugs.sh rockylinux:8
 RUN pkg-resolver/install-protobuf.sh rockylinux:8
 RUN pkg-resolver/install-zstandard.sh rockylinux:8
+RUN pkg-resolver/install-intel-isa-l.sh rockylinux:8
 RUN pkg-resolver/install-common-pkgs.sh
 
 ###


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19845. Add Intel ISA-L installation to RockyLinux 8 Dockerfile

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html