### PR TITLE
MAPREDUCE-7523. MapReduce Task-Level Security Enforcement

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.mapreduce.v2.app.rm.RMContainerRequestor;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMHeartbeatHandler;
 import org.apache.hadoop.mapreduce.v2.app.rm.preemption.AMPreemptionPolicy;
 import org.apache.hadoop.mapreduce.v2.app.rm.preemption.NoopAMPreemptionPolicy;
+import org.apache.hadoop.mapreduce.v2.app.security.authorize.TaskLevelSecurityEnforcer;
 import org.apache.hadoop.mapreduce.v2.app.speculate.DefaultSpeculator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.Speculator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.SpeculatorEvent;
@@ -1683,6 +1684,7 @@ public class MRAppMaster extends CompositeService {
       String jobUserName = System
           .getenv(ApplicationConstants.Environment.USER.name());
       conf.set(MRJobConfig.USER_NAME, jobUserName);
+      TaskLevelSecurityEnforcer.validate(conf);
       initAndStartAppMaster(appMaster, conf, jobUserName);
     } catch (Throwable t) {
       LOG.error("Error starting MRAppMaster", t);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -1684,7 +1684,7 @@ public class MRAppMaster extends CompositeService {
       String jobUserName = System
           .getenv(ApplicationConstants.Environment.USER.name());
       conf.set(MRJobConfig.USER_NAME, jobUserName);
-      TaskLevelSecurityEnforcer.validate(conf);
+      TaskLevelSecurityEnforcer.validate(conf, UserGroupInformation.getCurrentUser());
       initAndStartAppMaster(appMaster, conf, jobUserName);
     } catch (Throwable t) {
       LOG.error("Error starting MRAppMaster", t);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -77,7 +77,7 @@ public final class TaskLevelSecurityEnforcer {
 
     String currentUserName = UserGroupInformation.isSecurityEnabled()
         ? currentUser.getShortUserName()
-        : StringUtils.trim(conf.get(MRJobConfig.USER_NAME));
+        : conf.getTrimmed(MRJobConfig.USER_NAME);
 
     List<String> allowedUsers = Arrays.asList(conf.getTrimmedStrings(
         MRConfig.SECURITY_ALLOWED_USERS,
@@ -98,7 +98,7 @@ public final class TaskLevelSecurityEnforcer {
         MRConfig.DEFAULT_SECURITY_DENIED_TASKS
     );
     for (String property : propertyDomain) {
-      String propertyValue = StringUtils.trim(conf.get(property, ""));
+      String propertyValue = conf.getTrimmed(property, "");
       for (String deniedTask : deniedTasks) {
         if (propertyValue.startsWith(deniedTask)) {
           throw new TaskLevelSecurityException(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -68,9 +68,13 @@ public final class TaskLevelSecurityEnforcer {
    * @param currentUser the user who running the AM container
    * @throws TaskLevelSecurityException if the user is not authorized to use one of the task classes
    */
-  public static void validate(JobConf conf, UserGroupInformation currentUser) throws TaskLevelSecurityException {
-    if (!conf.getBoolean(MRConfig.SECURITY_ENABLED, MRConfig.DEFAULT_SECURITY_ENABLED)) {
-      LOG.debug("The {} is disabled",  MRConfig.SECURITY_ENABLED);
+  public static void validate(JobConf conf, UserGroupInformation currentUser)
+      throws TaskLevelSecurityException {
+    if (!conf.getBoolean(
+        MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED,
+        MRConfig.DEFAULT_SECURITY_ENABLED
+    )) {
+      LOG.debug("The {} is disabled",  MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED);
       return;
     }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.v2.app.security.authorize;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.MRConfig;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+
+/**
+ * Enforces task-level security rules for MapReduce jobs.
+ *
+ * <p>This security enforcement mechanism validates whether the user who submitted
+ * a job is allowed to execute the mapper/reducer/task classes defined in the job
+ * configuration. The check is performed inside the Application Master before
+ * task containers are launched.</p>
+ * <p>If the user is not on the allowed list and any job property within the configured
+ * security property domain references a denied class/prefix, a
+ * {@link TaskLevelSecurityException} is thrown and the job is rejected.</p>
+ * <p>This prevents unauthorized or unsafe custom code from running inside
+ * cluster containers.</p>
+ */
+public final class TaskLevelSecurityEnforcer {
+  private static final Logger LOG = LoggerFactory.getLogger(TaskLevelSecurityEnforcer.class);
+
+  /**
+   * Default constructor.
+   */
+  private TaskLevelSecurityEnforcer() {
+  }
+
+  /**
+   * Validates a MapReduce job's configuration against the cluster's task-level
+   * security policy.
+   *
+   * <p>The method performs the following steps:</p>
+   * <ol>
+   *   <li>Check whether task-level security is enabled.</li>
+   *   <li>Allow the job immediately if the user is on the configured allowed-users list.</li>
+   *   <li>Retrieve the security property domain (list of job configuration keys to inspect).</li>
+   *   <li>Retrieve the list of denied task class prefixes.</li>
+   *   <li>For each domain property, check whether its value begins with any denied prefix.</li>
+   *   <li>If a match is found, reject the job by throwing {@link TaskLevelSecurityException}.</li>
+   * </ol>
+   *
+   * @param conf the job configuration to validate
+   * @throws TaskLevelSecurityException if the user is not authorized to use one of the task classes
+   */
+  public static void validate(JobConf conf) throws TaskLevelSecurityException {
+    if (!conf.getBoolean(MRConfig.SECURITY_ENABLED, MRConfig.DEFAULT_SECURITY_ENABLED)) {
+      LOG.debug("The {} is disabled",  MRConfig.SECURITY_ENABLED);
+      return;
+    }
+
+    String currentUser = conf.get(MRJobConfig.USER_NAME).trim();
+    List<String> allowedUsers = Arrays.asList(conf.getTrimmedStrings(
+        MRConfig.SECURITY_ALLOWED_USERS,
+        MRConfig.DEFAULT_SECURITY_ALLOWED_USERS
+    ));
+    if (allowedUsers.contains(currentUser)) {
+      LOG.debug("The {} is allowed to execute every task", currentUser);
+      return;
+    }
+
+    String[] propertyDomain = conf.getTrimmedStrings(
+        MRConfig.SECURITY_PROPERTY_DOMAIN,
+        MRConfig.DEFAULT_SECURITY_PROPERTY_DOMAIN
+    );
+    String[] deniedTasks = conf.getTrimmedStrings(
+        MRConfig.SECURITY_DENIED_TASKS,
+        MRConfig.DEFAULT_SECURITY_DENIED_TASKS
+    );
+    for (String property : propertyDomain) {
+      String propertyValue = conf.get(property, "").trim();
+      for (String deniedTask : deniedTasks) {
+        if (propertyValue.startsWith(deniedTask)) {
+          throw new TaskLevelSecurityException(currentUser, property, propertyValue, deniedTask);
+        }
+      }
+    }
+    LOG.debug("The {} is allowed to execute the submitted job", currentUser);
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -72,7 +73,7 @@ public final class TaskLevelSecurityEnforcer {
       return;
     }
 
-    String currentUser = conf.get(MRJobConfig.USER_NAME).trim();
+    String currentUser = StringUtils.trim(conf.get(MRJobConfig.USER_NAME));
     List<String> allowedUsers = Arrays.asList(conf.getTrimmedStrings(
         MRConfig.SECURITY_ALLOWED_USERS,
         MRConfig.DEFAULT_SECURITY_ALLOWED_USERS
@@ -91,7 +92,7 @@ public final class TaskLevelSecurityEnforcer {
         MRConfig.DEFAULT_SECURITY_DENIED_TASKS
     );
     for (String property : propertyDomain) {
-      String propertyValue = conf.get(property, "").trim();
+      String propertyValue = StringUtils.trim(conf.get(property, ""));
       for (String deniedTask : deniedTasks) {
         if (propertyValue.startsWith(deniedTask)) {
           throw new TaskLevelSecurityException(currentUser, property, propertyValue, deniedTask);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 
 /**
  * Enforces task-level security rules for MapReduce jobs.
@@ -64,22 +65,27 @@ public final class TaskLevelSecurityEnforcer {
    *   <li>If a match is found, reject the job by throwing {@link TaskLevelSecurityException}.</li>
    * </ol>
    *
-   * @param conf the job configuration to validate
+   * @param conf        the job configuration to validate
+   * @param currentUser the user who running the AM container
    * @throws TaskLevelSecurityException if the user is not authorized to use one of the task classes
    */
-  public static void validate(JobConf conf) throws TaskLevelSecurityException {
+  public static void validate(JobConf conf, UserGroupInformation currentUser) throws TaskLevelSecurityException {
     if (!conf.getBoolean(MRConfig.SECURITY_ENABLED, MRConfig.DEFAULT_SECURITY_ENABLED)) {
       LOG.debug("The {} is disabled",  MRConfig.SECURITY_ENABLED);
       return;
     }
 
-    String currentUser = StringUtils.trim(conf.get(MRJobConfig.USER_NAME));
+    String currentUserName = UserGroupInformation.isSecurityEnabled()
+        ? currentUser.getShortUserName()
+        : StringUtils.trim(conf.get(MRJobConfig.USER_NAME));
+
     List<String> allowedUsers = Arrays.asList(conf.getTrimmedStrings(
         MRConfig.SECURITY_ALLOWED_USERS,
         MRConfig.DEFAULT_SECURITY_ALLOWED_USERS
     ));
-    if (allowedUsers.contains(currentUser)) {
-      LOG.debug("The {} is allowed to execute every task", currentUser);
+
+    if (allowedUsers.contains(currentUserName)) {
+      LOG.debug("The {} is allowed to execute every task", currentUserName);
       return;
     }
 
@@ -95,7 +101,8 @@ public final class TaskLevelSecurityEnforcer {
       String propertyValue = StringUtils.trim(conf.get(property, ""));
       for (String deniedTask : deniedTasks) {
         if (propertyValue.startsWith(deniedTask)) {
-          throw new TaskLevelSecurityException(currentUser, property, propertyValue, deniedTask);
+          throw new TaskLevelSecurityException(
+              currentUserName, property, propertyValue, deniedTask);
         }
       }
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityException.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityException.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.v2.app.security.authorize;
+
+import org.apache.hadoop.security.AccessControlException;
+
+/**
+ * Exception thrown when a MapReduce job violates the Task-Level Security policy.
+ */
+public class TaskLevelSecurityException extends AccessControlException {
+
+  /**
+   * Constructs a new TaskLevelSecurityException describing the specific policy violation.
+   *
+   * @param user the submitting user
+   * @param property the MapReduce configuration key that was checked
+   * @param propertyValue the value provided for that configuration property
+   * @param deniedTask the blacklist entry that the value matched
+   */
+  public TaskLevelSecurityException(
+      String user, String property, String propertyValue, String deniedTask
+  ) {
+    super(String.format(
+        "The %s is not allowed to use %s = %s config, cause it match with %s denied task",
+        user, property, propertyValue, deniedTask
+    ));
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.v2.app.security.authorize;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.MRConfig;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
+
+  @Test
+  public void testServiceDisabled() {
+    JobConf conf = new JobConf();
+    assertPass(conf);
+  }
+
+  @Test
+  public void testServiceEnabled() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    assertPass(conf);
+  }
+
+  @Test
+  public void testDeniedPackage() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    assertDenied(conf);
+  }
+
+  @Test
+  public void testDeniedClass() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS,
+        "org.apache.hadoop.streaming",
+        "org.apache.hadoop.examples.QuasiMonteCarlo$QmcReducer");
+    conf.set(MRJobConfig.REDUCE_CLASS_ATTR,
+        "org.apache.hadoop.examples.QuasiMonteCarlo$QmcReducer");
+    assertDenied(conf);
+  }
+
+  @Test
+  public void testIgnoreReducer() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_PROPERTY_DOMAIN,
+        MRJobConfig.MAP_CLASS_ATTR,
+        MRJobConfig.COMBINE_CLASS_ATTR);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS,
+        "org.apache.hadoop.streaming",
+        "org.apache.hadoop.examples.QuasiMonteCarlo$QmcReducer");
+    conf.set(MRJobConfig.REDUCE_CLASS_ATTR,
+        "org.apache.hadoop.examples.QuasiMonteCarlo$QmcReducer");
+    assertPass(conf);
+  }
+
+  @Test
+  public void testDeniedUser() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    conf.set(MRJobConfig.USER_NAME, "bob");
+    assertDenied(conf);
+  }
+
+  @Test
+  public void testAllowedUser() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice", "bob");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    conf.set(MRJobConfig.USER_NAME, "bob");
+    assertPass(conf);
+  }
+
+  @Test
+  public void testTurnOff() {
+    JobConf conf = new JobConf();
+    conf.setBoolean(MRConfig.SECURITY_ENABLED, false);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    conf.set(MRJobConfig.USER_NAME, "bob");
+    assertPass(conf);
+  }
+
+  @Test
+  public void testJobConfigCanNotOverwriteMapreduceConfig() {
+    JobConf mapreduceConf = new JobConf();
+    mapreduceConf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    mapreduceConf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    mapreduceConf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
+
+    JobConf jobConf = new JobConf();
+    jobConf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "bob");
+    jobConf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    jobConf.set(MRJobConfig.USER_NAME, "bob");
+
+    mapreduceConf.addResource(jobConf);
+    assertDenied(mapreduceConf);
+  }
+
+  private void assertPass(JobConf conf) {
+    assertDoesNotThrow(
+        () -> TaskLevelSecurityEnforcer.validate(conf),
+        "Config denied but validation pass was expected");
+  }
+
+  private void assertDenied(JobConf conf) {
+    assertThrows(TaskLevelSecurityException.class,
+        () -> TaskLevelSecurityEnforcer.validate(conf),
+        "Config validation pass but denied was expected");
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
 
@@ -128,14 +128,12 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   }
 
   private void assertPass(JobConf conf) {
-    assertDoesNotThrow(
-        () -> TaskLevelSecurityEnforcer.validate(conf),
-        "Config denied but validation pass was expected");
+    assertThatCode(() -> TaskLevelSecurityEnforcer.validate(conf))
+        .doesNotThrowAnyException();
   }
 
   private void assertDenied(JobConf conf) {
-    assertThrows(TaskLevelSecurityException.class,
-        () -> TaskLevelSecurityEnforcer.validate(conf),
-        "Config validation pass but denied was expected");
+    assertThatThrownBy(() -> TaskLevelSecurityEnforcer.validate(conf))
+        .isInstanceOf(TaskLevelSecurityException.class);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
@@ -39,14 +39,14 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testServiceEnabled() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     assertPass(conf);
   }
 
   @Test
   public void testDeniedPackage() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
     assertDenied(conf);
@@ -55,7 +55,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testDeniedClass() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS,
         "org.apache.hadoop.streaming",
         "org.apache.hadoop.examples.QuasiMonteCarlo$QmcReducer");
@@ -67,7 +67,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testIgnoreReducer() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_PROPERTY_DOMAIN,
         MRJobConfig.MAP_CLASS_ATTR,
         MRJobConfig.COMBINE_CLASS_ATTR);
@@ -82,7 +82,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testDeniedUser() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
@@ -93,7 +93,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testAllowedUser() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice", "bob");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
@@ -104,7 +104,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testTurnOff() {
     JobConf conf = new JobConf();
-    conf.setBoolean(MRConfig.SECURITY_ENABLED, false);
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, false);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
@@ -115,7 +115,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   @Test
   public void testJobConfigCanNotOverwriteMapreduceConfig() {
     JobConf mapreduceConf = new JobConf();
-    mapreduceConf.setBoolean(MRConfig.SECURITY_ENABLED, true);
+    mapreduceConf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     mapreduceConf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     mapreduceConf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -128,12 +129,14 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
   }
 
   private void assertPass(JobConf conf) {
-    assertThatCode(() -> TaskLevelSecurityEnforcer.validate(conf))
+    assertThatCode(() ->
+        TaskLevelSecurityEnforcer.validate(conf, UserGroupInformation.getCurrentUser()))
         .doesNotThrowAnyException();
   }
 
   private void assertDenied(JobConf conf) {
-    assertThatThrownBy(() -> TaskLevelSecurityEnforcer.validate(conf))
+    assertThatThrownBy(() ->
+        TaskLevelSecurityEnforcer.validate(conf, UserGroupInformation.getCurrentUser()))
         .isInstanceOf(TaskLevelSecurityException.class);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRConfig.java
@@ -146,7 +146,7 @@ public interface MRConfig {
    * Default: {@value #DEFAULT_SECURITY_ENABLED}
    * Value: {@value}
    */
-  String SECURITY_ENABLED = "mapreduce.security.enabled";
+  String MAPREDUCE_TASK_SECURITY_ENABLED = "mapreduce.security.enabled";
   boolean DEFAULT_SECURITY_ENABLED = false;
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRConfig.java
@@ -133,5 +133,94 @@ public interface MRConfig {
   boolean DEFAULT_MASTER_WEBAPP_UI_ACTIONS_ENABLED = true;
   String MULTIPLE_OUTPUTS_CLOSE_THREAD_COUNT = "mapreduce.multiple-outputs-close-threads";
   int DEFAULT_MULTIPLE_OUTPUTS_CLOSE_THREAD_COUNT = 10;
+
+  /**
+   * Enables MapReduce Task-Level Security Enforcement.
+   * <p>
+   * When enabled, the Application Master performs validation of user-submitted
+   * mapper, reducer, and other task-related classes before launching containers.
+   * This mechanism protects the cluster from running disallowed or unsafe task
+   * implementations as defined by administrator-controlled policies.
+   * </p>
+   * Property type: boolean
+   * Default: {@value #DEFAULT_SECURITY_ENABLED}
+   * Value: {@value}
+   */
+  String SECURITY_ENABLED = "mapreduce.security.enabled";
+  boolean DEFAULT_SECURITY_ENABLED = false;
+
+  /**
+   * MapReduce Task-Level Security Enforcement: Property Domain
+   * <p>
+   * Defines the set of MapReduce configuration keys that represent user-supplied
+   * class names involved in task execution (e.g., mapper, reducer, partitioner).
+   * The Application Master examines the values of these properties and checks
+   * whether any referenced class is listed in {@link #SECURITY_DENIED_TASKS}.
+   * Administrators may override this list to expand or restrict the validation
+   * domain.
+   * </p>
+   * Property type: list of configuration keys
+   * Default: all known task-level class properties (see list below)
+   * Value: {@value}
+   */
+  String SECURITY_PROPERTY_DOMAIN = "mapreduce.security.property-domain";
+  String[] DEFAULT_SECURITY_PROPERTY_DOMAIN = {
+      "mapreduce.job.combine.class",
+      "mapreduce.job.combiner.group.comparator.class",
+      "mapreduce.job.end-notification.custom-notifier-class",
+      "mapreduce.job.inputformat.class",
+      "mapreduce.job.map.class",
+      "mapreduce.job.map.output.collector.class",
+      "mapreduce.job.output.group.comparator.class",
+      "mapreduce.job.output.key.class",
+      "mapreduce.job.output.key.comparator.class",
+      "mapreduce.job.output.value.class",
+      "mapreduce.job.outputformat.class",
+      "mapreduce.job.partitioner.class",
+      "mapreduce.job.reduce.class",
+      "mapreduce.map.output.key.class",
+      "mapreduce.map.output.value.class",
+      "mapreduce.outputcommitter.factory.scheme.s3a",
+      "mapreduce.outputcommitter.factory.scheme.abfs",
+      "mapreduce.outputcommitter.factory.scheme.gs",
+      "mapreduce.outputcommitter.factory.scheme.hdfs",
+      "mapreduce.outputcommitter.named.classname",
+      "mapred.mapper.class",
+      "mapred.map.runner.class",
+      "mapred.reducer.class"
+  };
+
+  /**
+   * MapReduce Task-Level Security Enforcement: Denied Tasks
+   * <p>
+   * Specifies the list of disallowed task implementation classes or packages.
+   * If a user submits a job whose mapper, reducer, or other task-related classes
+   * match any entry in this blacklist.
+   * </p>
+   * Property type: list of class name or package patterns
+   * Default: empty (no restrictions)
+   * Example: org.apache.hadoop.streaming,org.apache.hadoop.examples.QuasiMonteCarlo
+   * Value: {@value}
+   */
+  String SECURITY_DENIED_TASKS = "mapreduce.security.denied-tasks";
+  String[] DEFAULT_SECURITY_DENIED_TASKS = {};
+
+  /**
+   * MapReduce Task-Level Security Enforcement: Allowed Users
+   * <p>
+   * Specifies users who may bypass the blacklist defined in
+   * {@link #SECURITY_DENIED_TASKS}.
+   * This whitelist is intended for trusted or system-level workflows that may
+   * legitimately require the use of restricted task implementations.
+   * If the submitting user is listed here, blacklist enforcement is skipped,
+   * although standard Hadoop authentication and ACL checks still apply.
+   * </p>
+   * Property type: list of usernames
+   * Default: empty (no bypass users)
+   * Example: hue,hive
+   * Value: {@value}
+   */
+  String SECURITY_ALLOWED_USERS = "mapreduce.security.allowed-users";
+  String[] DEFAULT_SECURITY_ALLOWED_USERS = {};
 }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -2282,4 +2282,44 @@
   </description>
 </property>
 
+<property>
+  <name>mapreduce.security.enabled</name>
+  <value>false</value>
+  <description>
+    Enables MapReduce Task-Level Security Enforcement
+    When enabled, the Application Master performs validation of user-submitted mapper, reducer, and other task-related classes before launching containers.
+    This mechanism protects the cluster from running disallowed or unsafe task implementations as defined by administrator-controlled policies.
+  </description>
+</property>
+
+<property>
+  <name>mapreduce.security.property-domain</name>
+  <value>mapreduce.job.combine.class,mapreduce.job.combiner.group.comparator.class,mapreduce.job.end-notification.custom-notifier-class,mapreduce.job.inputformat.class,mapreduce.job.map.class,mapreduce.job.map.output.collector.class,mapreduce.job.output.group.comparator.class,mapreduce.job.output.key.class,mapreduce.job.output.key.comparator.class,mapreduce.job.output.value.class,mapreduce.job.outputformat.class,mapreduce.job.partitioner.class,mapreduce.job.reduce.class,mapreduce.map.output.key.class,mapreduce.map.output.value.class</value>
+  <description>
+    MapReduce Task-Level Security Enforcement: Property Domain
+    Defines the set of MapReduce configuration keys that represent user-supplied class names involved in task execution (e.g., mapper, reducer, partitioner).
+    The Application Master examines the values of these properties and checks whether any referenced class is listed in denied tasks.
+    Administrators may override this list to expand or restrict the validation domain.
+  </description>
+</property>
+
+<property>
+  <name>mapreduce.security.denied-tasks</name>
+  <value></value>
+  <description>
+    Specifies the list of disallowed task implementation classes or packages.
+    If a user submits a job whose mapper, reducer, or other task-related classes match any entry in this blacklist.
+  </description>
+</property>
+
+  <property>
+    <name>mapreduce.security.allowed-users</name>
+    <value></value>
+    <description>
+      Specifies users who may bypass the blacklist defined in denied tasks.
+      This whitelist is intended for trusted or system-level workflows that may legitimately require the use of restricted task implementations.
+      If the submitting user is listed here, blacklist enforcement is skipped, although standard Hadoop authentication and ACL checks still apply.
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/TaskLevelSecurityEnforcement.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/TaskLevelSecurityEnforcement.md
@@ -78,9 +78,9 @@ Administrators may override this list to expand or restrict the validation domai
   - mapreduce.outputcommitter.factory.scheme.gs
   - mapreduce.outputcommitter.factory.scheme.hdfs
   - mapreduce.outputcommitter.named.classname
-  - "mapred.mapper.class"
-  - "mapred.map.runner.class"
-  - "mapred.reducer.class"
+  - mapred.mapper.class
+  - mapred.map.runner.class
+  - mapred.reducer.class
 
 #### MapReduce Task-Level Security Enforcement: Denied Tasks
 Specifies the list of disallowed task implementation classes or packages.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/TaskLevelSecurityEnforcement.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/TaskLevelSecurityEnforcement.md
@@ -1,0 +1,100 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+MR Task-Level Security Enforcement
+==================
+
+<!-- MACRO{toc|fromDepth=0|toDepth=2} -->
+
+Overview
+-------
+The goal of this feature tp provide a configurable mechanism to control which users are allowed to execute specific MapReduce jobs.
+This feature aims to prevent unauthorized or potentially harmful mapper/reducer implementations from running within the Hadoop cluster.
+
+In the standard Hadoop MapReduce execution flow:
+1) A MapReduce job is submitted by a user.
+2) The job is registered with the Resource Manager (RM).
+3) The RM assigns the job to a Node Manager (NM), where the Application Master (AM) for the job is launched.
+4) The AM requests additional containers from the cluster, to be able to start tasks.
+5) The NM launches those containers, and the containers execute the mapper/reducer tasks defined by the job.
+
+This feature introduces a security filtering mechanism inside the Application Master.
+Before mapper or reducer tasks are launched, the AM will verify that the user-submitted MapReduce code complies with a cluster-defined security policy.
+This ensures that only approved classes or packages can be executed inside the containers.
+The goal is to protect the cluster from unwanted or unsafe task implementations, such as custom code that may introduce performance, stability, or security risks.
+
+Upon receiving job metadata, the Application Master will:
+1) Check the feature is enabled.
+2) Check the user who submitted the job is allowed to bypass the security check.
+3) Compare classes in job config against the denied task list.
+4) If job is not authorised an exception will be thrown and AM will fail.
+
+Configurations
+-------
+
+#### Enables MapReduce Task-Level Security Enforcement
+When enabled, the Application Master performs validation of user-submitted mapper, reducer, and other task-related classes before launching containers.
+This mechanism protects the cluster from running disallowed or unsafe task implementations as defined by administrator-controlled policies.
+- Property name: mapreduce.security.enabled
+- Property type: boolean
+- Default: false (security disabled)
+
+
+#### MapReduce Task-Level Security Enforcement: Property Domain
+Defines the set of MapReduce configuration keys that represent user-supplied class names involved in task execution (e.g., mapper, reducer, partitioner).
+The Application Master examines the values of these properties and checks whether any referenced class is listed in denied tasks.
+Administrators may override this list to expand or restrict the validation domain.
+- Property name: mapreduce.security.property-domain
+- Property type: list of configuration keys
+- Default:
+  - mapreduce.job.combine.class
+  - mapreduce.job.combiner.group.comparator.class
+  - mapreduce.job.end-notification.custom-notifier-class
+  - mapreduce.job.inputformat.class
+  - mapreduce.job.map.class
+  - mapreduce.job.map.output.collector.class
+  - mapreduce.job.output.group.comparator.class
+  - mapreduce.job.output.key.class
+  - mapreduce.job.output.key.comparator.class
+  - mapreduce.job.output.value.class
+  - mapreduce.job.outputformat.class
+  - mapreduce.job.partitioner.class
+  - mapreduce.job.reduce.class
+  - mapreduce.map.output.key.class
+  - mapreduce.map.output.value.class
+  - mapreduce.outputcommitter.factory.scheme.s3a
+  - mapreduce.outputcommitter.factory.scheme.abfs
+  - mapreduce.outputcommitter.factory.scheme.gs
+  - mapreduce.outputcommitter.factory.scheme.hdfs
+  - mapreduce.outputcommitter.named.classname
+  - "mapred.mapper.class"
+  - "mapred.map.runner.class"
+  - "mapred.reducer.class"
+
+#### MapReduce Task-Level Security Enforcement: Denied Tasks
+Specifies the list of disallowed task implementation classes or packages.
+If a user submits a job whose mapper, reducer, or other task-related classes match any entry in this blacklist.
+- Property name: mapreduce.security.denied-tasks
+- Property type: list of class name or package patterns
+- Default: empty
+- Example: org.apache.hadoop.streaming,org.apache.hadoop.examples.QuasiMonteCarlo
+
+#### MapReduce Task-Level Security Enforcement: Allowed Users
+Specifies users who may bypass the blacklist defined in denied tasks.
+This whitelist is intended for trusted or system-level workflows that may legitimately require the use of restricted task implementations.
+If the submitting user is listed here, blacklist enforcement is skipped, although standard Hadoop authentication and ACL checks still apply.
+- Property name: mapreduce.security.allowed-users
+- Property type: list of usernames
+- Default: empty
+- Example: alice,bob

--- a/hadoop-project/src/site/site.xml
+++ b/hadoop-project/src/site/site.xml
@@ -116,6 +116,7 @@
       <item name="Pluggable Shuffle/Sort" href="hadoop-mapreduce-client/hadoop-mapreduce-client-core/PluggableShuffleAndPluggableSort.html"/>
       <item name="Distributed Cache Deploy" href="hadoop-mapreduce-client/hadoop-mapreduce-client-core/DistributedCacheDeploy.html"/>
       <item name="Support for YARN Shared Cache" href="hadoop-mapreduce-client/hadoop-mapreduce-client-core/SharedCacheSupport.html"/>
+      <item name="Task Level Security Enforcement" href="hadoop-mapreduce-client/hadoop-mapreduce-client-core/TaskLevelSecurityEnforcement.html"/>
     </menu>
 
     <menu name="MapReduce REST APIs" inherit="top">


### PR DESCRIPTION

### Description of PR

The goal of this feature tp provide a configurable mechanism to control which users are allowed to execute specific MapReduce jobs. This feature aims to prevent unauthorized or potentially harmful mapper/reducer implementations from running within the Hadoop cluster.

In the standard Hadoop MapReduce execution flow:
1) A MapReduce job is submitted by a user.
2) The job is registered with the Resource Manager (RM). 
3) The RM assigns the job to a Node Manager (NM), where the Application Master (AM) for the job is launched. 
4) The AM requests additional containers from the cluster, to be able to start tasks. 
5) The NM launches those containers, and the containers execute the mapper/reducer tasks defined by the job.

The proposed feature introduces a security filtering mechanism inside the Application Master. Before mapper or reducer tasks are launched, the AM will verify that the user-submitted MapReduce code complies with a cluster-defined security policy. This ensures that only approved classes or packages can be executed inside the containers. The goal is to protect the cluster from unwanted or unsafe task implementations, such as custom code that may introduce performance, stability, or security risks.

Upon receiving job metadata, the Application Master will: 
1) Check the feature is enabled.
2) Check the user who submitted the job is allowed to bypass the security check. 
3) Compare classes in job config against the denied task list. 
4) If job is not authorised an exception will be thrown and AM will fail.

### How was this patch tested?

UT was created

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html