### PR TITLE
HADOOP-19758. Avoid tput in shell usage formatting when unavailable.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -375,9 +375,11 @@ function hadoop_generic_columnprinter
 
   if [[ -n "${COLUMNS}" ]]; then
     numcols=${COLUMNS}
-  else
-    numcols=$(tput cols) 2>/dev/null
-    COLUMNS=${numcols}
+  elif command -v tput >/dev/null 2>&1; then
+    numcols=$(tput cols 2>/dev/null)
+    if [[ "${numcols}" =~ ^[0-9]+$ ]]; then
+      COLUMNS=${numcols}
+    fi
   fi
 
   if [[ -z "${numcols}"

--- a/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_subcommands.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_subcommands.bats
@@ -76,3 +76,24 @@ TOKEN
   run "${BATS_TEST_DIRNAME}/../../main/bin/hadoop" multi 1 2
   [ "${output}" = 2 ]
 }
+
+@test "hadoop_generic_columnprinter (missing tput)" {
+  local oldpath="${PATH}"
+  local fakebin="${TMP}/fakebin"
+
+  mkdir -p "${fakebin}"
+  ln -s "$(command -v sort)" "${fakebin}/sort"
+  ln -s "$(command -v fold)" "${fakebin}/fold"
+
+  PATH="${fakebin}"
+  unset COLUMNS
+
+  run hadoop_generic_columnprinter "" \
+    "archive-logs@client@combine aggregated logs into hadoop archives"
+
+  PATH="${oldpath}"
+
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"archive-logs"* ]]
+  [[ "${output}" != *"tput: command not found"* ]]
+}


### PR DESCRIPTION
Summary
Avoid invoking `tput` when it is not installed, so Hadoop shell usage formatting works on minimal distros without ncurses.

Change
- `hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh`: guard the terminal-width probe with `command -v tput` and fall back cleanly to the default width.
- `hadoop-common-project/hadoop-common/src/test/scripts/hadoop_subcommands.bats`: add a regression for the missing-`tput` path.

JIRA
Fixes HADOOP-19758
