### PR TITLE
HADOOP-19847. Move logAllocatedBlock out of lock in FSNamesystem.getAdditionalBlock to reduce latency

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirWriteFileOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirWriteFileOp.java
@@ -67,6 +67,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot.CURRENT_STATE_ID;
 import static org.apache.hadoop.util.Time.now;
@@ -223,7 +224,7 @@ class FSDirWriteFileOp {
    */
   static LocatedBlock storeAllocatedBlock(FSNamesystem fsn, String src,
       long fileId, String clientName, ExtendedBlock previous,
-      DatanodeStorageInfo[] targets) throws IOException {
+      DatanodeStorageInfo[] targets, AtomicReference<BlockInfo> newBlockRef) throws IOException {
     long offset;
     // Run the full analysis again, since things could have changed
     // while chooseTarget() was executing.
@@ -256,7 +257,8 @@ class FSDirWriteFileOp {
     // allocate new block, record block locations in INode.
     Block newBlock = fsn.createNewBlock(blockType);
     INodesInPath inodesInPath = INodesInPath.fromINode(pendingFile);
-    saveAllocatedBlock(fsn, src, inodesInPath, newBlock, targets, blockType);
+    BlockInfo newBlockInfo = saveAllocatedBlock(fsn, src, inodesInPath, newBlock, targets, blockType);
+    newBlockRef.set(newBlockInfo);
 
     persistNewBlock(fsn, src, pendingFile);
     offset = pendingFile.computeFileSize();
@@ -781,17 +783,17 @@ class FSDirWriteFileOp {
    * @param targets target datanodes where replicas of the new block is placed
    * @throws QuotaExceededException If addition of block exceeds space quota
    */
-  static void saveAllocatedBlock(FSNamesystem fsn, String src,
+  static BlockInfo saveAllocatedBlock(FSNamesystem fsn, String src,
       INodesInPath inodesInPath, Block newBlock, DatanodeStorageInfo[] targets,
       BlockType blockType) throws IOException {
     assert fsn.hasWriteLock(RwLockMode.GLOBAL);
     BlockInfo b = addBlock(fsn.dir, src, inodesInPath, newBlock, targets,
         blockType);
-    logAllocatedBlock(src, b);
     DatanodeStorageInfo.incrementBlocksScheduled(targets);
+    return b;
   }
 
-  private static void logAllocatedBlock(String src, BlockInfo b) {
+  static void logAllocatedBlock(String src, BlockInfo b) {
     if (!NameNode.stateChangeLog.isInfoEnabled()) {
       return;
     }
@@ -803,7 +805,7 @@ class FSDirWriteFileOp {
     if (uc != null) {
       uc.appendUCPartsConcise(sb);
     }
-    sb.append(" for " + src);
+    sb.append(" for ").append(src);
     NameNode.stateChangeLog.info(sb.toString());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -182,6 +182,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
@@ -3111,14 +3112,18 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     checkOperation(OperationCategory.WRITE);
     writeLock(RwLockMode.GLOBAL);
     LocatedBlock lb;
+    AtomicReference<BlockInfo> newBlockRef = new AtomicReference<>();
     try {
       checkOperation(OperationCategory.WRITE);
       lb = FSDirWriteFileOp.storeAllocatedBlock(
-          this, src, fileId, clientName, previous, targets);
+          this, src, fileId, clientName, previous, targets, newBlockRef);
     } finally {
       writeUnlock(RwLockMode.GLOBAL, operationName);
     }
     getEditLog().logSync();
+    if (newBlockRef.get() != null) {
+      FSDirWriteFileOp.logAllocatedBlock(src, newBlockRef.get());
+    }
     return lb;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddBlockRetry.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddBlockRetry.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,7 +123,7 @@ public class TestAddBlockRetry {
     LocatedBlock newBlock;
     try {
       newBlock = FSDirWriteFileOp.storeAllocatedBlock(ns, src,
-          HdfsConstants.GRANDFATHER_INODE_ID, "clientName", null, targets);
+          HdfsConstants.GRANDFATHER_INODE_ID, "clientName", null, targets, new AtomicReference<>());
     } finally {
       ns.writeUnlock(RwLockMode.GLOBAL, "testRetryAddBlockWhileInChooseTarget");
     }


### PR DESCRIPTION
HADOOP-19847. Move logAllocatedBlock out of lock in FSNamesystem.getAdditionalBlock to reduce latency

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The logAllocatedBlock method in FSNamesystem.getAdditionalBlock is currently called while holding global lock. Flame graph analysis shows this logging path (via SLF4J/Log4j appenders) contributes non-trivial latency, blocking other NameNode operations.
 
Since logAllocatedBlock is only for audit/diagnostic logging and does not modify shared state, we can safely move it after releasing global lock to reduce lock hold time and improve write throughput.
 
This change preserves all existing logging behavior while eliminating unnecessary lock contention from I/O-bound logging operations.

### How was this patch tested?
N/A
<img width="3454" height="1206" alt="logAllocatedBlock takes lots of time" src="https://github.com/user-attachments/assets/4173630c-6c81-4dbe-9de1-82e3dfadcd46" />
