### PR TITLE
YARN-11952. FederationQueryRunner SQL cleanup

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/sql/FederationQueryRunner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/sql/FederationQueryRunner.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.federation.store.sql;
 import org.apache.hadoop.classification.VisibleForTesting;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.CallableStatement;
@@ -43,15 +44,15 @@ public class FederationQueryRunner {
   public final static String YARN_ROUTER_CURRENT_KEY_ID = "YARN_ROUTER_CURRENT_KEY_ID";
 
   public final static String QUERY_SEQUENCE_TABLE_SQL =
-      "SELECT nextVal FROM sequenceTable WHERE sequenceName = %s";
+      "SELECT nextVal FROM sequenceTable WHERE sequenceName = ?";
 
   public final static String INSERT_SEQUENCE_TABLE_SQL =
-      "INSERT INTO sequenceTable(sequenceName, nextVal) VALUES(%s, %d)";
+      "INSERT INTO sequenceTable(sequenceName, nextVal) VALUES(?, ?)";
 
   public final static String UPDATE_SEQUENCE_TABLE_SQL =
-      "UPDATE sequenceTable SET nextVal = %d WHERE sequenceName = %s";
+      "UPDATE sequenceTable SET nextVal = ? WHERE sequenceName = ?";
 
-  public final static String DELETE_QUEUE_SQL = "DELETE FROM policies WHERE queue = %s";
+  public final static String DELETE_QUEUE_SQL = "DELETE FROM policies WHERE queue = ?";
 
   public static final Logger LOG = LoggerFactory.getLogger(FederationQueryRunner.class);
 
@@ -215,38 +216,40 @@ public class FederationQueryRunner {
     int maxSequenceValue = 0;
     boolean insertDone = false;
     boolean committed = false;
-    Statement statement = null;
 
     try {
+      DbType dbType = DatabaseProduct.getDbType(connection);
+      // Build the FOR UPDATE variant of the SELECT template once (string op on the
+      // parameterized constant, before binding so the ? placeholder is preserved).
+      String forUpdateSQL = DatabaseProduct.addForUpdateClause(dbType, QUERY_SEQUENCE_TABLE_SQL);
 
       // Step1. Query SequenceValue.
       while (maxSequenceValue == 0) {
-        // Query SQL.
-        String sql = String.format(QUERY_SEQUENCE_TABLE_SQL, quoteString(sequenceName));
-        DbType dbType = DatabaseProduct.getDbType(connection);
-        String forUpdateSQL = DatabaseProduct.addForUpdateClause(dbType, sql);
-        statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery(forUpdateSQL);
-        if (rs.next()) {
-          maxSequenceValue = rs.getInt("nextVal");
-        } else if (insertDone) {
-          throw new SQLException("Invalid state of SEQUENCE_TABLE for " + sequenceName);
-        } else {
-          insertDone = true;
-          close(statement);
-          statement = connection.createStatement();
-          String insertSQL = String.format(INSERT_SEQUENCE_TABLE_SQL, quoteString(sequenceName), 1);
-          try {
-            statement.executeUpdate(insertSQL);
-          } catch (SQLException e) {
-            // If the record is already inserted by some other thread continue to select.
-            if (isDuplicateKeyError(dbType, e)) {
-              continue;
+        try (PreparedStatement select = connection.prepareStatement(forUpdateSQL)) {
+          select.setString(1, sequenceName);
+          try (ResultSet rs = select.executeQuery()) {
+            if (rs.next()) {
+              maxSequenceValue = rs.getInt("nextVal");
+            } else if (insertDone) {
+              throw new SQLException("Invalid state of SEQUENCE_TABLE for " + sequenceName);
+            } else {
+              insertDone = true;
+              try (PreparedStatement insert =
+                       connection.prepareStatement(INSERT_SEQUENCE_TABLE_SQL)) {
+                insert.setString(1, sequenceName);
+                insert.setInt(2, 1);
+                try {
+                  insert.executeUpdate();
+                } catch (SQLException e) {
+                  // If the record is already inserted by some other thread continue to select.
+                  if (isDuplicateKeyError(dbType, e)) {
+                    continue;
+                  }
+                  LOG.error("Unable to insert into SEQUENCE_TABLE for {}.", sequenceName, e);
+                  throw e;
+                }
+              }
             }
-            LOG.error("Unable to insert into SEQUENCE_TABLE for {}.", sequenceName, e);
-            throw e;
-          } finally {
-            close(statement);
           }
         }
       }
@@ -254,36 +257,34 @@ public class FederationQueryRunner {
       // Step2. Increase SequenceValue.
       if (isUpdate) {
         int nextSequenceValue = maxSequenceValue + 1;
-        close(statement);
-        statement = connection.createStatement();
-        String updateSQL =
-            String.format(UPDATE_SEQUENCE_TABLE_SQL, nextSequenceValue, quoteString(sequenceName));
-        statement.executeUpdate(updateSQL);
-        maxSequenceValue = nextSequenceValue;
+        try (PreparedStatement update =
+                 connection.prepareStatement(UPDATE_SEQUENCE_TABLE_SQL)) {
+          update.setInt(1, nextSequenceValue);
+          update.setString(2, sequenceName);
+          update.executeUpdate();
+          maxSequenceValue = nextSequenceValue;
+        }
       }
 
       connection.commit();
       committed = true;
       return maxSequenceValue;
-    } catch(SQLException e){
+    } catch (SQLException e) {
       throw new SQLException("Unable to selectOrUpdateSequenceTable due to: " + e.getMessage(), e);
     } finally {
       if (!committed) {
         rollbackDBConn(connection);
       }
-      close(statement);
     }
   }
 
   public void updateSequenceTable(Connection connection, String sequenceName, int sequenceValue)
       throws SQLException {
-    String updateSQL =
-        String.format(UPDATE_SEQUENCE_TABLE_SQL, sequenceValue, quoteString(sequenceName));
     boolean committed = false;
-    Statement statement = null;
-    try {
-      statement = connection.createStatement();
-      statement.executeUpdate(updateSQL);
+    try (PreparedStatement statement = connection.prepareStatement(UPDATE_SEQUENCE_TABLE_SQL)) {
+      statement.setInt(1, sequenceValue);
+      statement.setString(2, sequenceName);
+      statement.executeUpdate();
       connection.commit();
       committed = true;
     } catch (SQLException e) {
@@ -292,18 +293,21 @@ public class FederationQueryRunner {
       if (!committed) {
         rollbackDBConn(connection);
       }
-      close(statement);
     }
   }
 
+  /**
+   * Drop a queue from the policy.
+   * @param connection DB connection
+   * @param queue queue name
+   * @throws SQLException failure
+   */
   public void deletePolicyByQueue(Connection connection, String queue)
       throws SQLException {
-    String deleteSQL = String.format(DELETE_QUEUE_SQL, quoteString(queue));
     boolean committed = false;
-    Statement statement = null;
-    try {
-      statement = connection.createStatement();
-      statement.executeUpdate(deleteSQL);
+    try (PreparedStatement statement = connection.prepareStatement(DELETE_QUEUE_SQL)) {
+      statement.setString(1, queue);
+      statement.executeUpdate();
       connection.commit();
       committed = true;
     } catch (SQLException e) {
@@ -312,7 +316,6 @@ public class FederationQueryRunner {
       if (!committed) {
         rollbackDBConn(connection);
       }
-      close(statement);
     }
   }
 
@@ -339,9 +342,9 @@ public class FederationQueryRunner {
 
   private String getTruncateStatement(DbType dbType, String tableName) {
     if (isMYSQL(dbType)) {
-      return ("DELETE FROM \"" + tableName + "\"");
+      return "DELETE FROM `" + tableName + "`";
     } else {
-      return("DELETE FROM " + tableName);
+      return "DELETE FROM " + tableName;
     }
   }
 
@@ -357,9 +360,5 @@ public class FederationQueryRunner {
     } catch (SQLException e) {
       LOG.warn("Failed to rollback db connection ", e);
     }
-  }
-
-  static String quoteString(String input) {
-    return "'" + input + "'";
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/utils/FederationPolicyStoreInputValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/utils/FederationPolicyStoreInputValidator.java
@@ -158,5 +158,9 @@ public final class FederationPolicyStoreInputValidator {
       throw new FederationStateStoreInvalidInputException(
           "The queues that needs to be deleted cannot be empty.");
     }
+
+    for (String queue : queues) {
+      checkQueue(queue);
+    }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
@@ -96,6 +96,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Base class for FederationMembershipStateStore implementations.
@@ -1187,6 +1188,42 @@ public abstract class FederationStateStoreBaseTest {
     for (SubClusterPolicyConfiguration policyConfig : policiesConfigs2) {
       Assert.assertFalse(deleteQueues.contains(policyConfig.getQueue()));
     }
+  }
+
+  @Test
+  public void testAccidentalQueueDeletion() throws Exception {
+    // Make sure the parameters are processed.
+    FederationStateStore federationStateStore = this.getStateStore();
+    setPolicyConf("Queue1", "PolicyType1");
+    setPolicyConf("Queue2", "PolicyType2");
+
+    // with a PreparedStatement it is treated as a literal queue name that does not match.
+    List<String> queues = List.of("' OR '1'='1");
+    federationStateStore.deletePoliciesConfigurations(
+        DeleteSubClusterPoliciesConfigurationsRequest.newInstance(queues));
+
+    // Both queues must still be present.
+    GetSubClusterPoliciesConfigurationsResponse response =
+        federationStateStore.getPoliciesConfigurations(
+            GetSubClusterPoliciesConfigurationsRequest.newInstance());
+    assertThat(response).describedAs("response").isNotNull();
+    List<String> remaining = response.getPoliciesConfigs()
+        .stream()
+        .map(SubClusterPolicyConfiguration::getQueue)
+        .toList();
+    assertThat(remaining)
+        .contains("Queue1");
+    assertThat(remaining)
+        .contains("Queue2");
+  }
+
+  @Test
+  public void testEmptyQueueNameRejected() throws Exception {
+    // The input validator must reject a request that contains a blank queue name.
+    DeleteSubClusterPoliciesConfigurationsRequest request =
+        DeleteSubClusterPoliciesConfigurationsRequest.newInstance(List.of("ValidQueue", ""));
+    LambdaTestUtils.intercept(YarnException.class, "Missing Queue",
+        () -> getStateStore().deletePoliciesConfigurations(request));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
@@ -26,11 +26,13 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ReservationId;
@@ -89,6 +91,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.RouterRMTokenReque
 import org.apache.hadoop.yarn.server.federation.store.records.RouterRMTokenResponse;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.util.MonotonicClock;
+
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -96,7 +100,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * Base class for FederationMembershipStateStore implementations.
@@ -1198,7 +1201,7 @@ public abstract class FederationStateStoreBaseTest {
     setPolicyConf("Queue2", "PolicyType2");
 
     // with a PreparedStatement it is treated as a literal queue name that does not match.
-    List<String> queues = List.of("' OR '1'='1");
+    List<String> queues = Lists.newArrayList("' OR '1'='1");
     federationStateStore.deletePoliciesConfigurations(
         DeleteSubClusterPoliciesConfigurationsRequest.newInstance(queues));
 
@@ -1206,14 +1209,14 @@ public abstract class FederationStateStoreBaseTest {
     GetSubClusterPoliciesConfigurationsResponse response =
         federationStateStore.getPoliciesConfigurations(
             GetSubClusterPoliciesConfigurationsRequest.newInstance());
-    assertThat(response).describedAs("response").isNotNull();
+    Assertions.assertThat(response).describedAs("response").isNotNull();
     List<String> remaining = response.getPoliciesConfigs()
         .stream()
         .map(SubClusterPolicyConfiguration::getQueue)
-        .toList();
-    assertThat(remaining)
+        .collect(Collectors.toList());
+    Assertions.assertThat(remaining)
         .contains("Queue1");
-    assertThat(remaining)
+    Assertions.assertThat(remaining)
         .contains("Queue2");
   }
 
@@ -1221,7 +1224,7 @@ public abstract class FederationStateStoreBaseTest {
   public void testEmptyQueueNameRejected() throws Exception {
     // The input validator must reject a request that contains a blank queue name.
     DeleteSubClusterPoliciesConfigurationsRequest request =
-        DeleteSubClusterPoliciesConfigurationsRequest.newInstance(List.of("ValidQueue", ""));
+        DeleteSubClusterPoliciesConfigurationsRequest.newInstance(Lists.newArrayList("ValidQueue", ""));
     LambdaTestUtils.intercept(YarnException.class, "Missing Queue",
         () -> getStateStore().deletePoliciesConfigurations(request));
   }


### PR DESCRIPTION
All SQL statements other than truncateTable() now use prepared statements.

Extra tests for the public operation which was the most brittle.

Closes #8373

Backport of 9386a5db5c00

Contains code generated by copilot/claude

### How was this patch tested?

new test

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [X] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html