### PR TITLE
HDFS-17902. StripedBlockChecksumReconstructor leaks connections on init failure

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockChecksumHelper.java
@@ -713,6 +713,7 @@ final class BlockChecksumHelper {
           new StripedBlockChecksumMd5CrcReconstructor(
               getDatanode().getErasureCodingWorker(), stripedReconInfo,
               blockChecksumBuf, blockLength)) {
+        checksumRecon.init();
         checksumRecon.reconstruct();
 
         DataChecksum checksum = checksumRecon.getChecksum();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockChecksumReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockChecksumReconstructor.java
@@ -52,16 +52,9 @@ public abstract class StripedBlockChecksumReconstructor
     assert targetIndices != null;
     this.checksumWriter = checksumWriter;
     this.requestedLen = requestedBlockLength;
-    try {
-      init();
-    } catch (IOException e) {
-      getStripedReader().close();
-      cleanup();
-      throw e;
-    }
   }
 
-  private void init() throws IOException {
+  public void init() throws IOException {
     initDecoderIfNecessary();
     initDecodingValidatorIfNecessary();
     getStripedReader().init();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockChecksumReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockChecksumReconstructor.java
@@ -52,7 +52,13 @@ public abstract class StripedBlockChecksumReconstructor
     assert targetIndices != null;
     this.checksumWriter = checksumWriter;
     this.requestedLen = requestedBlockLength;
-    init();
+    try {
+      init();
+    } catch (IOException e) {
+      getStripedReader().close();
+      cleanup();
+      throw e;
+    }
   }
 
   private void init() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileChecksum.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileChecksum.java
@@ -717,6 +717,48 @@ public class TestFileChecksum {
     }
   }
 
+  @MethodSource("getParameters")
+  @ParameterizedTest
+  @Timeout(value = 90)
+  public void testStripedChecksumReconCleanupOnInitFailure(String pMode)
+      throws Exception {
+    initTestFileChecksum(pMode);
+    String stripedFile = ecDir + "/stripedFileChecksumInitFail";
+    prepareTestFiles(fileSize, new String[]{stripedFile});
+
+    LocatedBlocks locatedBlocks = client.getLocatedBlocks(stripedFile, 0);
+    LocatedBlock locatedBlock = locatedBlocks.get(0);
+    DatanodeInfo[] blockDns = locatedBlock.getLocations();
+
+    int numToKill = parityBlocks + 1;
+    int[] killedIdx = new int[numToKill];
+    int killed = 0;
+    for (int i = 0; i < blockDns.length && killed < numToKill; i++) {
+      int idx = 0;
+      for (DataNode dn : cluster.getDataNodes()) {
+        if (dn.getInfoPort() == blockDns[i].getInfoPort()) {
+          shutdownDataNode(dn);
+          killedIdx[killed++] = idx;
+          break;
+        }
+        idx++;
+      }
+    }
+
+    try {
+      Exception ex = assertThrows(Exception.class, () -> {
+        fs.getFileChecksum(new Path(stripedFile));
+      });
+      LOG.info("Got expected failure when too many DNs are down: {}",
+          ex.getMessage());
+    } finally {
+      for (int i = 0; i < killed; i++) {
+        cluster.restartDataNode(killedIdx[i]);
+      }
+      cluster.waitActive();
+    }
+  }
+
   private FileChecksum getFileChecksum(String filePath, int range,
                                        boolean killDn) throws Exception {
     int dnIdxToDie = -1;


### PR DESCRIPTION
HDFS-17902. StripedBlockChecksumReconstructor leaks connections on init failure

### Description of PR
When BlockGroupNonStripedChecksumComputer.recalculateChecksum() allocates a StripedBlockChecksumReconstructor with try-with-resources, the reconstructor's constructor calls StripedReconstructor's superclass constructor first, which creates a StripedReader. The constructor then calls getStripedReader().init(), which in turn calls initReaders().

If initReaders() fails because nSuccess < minRequiredSources, it throws IOException. initReaders() does not close StripedBlockReader instances that were already created and may already hold open block/TCP connections to peer DataNodes.

Because the constructor throws before the StripedBlockChecksumReconstructor instance is successfully created, the try-with-resources statement never assigns the resource variable and therefore does not invoke Closeable.close() on the reconstructor (JLS: resource is only closed if initialization completes normally). As a result, StripedReader.close() is never called on that code path, and connections opened during the failed initReaders() loop can leak.

By contrast, StripedBlockReconstructor.run() always calls getStripedReader().close() in a finally block, so the same failure mode is cleaned up there.