### PR TITLE
HADOOP-19852: hadoop-tos test failures due to reflection failure

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-tos/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-tos/pom.xml
@@ -165,7 +165,6 @@
           <perCoreThreadCount>true</perCoreThreadCount>
           <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <forkCount>8</forkCount>
-          <argLine>-Xmx2048m</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
### Description of PR

hadoop-tos tests fail for me locally due to a reflection error. The reason is that hadoop-tos/pom.xml overrides the maven-surefire-plugin JVM `<argLine>` twice, dropping the `--add-opens` that enables the reflective access for short-term compatibility in Java 17.

```
[ERROR] org.apache.hadoop.fs.tosfs.object.TestObjectRangeInputStream.testSeek -- Time elapsed: 0.016 s <<< ERROR!
java.lang.IllegalStateException: Failed to set environment variable
	at org.apache.hadoop.fs.tosfs.util.TestUtility.setSystemEnv(TestUtility.java:120)
	at org.apache.hadoop.fs.tosfs.object.ObjectStorageTestBase.setUp(ObjectStorageTestBase.java:59)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @7fab8c68
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at org.apache.hadoop.fs.tosfs.util.TestUtility.setSystemEnv(TestUtility.java:116)
	... 4 more
```

### How was this patch tested?

`mvn -o clean test` in hadoop-tos passes for me locally after applying this patch.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html