### PR TITLE
YARN-11851. Make preemptable container tracking thread-safe.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSPreemptionThread.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSPreemptionThread.java
@@ -295,7 +295,7 @@ class FSPreemptionThread extends Thread {
    * A class to track preemptable containers.
    */
   private static class PreemptableContainers {
-    Map<ApplicationId, List<RMContainer>> containersByApp;
+    private final Map<ApplicationId, List<RMContainer>> containersByApp;
     int numAMContainers;
     int maxAMContainers;
 
@@ -312,7 +312,8 @@ class FSPreemptionThread extends Thread {
      * @param container the container to add
      * @return true if success; false otherwise
      */
-    private boolean addContainer(RMContainer container, ApplicationId appId) {
+    private synchronized boolean addContainer(RMContainer container,
+        ApplicationId appId) {
       if (container.isAMContainer()) {
         numAMContainers++;
         if (numAMContainers >= maxAMContainers) {
@@ -320,15 +321,12 @@ class FSPreemptionThread extends Thread {
         }
       }
 
-      if (!containersByApp.containsKey(appId)) {
-        containersByApp.put(appId, new ArrayList<>());
-      }
-
-      containersByApp.get(appId).add(container);
+      containersByApp.computeIfAbsent(appId, key -> new ArrayList<>())
+          .add(container);
       return true;
     }
 
-    private List<RMContainer> getAllContainers() {
+    private synchronized List<RMContainer> getAllContainers() {
       List<RMContainer> allContainers = new ArrayList<>();
       for (List<RMContainer> containersForApp : containersByApp.values()) {
         allContainers.addAll(containersForApp);
@@ -336,12 +334,15 @@ class FSPreemptionThread extends Thread {
       return allContainers;
     }
 
-    private Resource getResourcesToPreemptForApp(ApplicationId appId) {
+    private synchronized Resource getResourcesToPreemptForApp(
+        ApplicationId appId) {
       Resource resourcesToPreempt = Resources.createResource(0, 0);
-      if (containersByApp.containsKey(appId)) {
-        for (RMContainer container : containersByApp.get(appId)) {
-          Resources.addTo(resourcesToPreempt, container.getAllocatedResource());
-        }
+      List<RMContainer> containersForApp = containersByApp.get(appId);
+      if (containersForApp == null) {
+        return resourcesToPreempt;
+      }
+      for (RMContainer container : containersForApp) {
+        Resources.addTo(resourcesToPreempt, container.getAllocatedResource());
       }
       return resourcesToPreempt;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSPreemptionThread.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSPreemptionThread.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
+import org.apache.hadoop.yarn.util.resource.Resources;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class TestFSPreemptionThread {
+
+  @Test
+  public void testPreemptableContainersConcurrentAccess() throws Exception {
+    Class<?> preemptableContainersClass = Class.forName(
+        FSPreemptionThread.class.getName() + "$PreemptableContainers");
+    Constructor<?> constructor =
+        preemptableContainersClass.getDeclaredConstructor(int.class);
+    constructor.setAccessible(true);
+    Object preemptableContainers = constructor.newInstance(Integer.MAX_VALUE);
+
+    Method addContainer = preemptableContainersClass.getDeclaredMethod(
+        "addContainer", RMContainer.class, ApplicationId.class);
+    Method getAllContainers = preemptableContainersClass.getDeclaredMethod(
+        "getAllContainers");
+    addContainer.setAccessible(true);
+    getAllContainers.setAccessible(true);
+
+    int iterations = 500;
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> writer = executor.submit(() -> {
+        await(start);
+        for (int i = 0; i < iterations; i++) {
+          invokeAddContainer(addContainer, preemptableContainers, i);
+        }
+      });
+      Future<?> reader = executor.submit(() -> {
+        await(start);
+        for (int i = 0; i < iterations; i++) {
+          invokeGetAllContainers(getAllContainers, preemptableContainers);
+        }
+      });
+
+      start.countDown();
+      writer.get();
+      reader.get();
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
+
+    @SuppressWarnings("unchecked")
+    List<RMContainer> allContainers =
+        (List<RMContainer>) getAllContainers.invoke(preemptableContainers);
+    assertEquals(iterations, allContainers.size());
+  }
+
+  private static void invokeAddContainer(Method addContainer,
+      Object preemptableContainers, int index) {
+    try {
+      addContainer.invoke(preemptableContainers, createContainer(index),
+          ApplicationId.newInstance(1L, index));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void invokeGetAllContainers(Method getAllContainers,
+      Object preemptableContainers) {
+    try {
+      getAllContainers.invoke(preemptableContainers);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static RMContainer createContainer(int index) {
+    RMContainer container = Mockito.mock(RMContainer.class);
+    when(container.isAMContainer()).thenReturn(false);
+    Resource resource = Resources.createResource(1);
+    when(container.getAllocatedResource()).thenReturn(resource);
+    when(container.getContainerId()).thenReturn(null);
+    when(container.getNodeId()).thenReturn(null);
+    return container;
+  }
+
+  private static void await(CountDownLatch start) {
+    try {
+      start.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
Summary
This PR makes FairScheduler preemption tracking thread-safe by synchronizing mutable access in `FSPreemptionThread`.

Change
- `hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSPreemptionThread.java`: synchronize `PreemptableContainers` mutation and iteration so concurrent preemption bookkeeping cannot hit `ConcurrentModificationException`.
- `hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSPreemptionThread.java`: add a regression test that hammers concurrent add and iterate access.

JIRA
Fixes YARN-11851

### For code changes:

- [x] The title starts with the corresponding JIRA issue ID.
- [ ] Object storage integration tests and endpoint declaration: Not applicable: this PR does not change an object-store connector.
- [x] No new dependencies are introduced.
- [x] No LICENSE or NOTICE updates are needed for this diff.

### AI Tooling

Contains content generated by Codex.

- [x] AI-generated content is disclosed.
- [x] Use follows https://www.apache.org/legal/generative-tooling.html.

### How was this patch tested?

Earlier commands above are historical evidence, where present. Current rebase validation passed `git diff --check`; fresh hosted CI is running. Focused Java validation is reported separately when complete.

### Validated repair head `08439e84` (2026-09-19)

The concurrency regression passes in a Java 17/Maven 3.9.15 container (1 test, no failures or errors).

`mvn -B -ntp -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager -am -Dtest=TestFSPreemptionThread -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test`

The reactor completed successfully and Surefire reported 1 tests, 0 failures, 0 errors, 0 skipped. `git diff --check` also passes. Hosted CI for this head remains separate.
