### PR TITLE
MAPREDUCE-7486. Add fast-fail guidance when cluster storage capacity is exceeded.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/YarnChild.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/YarnChild.java
@@ -255,6 +255,11 @@ class YarnChild {
         LOG.error(
             "Fast fail the job because the cluster storage capacity was exceeded.");
         fastFailJob = true;
+      } else {
+        LOG.warn(
+            "The cluster storage capacity was exceeded, but fast fail is disabled. "
+                + "Set {} to true to enable fast fail.",
+            MRJobConfig.JOB_DFS_STORAGE_CAPACITY_KILL_LIMIT_EXCEED);
       }
     }
     umbilical.fatalError(taskid, StringUtils.stringifyException(exception),

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ClusterStorageCapacityExceededException;
+import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the behavior of YarnChild.
@@ -91,7 +94,8 @@ public class TestYarnChild {
         new RuntimeException(new ClusterStorageCapacityExceededException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, false);
 
-    verifyReportError(exception, false);
+    verifyReportError(exception, false,
+        "The cluster storage capacity was exceeded, but fast fail is disabled.");
   }
 
   @Test
@@ -119,5 +123,24 @@ public class TestYarnChild {
     YarnChild.reportError(exception, task, umbilical);
     verify(umbilical).fatalError(any(), anyString(),
         eq(fastFail));
+  }
+
+  private void verifyReportError(Exception exception, boolean fastFail,
+      String expectedLogMessage) throws IOException {
+    LogCapturer logCapturer = LogCapturer.captureLogs(
+        LoggerFactory.getLogger(YarnChild.class));
+    try {
+      verifyReportError(exception, fastFail);
+      assertTrue(logCapturer.getOutput().contains(expectedLogMessage));
+      if (fastFail) {
+        assertTrue(logCapturer.getOutput().contains(
+            "Fast fail the job because the cluster storage capacity was exceeded."));
+      } else {
+        assertTrue(logCapturer.getOutput().contains(
+            KILL_LIMIT_EXCEED_CONF_NAME));
+      }
+    } finally {
+      logCapturer.stopCapturing();
+    }
   }
 }


### PR DESCRIPTION

## Summary
This patch improves the logging path in `YarnChild.reportError()` when `ClusterStorageCapacityExceededException` is raised and fast fail is disabled. The task now emits a warning that explains why the job is not failing immediately and points users to the configuration that enables fast fail.

## Change
- `hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/YarnChild.java`: add a warning log message for the non-fast-fail capacity-exceeded path.
- `hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java`: extend the unit coverage to assert the warning path and preserve the existing fatal-error behavior checks.

## Tests
- `JAVA_HOME=/opt/homebrew/opt/openjdk /opt/homebrew/bin/mvn -Dmaven.repo.local=/tmp/codex-m2 test -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app -am -Dtest=TestYarnChild -DskipTests=false`

## JIRA
Fixes MAPREDUCE-7486

### For code changes:

- [x] The title starts with the corresponding JIRA issue ID.
- [ ] Object storage integration tests and endpoint declaration: Not applicable: this PR does not change an object-store connector.
- [x] No new dependencies are introduced.
- [x] No LICENSE or NOTICE updates are needed for this diff.

### AI Tooling

Contains content generated by Codex.

- [x] AI-generated content is disclosed.
- [x] Use follows https://www.apache.org/legal/generative-tooling.html.

### How was this patch tested?

Earlier commands above are historical evidence, where present. Current rebase validation passed `git diff --check`; fresh hosted CI is running. Focused Java validation is reported separately when complete.

### Validated repair head `3b214ff2` (2026-09-19)

`TestYarnChild` passed in a Java 17/Maven 3.9.15 Linux container: 7 tests, 0 failures, 0 errors, 0 skipped. The full selected reactor finished successfully; this verifies the warning and existing fatal-error paths.

`mvn -B -ntp -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app -am -Dtest=TestYarnChild -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test`
