### PR TITLE
YARN-11953. Use the HTTP auth type property to check the necessary authentication steps in CS UI. (#8374)

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/config/constants.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/config/constants.ts
@@ -25,3 +25,8 @@
  * When set to 'true', the UI will allow viewing and staging changes but prevent mutations.
  */
 export const READ_ONLY_PROPERTY = 'yarn.webapp.scheduler-ui.read-only.enable';
+
+/**
+ * YARN configuration property that controls HTTP authentication for web UIs and REST APIs.
+ */
+export const HTTP_AUTH_PROPERTY = 'hadoop.http.authentication.type';

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/lib/api/YarnApiClient.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/lib/api/YarnApiClient.ts
@@ -35,7 +35,7 @@ import type {
   YarnConfigResponse,
   ValidationResponse,
 } from '~/types';
-import { READ_ONLY_PROPERTY } from '~/config';
+import { HTTP_AUTH_PROPERTY, READ_ONLY_PROPERTY } from '~/config';
 
 export class YarnApiClient {
   private readonly baseUrl: string;
@@ -238,11 +238,13 @@ export class YarnApiClient {
   }
 
   /**
-   * Detect YARN security mode by checking hadoop.security.authentication
+   * Detect YARN security mode by checking the HTTP authentication type.
+   * This governs the REST API layer, which may differ from the cluster-wide
+   * hadoop.security.authentication setting (e.g. Kerberos RPC + simple HTTP).
    */
   private async detectSecurityMode(): Promise<void> {
     try {
-      const authMode = await this.getConfiguration('hadoop.security.authentication');
+      const authMode = await this.getConfiguration(HTTP_AUTH_PROPERTY);
       this.securityMode = authMode.toLowerCase() === 'simple' ? 'simple' : 'kerberos';
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/lib/api/mocks/handlers.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/lib/api/mocks/handlers.ts
@@ -19,7 +19,7 @@
 
 import { http, HttpResponse, type HttpHandler } from 'msw';
 import { API_CONFIG } from '~/lib/api/config';
-import { READ_ONLY_PROPERTY } from '~/config';
+import { HTTP_AUTH_PROPERTY, READ_ONLY_PROPERTY } from '~/config';
 
 // Base URL pattern that matches the API configuration
 
@@ -114,11 +114,11 @@ const staticHandlers: HttpHandler[] = [
     const url = new URL(request.url);
     const configName = url.searchParams.get('name');
 
-    // Handle security authentication mode query
-    if (configName === 'hadoop.security.authentication') {
+    // Handle HTTP authentication mode query
+    if (configName === HTTP_AUTH_PROPERTY) {
       return HttpResponse.json({
         property: {
-          name: 'hadoop.security.authentication',
+          name: HTTP_AUTH_PROPERTY,
           value: 'simple',
         },
       });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/lib/api/mocks/server-handlers.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/lib/api/mocks/server-handlers.ts
@@ -20,6 +20,7 @@
 import { http, HttpResponse } from 'msw';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { HTTP_AUTH_PROPERTY } from '~/config';
 
 // Helper to load JSON files for server-side testing
 function loadMockData(filename: string) {
@@ -38,7 +39,7 @@ export const serverHandlers = [
     const url = new URL(request.url);
     const name = url.searchParams.get('name');
 
-    if (name === 'hadoop.security.authentication') {
+    if (name === HTTP_AUTH_PROPERTY) {
       return HttpResponse.json({ property: { value: 'simple' } });
     }
 


### PR DESCRIPTION
(cherry picked from commit a05185a550b5fed1ae4ce9a523e4a1e69c2b05a8)

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html