### PR TITLE
[HDFS-17897] Handle InvalidEncryptionKeyException during striped file checksum

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
@@ -666,6 +666,17 @@ final class FileChecksumHelper {
             bgIdx--; // repeat at bgIdx-th block
             setRefetchBlocks(true);
           }
+        } catch (InvalidEncryptionKeyException iee) {
+          if (bgIdx > getLastRetriedIndex()) {
+            LOG.debug("Got invalid encryption key error in response to "
+                    + "OP_BLOCK_GROUP_CHECKSUM for file {} for block {} from "
+                    + "datanode {}. Will retry the block once.",
+                getSrc(), block, datanodes[j]);
+            setLastRetriedIndex(bgIdx);
+            done = true; // actually it's not done; but we'll retry
+            bgIdx--; // repeat at bgIdx-th block
+            getClient().clearDataEncryptionKey();
+          }
         } catch (IOException ie) {
           LOG.warn("src={}" + ", datanodes[{}]={}",
               getSrc(), j, datanodes[j], ie);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptedTransfer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptedTransfer.java
@@ -46,7 +46,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
 import org.apache.hadoop.hdfs.protocol.datatransfer.TrustedChannelResolver;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.DataTransferSaslUtil;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.SaslDataTransferServer;
@@ -378,6 +380,80 @@ public class TestEncryptedTransfer {
     // Retry the operation after clearing the encryption key
     FileChecksum verifyChecksum = fs.getFileChecksum(TEST_PATH);
     assertEquals(checksum, verifyChecksum);
+  }
+
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testStripedFileChecksumWithInvalidEncryptionKey(
+      String pResolverClazz)
+      throws IOException, InterruptedException, TimeoutException {
+    initTestEncryptedTransfer(pResolverClazz);
+    if (resolverClazz != null) {
+      // TestTrustedChannelResolver does not use encryption keys.
+      return;
+    }
+    setEncryptionConfigKeys();
+    // XOR-2-1 requires 3 DNs (2 data + 1 parity).
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    cluster.waitActive();
+
+    DistributedFileSystem dfs =
+        (DistributedFileSystem) getFileSystem(conf);
+    try {
+      // Enable XOR-2-1 EC policy and create an EC directory.
+      ErasureCodingPolicy ecPolicy = SystemErasureCodingPolicies.getByID(
+          SystemErasureCodingPolicies.XOR_2_1_POLICY_ID);
+      dfs.enableErasureCodingPolicy(ecPolicy.getName());
+      Path ecDir = new Path("/ec");
+      dfs.mkdirs(ecDir);
+      dfs.setErasureCodingPolicy(ecDir, ecPolicy.getName());
+
+      // Write a striped file.
+      Path ecFile = new Path(ecDir, "test-file");
+      int cellSize = ecPolicy.getCellSize();
+      // Write enough data to span at least one full stripe.
+      byte[] data = new byte[cellSize * ecPolicy.getNumDataUnits()];
+      Arrays.fill(data, (byte) 'a');
+      try (FSDataOutputStream out = dfs.create(ecFile)) {
+        out.write(data);
+      }
+
+      DFSClient client =
+          DFSClientAdapter.getDFSClient(dfs);
+      DFSClient spyClient = Mockito.spy(client);
+      DFSClientAdapter.setDFSClient(dfs, spyClient);
+
+      FileChecksum checksum = dfs.getFileChecksum(ecFile);
+
+      BlockTokenSecretManager btsm = cluster.getNamesystem()
+          .getBlockManager().getBlockTokenSecretManager();
+      // Reduce key update interval and token life for testing.
+      btsm.setKeyUpdateIntervalForTesting(2 * 1000);
+      btsm.setTokenLifetime(2 * 1000);
+      btsm.clearAllKeysForTesting();
+
+      // Wait until the encryption key becomes invalid on all DNs.
+      LOG.info("Wait until encryption keys become invalid...");
+      DataEncryptionKey encryptionKey = spyClient.getEncryptionKey();
+      List<DataNode> dataNodes = cluster.getDataNodes();
+      for (DataNode dn : dataNodes) {
+        GenericTestUtils.waitFor(
+            () -> !dn.getBlockPoolTokenSecretManager()
+                .get(encryptionKey.blockPoolId)
+                .hasKey(encryptionKey.keyId),
+            100, 30 * 1000);
+      }
+      LOG.info("The encryption key is invalid on all nodes now.");
+
+      // This should succeed: InvalidEncryptionKeyException should be
+      // caught, the stale key cleared, and the checksum retried.
+      FileChecksum verifyChecksum = dfs.getFileChecksum(ecFile);
+      // Verify that clearDataEncryptionKey was called to refresh the key.
+      Mockito.verify(spyClient, times(1)).clearDataEncryptionKey();
+      assertEquals(checksum, verifyChecksum);
+    } finally {
+      dfs.close();
+    }
   }
 
   @MethodSource("data")

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptedTransfer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptedTransfer.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
+import org.apache.hadoop.hdfs.protocol.datatransfer.InvalidEncryptionKeyException;
 import org.apache.hadoop.hdfs.protocol.datatransfer.TrustedChannelResolver;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.DataTransferSaslUtil;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.SaslDataTransferServer;
@@ -418,38 +419,34 @@ public class TestEncryptedTransfer {
         out.write(data);
       }
 
-      DFSClient client =
-          DFSClientAdapter.getDFSClient(dfs);
+      // Get baseline checksum with valid keys.
+      FileChecksum checksum = dfs.getFileChecksum(ecFile);
+
+      // Spy on DFSClient to simulate InvalidEncryptionKeyException
+      // on connectToDN until clearDataEncryptionKey is called.
+      DFSClient client = DFSClientAdapter.getDFSClient(dfs);
       DFSClient spyClient = Mockito.spy(client);
       DFSClientAdapter.setDFSClient(dfs, spyClient);
 
-      FileChecksum checksum = dfs.getFileChecksum(ecFile);
-
-      BlockTokenSecretManager btsm = cluster.getNamesystem()
-          .getBlockManager().getBlockTokenSecretManager();
-      // Reduce key update interval and token life for testing.
-      btsm.setKeyUpdateIntervalForTesting(2 * 1000);
-      btsm.setTokenLifetime(2 * 1000);
-      btsm.clearAllKeysForTesting();
-
-      // Wait until the encryption key becomes invalid on all DNs.
-      LOG.info("Wait until encryption keys become invalid...");
-      DataEncryptionKey encryptionKey = spyClient.getEncryptionKey();
-      List<DataNode> dataNodes = cluster.getDataNodes();
-      for (DataNode dn : dataNodes) {
-        GenericTestUtils.waitFor(
-            () -> !dn.getBlockPoolTokenSecretManager()
-                .get(encryptionKey.blockPoolId)
-                .hasKey(encryptionKey.keyId),
-            100, 30 * 1000);
-      }
-      LOG.info("The encryption key is invalid on all nodes now.");
+      java.util.concurrent.atomic.AtomicBoolean keyCleared =
+          new java.util.concurrent.atomic.AtomicBoolean(false);
+      Mockito.doAnswer(invocation -> {
+        keyCleared.set(true);
+        return invocation.callRealMethod();
+      }).when(spyClient).clearDataEncryptionKey();
+      Mockito.doAnswer(invocation -> {
+        if (!keyCleared.get()) {
+          throw new InvalidEncryptionKeyException("test invalid key");
+        }
+        return invocation.callRealMethod();
+      }).when(spyClient).connectToDN(Mockito.any(DatanodeInfo.class),
+          Mockito.anyInt(), Mockito.any());
 
       // This should succeed: InvalidEncryptionKeyException should be
       // caught, the stale key cleared, and the checksum retried.
       FileChecksum verifyChecksum = dfs.getFileChecksum(ecFile);
-      // Verify that clearDataEncryptionKey was called to refresh the key.
-      Mockito.verify(spyClient, times(1)).clearDataEncryptionKey();
+      Mockito.verify(spyClient, Mockito.atLeastOnce())
+          .clearDataEncryptionKey();
       assertEquals(checksum, verifyChecksum);
     } finally {
       dfs.close();


### PR DESCRIPTION
  ### Description of PR

Jira: [HDFS-17897](https://issues.apache.org/jira/browse/HDFS-17897)


  HDFS-12931 added handling for `InvalidEncryptionKeyException` in `ReplicatedFileChecksumComputer.checksumBlock()` but missed the parallel striped file path `StripedFileNonStripedChecksumComputer.checksumBlockGroup()`.

Both paths call `DFSClient.connectToDN()`, which performs a SASL handshake using a cached `DataEncryptionKey` (DEK). After NameNode key rotation, the client may still hold a cached DEK derived from an old `BlockKey` that has already expired and been removed from DataNodes (as described in HDFS-12931), causing the handshake to fail with `InvalidEncryptionKeyException`. 

In the replicated path, this exception is caught, `clearDataEncryptionKey()` is called to invalidate the cached DEK, and the block is retried. In the striped path, the exception falls through to the generic `catch (IOException)` block, which only logs a warning. The stale DEK is never cleared, so every DataNode in the block group fails with the same error. The operation fails permanently — even retrying within the same DFSClient instance (e.g., from a long-lived application like Hive in HDFS-12931)

  **Fix:** Add `catch (InvalidEncryptionKeyException)` in `checksumBlockGroup()`, mirroring the existing handling in `checksumBlock()`.

  ### How was this patch tested?

  - Added `testStripedFileChecksumWithInvalidEncryptionKey` in `TestEncryptedTransfer`, which creates an EC file, invalidates the encryption key on all DataNodes, and verifies that `getFileChecksum()` succeeds by catching the exception and refreshing the key.

