### PR TITLE
HADOOP-19824: Proper fix using maven.multiModuleProjectDirectory

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-cos/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-cos/pom.xml
@@ -72,7 +72,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-cloud-storage-project/hadoop-gcp/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-gcp/pom.xml
@@ -372,7 +372,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -67,7 +67,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-cloud-storage-project/hadoop-tos/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-tos/pom.xml
@@ -177,7 +177,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -269,7 +269,7 @@
         <configuration>
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-common-project/hadoop-kms/pom.xml
+++ b/hadoop-common-project/hadoop-kms/pom.xml
@@ -247,7 +247,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-common-project/hadoop-minikdc/pom.xml
+++ b/hadoop-common-project/hadoop-minikdc/pom.xml
@@ -79,7 +79,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-common-project/hadoop-nfs/pom.xml
+++ b/hadoop-common-project/hadoop-nfs/pom.xml
@@ -118,7 +118,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-common-project/hadoop-registry/pom.xml
+++ b/hadoop-common-project/hadoop-registry/pom.xml
@@ -196,7 +196,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${project.basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
@@ -367,7 +367,7 @@
         <configuration>
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/pom.xml
@@ -247,7 +247,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <configuration>
           <excludeFilterFiles>
             <excludeFilterFile>
-              ../../dev-support/findbugs-exclude-global.xml
+              ${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/pom.xml
@@ -181,8 +181,7 @@
           <xmlOutput>true</xmlOutput>
            <excludeFilterFiles>
              <excludeFilterFile>${mr.basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-             <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
-             </excludeFilterFile>
+             <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml</excludeFilterFile>
            </excludeFilterFiles>
           <effort>Max</effort>
        </configuration>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/pom.xml
@@ -168,7 +168,7 @@
            <excludeFilterFiles>
              <excludeFilterFile>${mr.examples.basedir}/dev-support/findbugs-exclude.xml
              </excludeFilterFile>
-             <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+             <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
              </excludeFilterFile>
            </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-mapreduce-project/pom.xml
+++ b/hadoop-mapreduce-project/pom.xml
@@ -128,7 +128,7 @@
             <xmlOutput>true</xmlOutput>
             <excludeFilterFiles>
               <excludeFilterFile>${mr.basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-              <excludeFilterFile>../dev-support/findbugs-exclude-global.xml
+              <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
               </excludeFilterFile>
             </excludeFilterFiles>
             <effort>Max</effort>

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -94,7 +94,7 @@
         <configuration>
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-            <excludeFilterFile>../dev-support/findbugs-exclude-global.xml</excludeFilterFile>
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml</excludeFilterFile>
           </excludeFilterFiles>
           <maxHeap>2048</maxHeap>
         </configuration>

--- a/hadoop-tools/hadoop-aliyun/pom.xml
+++ b/hadoop-tools/hadoop-aliyun/pom.xml
@@ -65,7 +65,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-archive-logs/pom.xml
+++ b/hadoop-tools/hadoop-archive-logs/pom.xml
@@ -219,7 +219,7 @@
               ${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
             <excludeFilterFile>
-              ../../dev-support/findbugs-exclude-global.xml
+              ${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -332,7 +332,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${project.basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -59,7 +59,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-benchmark/pom.xml
+++ b/hadoop-tools/hadoop-benchmark/pom.xml
@@ -77,7 +77,7 @@
         <configuration>
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/src/main/findbugs/exclude.xml</excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
         </configuration>

--- a/hadoop-tools/hadoop-datajoin/pom.xml
+++ b/hadoop-tools/hadoop-datajoin/pom.xml
@@ -136,7 +136,7 @@
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
             </excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-fs2img/pom.xml
+++ b/hadoop-tools/hadoop-fs2img/pom.xml
@@ -114,7 +114,7 @@
           <xmlOutput>true</xmlOutput>
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-gridmix/pom.xml
+++ b/hadoop-tools/hadoop-gridmix/pom.xml
@@ -150,7 +150,7 @@
           <xmlOutput>true</xmlOutput>
            <excludeFilterFiles>
              <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-             <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+             <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
              </excludeFilterFile>
            </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-rumen/pom.xml
+++ b/hadoop-tools/hadoop-rumen/pom.xml
@@ -129,7 +129,7 @@
           <xmlOutput>true</xmlOutput>
            <excludeFilterFiles>
              <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-             <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+             <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
              </excludeFilterFile>
            </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-sls/pom.xml
+++ b/hadoop-tools/hadoop-sls/pom.xml
@@ -139,7 +139,7 @@
           <xmlOutput>true</xmlOutput>
           <excludeFilterFiles>
             <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-            <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
             </excludeFilterFile>
           </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-tools/hadoop-streaming/pom.xml
+++ b/hadoop-tools/hadoop-streaming/pom.xml
@@ -156,7 +156,7 @@
           <xmlOutput>true</xmlOutput>
            <excludeFilterFiles>
              <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-             <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+             <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
              </excludeFilterFile>
            </excludeFilterFiles>
           <effort>Max</effort>

--- a/hadoop-yarn-project/hadoop-yarn/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/pom.xml
@@ -46,7 +46,7 @@
           <xmlOutput>true</xmlOutput>
            <excludeFilterFiles>
              <excludeFilterFile>${yarn.basedir}/dev-support/findbugs-exclude.xml</excludeFilterFile>
-             <excludeFilterFile>../../dev-support/findbugs-exclude-global.xml
+             <excludeFilterFile>${maven.multiModuleProjectDirectory}/dev-support/findbugs-exclude-global.xml
              </excludeFilterFile>
            </excludeFilterFiles>
           <effort>Max</effort>


### PR DESCRIPTION
My previous fix #8344 for the spotbugs build failure `Build failure: Could not find
resource '${repo.root}'` used relative paths which break for inherited projects.

Instead use maven.multiModuleProjectDirectory, which resolves correctly for
inherited projects (since Maven 3.3.1).

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
```
mvn -DskipTests test-compile spotbugs:spotbugs -DskipTests=true
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [na] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [na] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [na] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html