### PR TITLE
HADOOP-19848: AzureNativeFileSystemStore fails with NoSuchMethodError on Jetty 9.4.57+

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
@@ -426,7 +426,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
    * @return The JSON serializer.
    */
   private static JSON createPermissionJsonSerializer() {
-    org.eclipse.jetty.util.log.Log.getProperties().setProperty("org.eclipse.jetty.util.log.announce", "false");
+    System.setProperty("org.eclipse.jetty.util.log.announce", "false");
     JSON serializer = new JSON();
     serializer.addConvertor(PermissionStatus.class,
         new PermissionStatusJsonSerializer());


### PR DESCRIPTION
### Description of PR

When using hadoop-azure with Apache Spark 4.0, AzureNativeFileSystemStore fails to load with:

 
_`Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NoSuchMethodError: 'java.util.Properties org.eclipse.jetty.util.log.Log.getProperties()' [in thread "Thread-31"]`_

 **Root cause:**

 **AzureNativeFileSystemStore.createPermissionJsonSerializer()** calls org.eclipse.jetty.util.log.Log.getProperties() to suppress Jetty's log announcement. While this method exists in **jetty-util** 9.4.57 (as shipped with Hadoop 3.4.x), Spark 4.0 bundles a different version of Jetty on the runtime classpath where this method has been removed. This causes a compile-vs-runtime classpath mismatch — the code compiles fine against Hadoop's Jetty version but fails at runtime under Spark's classloader.

  This is a fragile dependency on a Jetty internal API (org.eclipse.jetty.util.log.Log) that is unnecessary. Jetty reads the org.eclipse.jetty.util.log.announce property from system properties, so **System.setProperty()**  achieves the same effect without coupling to Jetty internals.

### How was this patch tested?
Tested with Spark 4.0 Job. After this change Azure filesytem initialization is successful 

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')? -- Yes
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation? --Yes
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? -- No
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? -- No

### AI Tooling
 
If an AI tool was used:  -- No

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html