### PR TITLE
YARN-11941: Follow-up to YARN-11937: Fix NPE and improve parameter detection for yarn.web-proxy.redirect-flag

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -552,10 +552,13 @@ public class WebAppProxyServlet extends HttpServlet {
        * handle authentication and route the request to the appropriate
        * backend service.
        */
-      String redirectFlagName = conf.get(YarnConfiguration.PROXY_REDIRECT_FLAG, "");
-      if (!redirectFlagName.isBlank() && toFetch.getQuery().equals(redirectFlagName + "=true")) {
-        ProxyUtils.sendRedirect(req, resp, toFetch.toString());
-        return;
+      String toFetchQuery = toFetch.getQuery();
+      if (toFetchQuery != null) {
+        String redirectFlagName = conf.get(YarnConfiguration.PROXY_REDIRECT_FLAG, "");
+        if (!redirectFlagName.isBlank() && toFetchQuery.contains(redirectFlagName + "=true")) {
+          ProxyUtils.sendRedirect(req, resp, toFetch.toString());
+          return;
+        }
       }
 
       Cookie c = null;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
@@ -359,21 +359,29 @@ public class TestWebAppProxyServlet {
 
     appReportFetcher.answer = 8;
 
-    //Check if flag is on
-    YarnConfiguration conf = new YarnConfiguration();
-    conf.set(YarnConfiguration.PROXY_REDIRECT_FLAG, "yarn_knox_proxy");
-    servlet.setConf(conf);
-    servlet.doGet(request, response);
-
     //Check if flag is off
+    YarnConfiguration conf = new YarnConfiguration();
     conf.set(YarnConfiguration.PROXY_REDIRECT_FLAG, "");
     servlet.setConf(conf);
     servlet.doGet(request, response);
 
+    //Check if flag is on
+    conf.set(YarnConfiguration.PROXY_REDIRECT_FLAG, "yarn_knox_proxy");
+    servlet.setConf(conf);
+    servlet.doGet(request, response);
+
+    appReportFetcher.answer = 9;
+    servlet.doGet(request, response);
+
+    appReportFetcher.answer = 10;
+    servlet.doGet(request, response);
+
     ArgumentCaptor<Integer> statusCaptor = ArgumentCaptor.forClass(Integer.class);
-    Mockito.verify(response, Mockito.times(2)).setStatus(statusCaptor.capture());
-    assertEquals(HttpServletResponse.SC_FOUND, statusCaptor.getAllValues().get(0));
-    assertEquals(HttpServletResponse.SC_OK, statusCaptor.getAllValues().get(1));
+    Mockito.verify(response, Mockito.times(4)).setStatus(statusCaptor.capture());
+    assertEquals(HttpServletResponse.SC_OK, statusCaptor.getAllValues().get(0));
+    assertEquals(HttpServletResponse.SC_FOUND, statusCaptor.getAllValues().get(1));
+    assertEquals(HttpServletResponse.SC_FOUND, statusCaptor.getAllValues().get(2));
+    assertEquals(HttpServletResponse.SC_NOT_FOUND, statusCaptor.getAllValues().get(3));
   }
 
   @Test
@@ -701,6 +709,16 @@ public class TestWebAppProxyServlet {
         FetchedAppReport result = getDefaultApplicationReport(appId);
         result.getApplicationReport().setOriginalTrackingUrl("localhost:"
             + originalPort + "/foo/bar?yarn_knox_proxy=true");
+        return result;
+      } else if (answer == 9) {
+        FetchedAppReport result = getDefaultApplicationReport(appId);
+        result.getApplicationReport().setOriginalTrackingUrl("localhost:"
+            + originalPort + "/foo/bar?parameter1=true&yarn_knox_proxy=true&doAs=user");
+        return result;
+      } else if (answer == 10) {
+        FetchedAppReport result = getDefaultApplicationReport(appId);
+        result.getApplicationReport().setOriginalTrackingUrl("localhost:"
+            + originalPort);
         return result;
       }
       return null;


### PR DESCRIPTION
### Description of PR

**Problem Statement**

The fix for YARN-11937 introduced a mechanism to handle yarn_knox_proxy=true (yarn.web-proxy.redirect-flag=yarn_knox_proxy) parameter in the HTTP query. However the current implementation might not correctly identify this parameter when it is part of a larger query string containing multiple parameters. For example in the following URL:

```
...?parameter1=true&parameter2=true&yarn_knox_proxy=true&doAs=user
```

Currently the logic expects the query string to be exactly yarn_knox_proxy=true, it will fail to recognize the flag when other parameters (like doAs, parameter1, or parameter2) are present.

[https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/ hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java#L555
](https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java#L555)

```
      String redirectFlagName = conf.get(YarnConfiguration.PROXY_REDIRECT_FLAG, "");
      if (!redirectFlagName.isBlank() && toFetch.getQuery().equals(redirectFlagName + "=true")) {
        ProxyUtils.sendRedirect(req, resp, toFetch.toString());
        return;
      }
```

If the toFetch URI does not contain a query string, the current logic throws a java.lang.NullPointerException when attempting to call .equals() on the null result. This scenario is common in Spark Client mode when the tracking URL points directly to the Spark UI (http://host.example.com:4040/). In such cases the absence of a query string causes the current implementation to fail with a NullPointerException.

**Proposed Changes**

Robust parsing: 

Instead of a simple string comparison, the logic will safely check for the presence of the redirect flag within the query string, even when combined with other parameters.

Null Safety: 

Add a null check for toFetch.getQuery() to prevent NullPointerException when no query parameters are present in the URI.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->


### How was this patch tested?

- Updated the testRedirectFlagProxyServlet unit test to cover this scenario as well
- Deployed a cluster with YARN, SPARK, KNOX and checked it there


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html