### PR TITLE
HDFS-17723. RBF: Optimize multiple mount point removal

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterAdminProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterAdminProtocolServerSideTranslatorPB.java
@@ -43,6 +43,8 @@ import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProt
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.LeaveSafeModeResponseProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RefreshMountTableEntriesRequestProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RefreshMountTableEntriesResponseProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesRequestProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesResponseProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntryRequestProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntryResponseProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.UpdateMountTableEntryRequestProto;
@@ -73,6 +75,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.LeaveSafeModeRequ
 import org.apache.hadoop.hdfs.server.federation.store.protocol.LeaveSafeModeResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryRequest;
@@ -100,6 +104,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.LeaveSafe
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RefreshMountTableEntriesRequestPBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RefreshMountTableEntriesResponsePBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RefreshSuperUserGroupsConfigurationResponsePBImpl;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntriesRequestPBImpl;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntriesResponsePBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntryRequestPBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntryResponsePBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.UpdateMountTableEntryRequestPBImpl;
@@ -162,6 +168,24 @@ public class RouterAdminProtocolServerSideTranslatorPB implements
           server.removeMountTableEntry(req);
       RemoveMountTableEntryResponsePBImpl responsePB =
           (RemoveMountTableEntryResponsePBImpl)response;
+      return responsePB.getProto();
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
+  }
+
+  @Override
+  public RemoveMountTableEntriesResponseProto removeMountTableEntries(
+      RpcController controller,
+      RemoveMountTableEntriesRequestProto request)
+      throws ServiceException {
+    try {
+      RemoveMountTableEntriesRequest req =
+          new RemoveMountTableEntriesRequestPBImpl(request);
+      RemoveMountTableEntriesResponse response =
+          server.removeMountTableEntries(req);
+      RemoveMountTableEntriesResponsePBImpl responsePB =
+          (RemoveMountTableEntriesResponsePBImpl)response;
       return responsePB.getProto();
     } catch (IOException e) {
       throw new ServiceException(e);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterAdminProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterAdminProtocolTranslatorPB.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProt
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RefreshMountTableEntriesResponseProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RefreshSuperUserGroupsConfigurationRequestProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RefreshSuperUserGroupsConfigurationResponseProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesRequestProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesResponseProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntryRequestProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntryResponseProto;
 import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.UpdateMountTableEntryRequestProto;
@@ -76,6 +78,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.LeaveSafeModeRequ
 import org.apache.hadoop.hdfs.server.federation.store.protocol.LeaveSafeModeResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryRequest;
@@ -99,6 +103,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.LeaveSafe
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RefreshMountTableEntriesRequestPBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RefreshMountTableEntriesResponsePBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RefreshSuperUserGroupsConfigurationResponsePBImpl;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntriesRequestPBImpl;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntriesResponsePBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntryRequestPBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.RemoveMountTableEntryResponsePBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb.UpdateMountTableEntryRequestPBImpl;
@@ -203,6 +209,21 @@ public class RouterAdminProtocolTranslatorPB
       return new RemoveMountTableEntryResponsePBImpl(responseProto);
     } catch (ServiceException e) {
 
+      throw new IOException(getRemoteException(e).getMessage());
+    }
+  }
+
+  @Override
+  public RemoveMountTableEntriesResponse removeMountTableEntries(
+      RemoveMountTableEntriesRequest request) throws IOException {
+    RemoveMountTableEntriesRequestPBImpl requestPB =
+        (RemoveMountTableEntriesRequestPBImpl)request;
+    RemoveMountTableEntriesRequestProto proto = requestPB.getProto();
+    try {
+      RemoveMountTableEntriesResponseProto responseProto =
+          rpcProxy.removeMountTableEntries(null, proto);
+      return new RemoveMountTableEntriesResponsePBImpl(responseProto);
+    } catch (ServiceException e) {
       throw new IOException(getRemoteException(e).getMessage());
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableManager.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntr
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryRequest;
@@ -76,11 +78,21 @@ public interface MountTableManager {
    * Remove an entry from the mount table.
    *
    * @param request Fully populated request object.
-   * @return True the mount table entry was removed from the data store.
+   * @return True if the mount table entry was removed from the data store.
    * @throws IOException Throws exception if the data store is not initialized.
    */
   RemoveMountTableEntryResponse removeMountTableEntry(
       RemoveMountTableEntryRequest request) throws IOException;
+
+  /**
+   * Remove multiple entries from the mount table.
+   *
+   * @param request Fully populated request object.
+   * @return True if all paths were removed from the data store.
+   * @throws IOException if the data store is not initialized.
+   */
+  RemoveMountTableEntriesResponse removeMountTableEntries(RemoveMountTableEntriesRequest request)
+      throws IOException;
 
   /**
    * List all mount table entries present at or below the path. Fetches from the

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
@@ -34,6 +34,8 @@ import java.util.Set;
 
 import org.apache.hadoop.hdfs.server.federation.store.protocol.AddMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.AddMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.util.Preconditions;
 
 import org.apache.hadoop.conf.Configuration;
@@ -513,6 +515,22 @@ public class RouterAdminServer extends AbstractService
           request.getSrcPath(), e.getMessage());
     }
     return getMountTableStore().removeMountTableEntry(request);
+  }
+
+  @Override
+  public RemoveMountTableEntriesResponse removeMountTableEntries(
+      RemoveMountTableEntriesRequest request) throws IOException {
+    // clear sub-cluster's quota definition
+    for (String path : request.getSrcPaths()) {
+      try {
+        synchronizeQuota(path, HdfsConstants.QUOTA_RESET, HdfsConstants.QUOTA_RESET, null);
+      } catch (Exception e) {
+        // Ignore exception, if any while reseting quota. Specifically to handle
+        // if the actual destination doesn't exist.
+        LOG.warn("Unable to clear quota at the destinations for {}: {}", path, e.getMessage());
+      }
+    }
+    return getMountTableStore().removeMountTableEntries(request);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MountTableStoreImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MountTableStoreImpl.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.hdfs.server.federation.store.impl;
 import static org.apache.hadoop.hdfs.DFSUtil.isParentEntry;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -44,6 +46,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntr
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryRequest;
@@ -53,6 +57,7 @@ import org.apache.hadoop.hdfs.server.federation.store.records.Query;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.util.Time;
 import static org.apache.hadoop.hdfs.server.federation.router.Quota.eachByStorageType;
+import static org.apache.hadoop.hdfs.server.federation.store.StateStoreUtils.filterMultiple;
 
 /**
  * Implementation of the {@link MountTableStore} state store API.
@@ -204,6 +209,63 @@ public class MountTableStoreImpl extends MountTableStore {
         RemoveMountTableEntryResponse.newInstance();
     response.setStatus(status);
     if (status) {
+      updateCacheAllRouters();
+    }
+    return response;
+  }
+
+  @Override
+  public RemoveMountTableEntriesResponse removeMountTableEntries(
+      RemoveMountTableEntriesRequest request) throws IOException {
+    List<RemoveMountTableEntriesResponse.EntryFailure> failures = new ArrayList<>();
+    List<MountTable> entriesToRemove = new ArrayList<>();
+    List<MountTable> allEntries = getDriver().get(getRecordClass()).getRecords();
+    for (String path : request.getSrcPaths()) {
+      final MountTable partial = MountTable.newInstance();
+      partial.setSourcePath(path);
+      final Query<MountTable> query = new Query<>(partial);
+      List<MountTable> filtered = filterMultiple(query, allEntries);
+      if (filtered.isEmpty()) {
+        failures.add(new RemoveMountTableEntriesResponse.EntryFailure(path,
+            RemoveMountTableEntriesResponse.FailureReason.NONEXISTENT_MOUNT_POINT));
+        continue;
+      }
+      if (filtered.size() > 1) {
+        failures.add(new RemoveMountTableEntriesResponse.EntryFailure(path,
+            RemoveMountTableEntriesResponse.FailureReason.UNKNOWN_FAILURE));
+        continue;
+      }
+      MountTable deleteEntry = filtered.get(0);
+      try {
+        RouterPermissionChecker pc = RouterAdminServer.getPermissionChecker();
+        if (pc != null) {
+          pc.checkPermission(deleteEntry, FsAction.WRITE);
+        }
+        entriesToRemove.add(deleteEntry);
+      } catch (AccessControlException e) {
+        failures.add(new RemoveMountTableEntriesResponse.EntryFailure(path,
+            RemoveMountTableEntriesResponse.FailureReason.ACCESS_DENIED));
+      }
+    }
+
+    boolean anyRemoved = false;
+    if (!entriesToRemove.isEmpty()) {
+      Map<MountTable, Boolean> statuses = getDriver().removeMultiple(entriesToRemove);
+      for (Map.Entry<MountTable, Boolean> mapEntry : statuses.entrySet()) {
+        if (!mapEntry.getValue()) {
+          failures.add(new RemoveMountTableEntriesResponse.EntryFailure(
+              mapEntry.getKey().getSourcePath(),
+              RemoveMountTableEntriesResponse.FailureReason.DRIVER_FAILURE));
+        } else {
+          anyRemoved = true;
+        }
+      }
+    }
+
+    RemoveMountTableEntriesResponse response = RemoveMountTableEntriesResponse.newInstance();
+    response.setStatus(failures.isEmpty());
+    response.setFailedEntries(failures);
+    if (anyRemoved) {
       updateCacheAllRouters();
     }
     return response;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/RemoveMountTableEntriesRequest.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/RemoveMountTableEntriesRequest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.store.protocol;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreSerializer;
+
+/**
+ * API request for removing multiple mount table paths in the state store.
+ */
+public abstract class RemoveMountTableEntriesRequest {
+
+  public static RemoveMountTableEntriesRequest newInstance() throws IOException {
+    return StateStoreSerializer.newRecord(RemoveMountTableEntriesRequest.class);
+  }
+
+  public static RemoveMountTableEntriesRequest newInstance(List<String> paths) throws IOException {
+    RemoveMountTableEntriesRequest request = newInstance();
+    request.setSrcPaths(paths);
+    return request;
+  }
+
+  @Public
+  @Unstable
+  public abstract List<String> getSrcPaths();
+
+  @Public
+  @Unstable
+  public abstract void setSrcPaths(List<String> paths);
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/RemoveMountTableEntriesResponse.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/RemoveMountTableEntriesResponse.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.store.protocol;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreSerializer;
+
+/**
+ * API response for removing multiple mount table paths in the state store.
+ */
+public abstract class RemoveMountTableEntriesResponse {
+
+  public static RemoveMountTableEntriesResponse newInstance() throws IOException {
+    return StateStoreSerializer.newRecord(RemoveMountTableEntriesResponse.class);
+  }
+
+  @Public
+  @Unstable
+  public abstract boolean getStatus();
+
+  @Public
+  @Unstable
+  public abstract List<EntryFailure> getFailedEntries();
+
+  @Public
+  @Unstable
+  public abstract void setStatus(boolean result);
+
+  @Public
+  @Unstable
+  public abstract void setFailedEntries(List<EntryFailure> failedEntries);
+
+  /**
+   * A mount table that failed to be removed, as well as the reason why.
+   */
+  @Public
+  @Unstable
+  public static class EntryFailure {
+    private final String srcPath;
+    private final FailureReason reason;
+
+    public EntryFailure(String srcPath,
+        FailureReason reason) {
+      this.srcPath = srcPath;
+      this.reason = reason;
+    }
+
+    public String getSrcPath() {
+      return srcPath;
+    }
+
+    public FailureReason getReason() {
+      return reason;
+    }
+  }
+
+  /**
+   * Reason a mount table path failed to be removed.
+   */
+  @Public
+  @Unstable
+  public enum FailureReason {
+    UNKNOWN_FAILURE,
+    NONEXISTENT_MOUNT_POINT,
+    DRIVER_FAILURE,
+    ACCESS_DENIED
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/impl/pb/RemoveMountTableEntriesRequestPBImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/impl/pb/RemoveMountTableEntriesRequestPBImpl.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.thirdparty.protobuf.Message;
+
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesRequestProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesRequestProtoOrBuilder;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.records.impl.pb.PBRecord;
+
+/**
+ * Protobuf implementation of the state store API object
+ * RemoveMountTableEntriesRequest.
+ */
+public class RemoveMountTableEntriesRequestPBImpl extends RemoveMountTableEntriesRequest
+    implements PBRecord {
+
+  private FederationProtocolPBTranslator<
+      RemoveMountTableEntriesRequestProto,
+      RemoveMountTableEntriesRequestProto.Builder,
+      RemoveMountTableEntriesRequestProtoOrBuilder>
+      translator = new FederationProtocolPBTranslator<>(RemoveMountTableEntriesRequestProto.class);
+
+  public RemoveMountTableEntriesRequestPBImpl() {
+  }
+
+  public RemoveMountTableEntriesRequestPBImpl(RemoveMountTableEntriesRequestProto proto) {
+    this.setProto(proto);
+  }
+
+  @Override
+  public RemoveMountTableEntriesRequestProto getProto() {
+    return this.translator.build();
+  }
+
+  @Override
+  public void setProto(Message proto) {
+    this.translator.setProto(proto);
+  }
+
+  @Override
+  public void readInstance(String base64String) throws IOException {
+    this.translator.readInstance(base64String);
+  }
+
+  @Override
+  public List<String> getSrcPaths() {
+    return this.translator.getProtoOrBuilder().getSrcPathsList();
+  }
+
+  @Override
+  public void setSrcPaths(List<String> paths) {
+    this.translator.getBuilder().addAllSrcPaths(paths);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/impl/pb/RemoveMountTableEntriesResponsePBImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/impl/pb/RemoveMountTableEntriesResponsePBImpl.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.store.protocol.impl.pb;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.thirdparty.protobuf.Message;
+
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesResponseProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesResponseProto.Builder;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntriesResponseProtoOrBuilder;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntryFailureProto;
+import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RemoveMountTableEntryFailureReasonProto;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.records.impl.pb.PBRecord;
+
+/**
+ * Protobuf implementation of the state store API object
+ * RemoveMountTableEntriesResponse.
+ */
+public class RemoveMountTableEntriesResponsePBImpl extends RemoveMountTableEntriesResponse
+    implements PBRecord {
+
+  private FederationProtocolPBTranslator<RemoveMountTableEntriesResponseProto, Builder,
+      RemoveMountTableEntriesResponseProtoOrBuilder> translator
+          = new FederationProtocolPBTranslator<>(RemoveMountTableEntriesResponseProto.class);
+
+  public RemoveMountTableEntriesResponsePBImpl() {
+  }
+
+  public RemoveMountTableEntriesResponsePBImpl(RemoveMountTableEntriesResponseProto proto) {
+    this.setProto(proto);
+  }
+
+  private static FailureReason convert(
+      RemoveMountTableEntryFailureReasonProto proto) {
+    return switch (proto) {
+      case NONEXISTENT_MOUNT_POINT -> FailureReason.NONEXISTENT_MOUNT_POINT;
+      case DRIVER_FAILURE -> FailureReason.DRIVER_FAILURE;
+      case ACCESS_DENIED -> FailureReason.ACCESS_DENIED;
+      default -> FailureReason.UNKNOWN_FAILURE;
+    };
+  }
+
+  private static RemoveMountTableEntryFailureReasonProto convert(
+      FailureReason reason) {
+    return switch (reason) {
+      case NONEXISTENT_MOUNT_POINT ->
+          RemoveMountTableEntryFailureReasonProto.NONEXISTENT_MOUNT_POINT;
+      case DRIVER_FAILURE -> RemoveMountTableEntryFailureReasonProto.DRIVER_FAILURE;
+      case ACCESS_DENIED -> RemoveMountTableEntryFailureReasonProto.ACCESS_DENIED;
+      default -> RemoveMountTableEntryFailureReasonProto.UNKNOWN_FAILURE;
+    };
+  }
+
+  @Override
+  public RemoveMountTableEntriesResponseProto getProto() {
+    return this.translator.build();
+  }
+
+  @Override
+  public void setProto(Message proto) {
+    this.translator.setProto(proto);
+  }
+
+  @Override
+  public void readInstance(String base64String) throws IOException {
+    this.translator.readInstance(base64String);
+  }
+
+  @Override
+  public boolean getStatus() {
+    return this.translator.getProtoOrBuilder().getStatus();
+  }
+
+  @Override
+  public List<EntryFailure> getFailedEntries() {
+    List<EntryFailure> list = new ArrayList<>();
+    for (RemoveMountTableEntryFailureProto p : this.translator.getProtoOrBuilder()
+        .getFailedEntriesList()) {
+      list.add(new EntryFailure(p.getSrcPath(), convert(p.getReason())));
+    }
+    return list;
+  }
+
+  @Override
+  public void setStatus(boolean result) {
+    this.translator.getBuilder().setStatus(result);
+  }
+
+  @Override
+  public void setFailedEntries(List<EntryFailure> failedEntries) {
+    Builder b = translator.getBuilder();
+    b.clearFailedEntries();
+    for (EntryFailure entry : failedEntries) {
+      b.addFailedEntries(RemoveMountTableEntryFailureProto.newBuilder()
+          .setSrcPath(entry.getSrcPath())
+          .setReason(convert(entry.getReason()))
+          .build());
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/impl/pb/RemoveMountTableEntriesResponsePBImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/protocol/impl/pb/RemoveMountTableEntriesResponsePBImpl.java
@@ -52,21 +52,21 @@ public class RemoveMountTableEntriesResponsePBImpl extends RemoveMountTableEntri
   private static FailureReason convert(
       RemoveMountTableEntryFailureReasonProto proto) {
     return switch (proto) {
-      case NONEXISTENT_MOUNT_POINT -> FailureReason.NONEXISTENT_MOUNT_POINT;
-      case DRIVER_FAILURE -> FailureReason.DRIVER_FAILURE;
-      case ACCESS_DENIED -> FailureReason.ACCESS_DENIED;
-      default -> FailureReason.UNKNOWN_FAILURE;
+    case NONEXISTENT_MOUNT_POINT -> FailureReason.NONEXISTENT_MOUNT_POINT;
+    case DRIVER_FAILURE -> FailureReason.DRIVER_FAILURE;
+    case ACCESS_DENIED -> FailureReason.ACCESS_DENIED;
+    default -> FailureReason.UNKNOWN_FAILURE;
     };
   }
 
   private static RemoveMountTableEntryFailureReasonProto convert(
       FailureReason reason) {
     return switch (reason) {
-      case NONEXISTENT_MOUNT_POINT ->
-          RemoveMountTableEntryFailureReasonProto.NONEXISTENT_MOUNT_POINT;
-      case DRIVER_FAILURE -> RemoveMountTableEntryFailureReasonProto.DRIVER_FAILURE;
-      case ACCESS_DENIED -> RemoveMountTableEntryFailureReasonProto.ACCESS_DENIED;
-      default -> RemoveMountTableEntryFailureReasonProto.UNKNOWN_FAILURE;
+    case NONEXISTENT_MOUNT_POINT ->
+        RemoveMountTableEntryFailureReasonProto.NONEXISTENT_MOUNT_POINT;
+    case DRIVER_FAILURE -> RemoveMountTableEntryFailureReasonProto.DRIVER_FAILURE;
+    case ACCESS_DENIED -> RemoveMountTableEntryFailureReasonProto.ACCESS_DENIED;
+    default -> RemoveMountTableEntryFailureReasonProto.UNKNOWN_FAILURE;
     };
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -77,6 +78,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.LeaveSafeModeRequ
 import org.apache.hadoop.hdfs.server.federation.store.protocol.LeaveSafeModeResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RefreshMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryRequest;
@@ -383,17 +386,12 @@ public class RouterAdmin extends Configured implements Tool {
           exitCode = -1;
         }
       } else if ("-rm".equals(cmd)) {
-        while (i < argv.length) {
-          try {
-            if (removeMount(argv[i])) {
-              System.out.println("Successfully removed mount point " + argv[i]);
-            }
-          } catch (IOException e) {
-            exitCode = -1;
-            System.err
-                .println(cmd.substring(1) + ": " + e.getLocalizedMessage());
-          }
-          i++;
+        try {
+          removeMounts(argv, i);
+        } catch (IOException e) {
+          exitCode = -1;
+          System.err
+              .println(cmd.substring(1) + ": " + e.getLocalizedMessage());
         }
       } else if ("-ls".equals(cmd)) {
         listMounts(argv, i);
@@ -862,24 +860,69 @@ public class RouterAdmin extends Configured implements Tool {
   }
 
   /**
-   * Remove mount point.
+   * Remove one or multiple mount points.
    *
-   * @param path Path to remove.
-   * @return If the mount point was removed successfully.
+   * @param params parameters, should contain paths to remove
+   * @param paramIdx starting param index
    * @throws IOException If it cannot be removed.
    */
-  public boolean removeMount(String path) throws IOException {
-    path = normalizeFileSystemPath(path);
-    MountTableManager mountTable = client.getMountTableManager();
-    RemoveMountTableEntryRequest request =
-        RemoveMountTableEntryRequest.newInstance(path);
-    RemoveMountTableEntryResponse response =
-        mountTable.removeMountTableEntry(request);
-    boolean removed = response.getStatus();
-    if (!removed) {
-      System.out.println("Cannot remove mount point " + path);
+  public void removeMounts(String[] params, int paramIdx) throws IOException {
+    List<String> pathsToRemove = new ArrayList<>();
+    while (paramIdx < params.length) {
+      pathsToRemove.add(normalizeFileSystemPath(params[paramIdx]));
+      paramIdx++;
     }
-    return removed;
+    MountTableManager mountTable = client.getMountTableManager();
+    if (pathsToRemove.isEmpty()) {
+      return;
+    }
+    if (pathsToRemove.size() == 1) {
+      String path = pathsToRemove.get(0);
+      RemoveMountTableEntryRequest request = RemoveMountTableEntryRequest.newInstance(path);
+      RemoveMountTableEntryResponse response = mountTable.removeMountTableEntry(request);
+      boolean removed = response.getStatus();
+      if (!removed) {
+        System.err.println("Cannot remove mount point " + path);
+      } else {
+        System.out.println("Successfully removed mount point " + path);
+      }
+      return;
+    }
+    RemoveMountTableEntriesRequest request =
+        RemoveMountTableEntriesRequest.newInstance(pathsToRemove);
+    RemoveMountTableEntriesResponse response = mountTable.removeMountTableEntries(request);
+    Map<String, RemoveMountTableEntriesResponse.FailureReason> failures = new HashMap<>();
+    for (RemoveMountTableEntriesResponse.EntryFailure failedEntry : response.getFailedEntries()) {
+      failures.put(failedEntry.getSrcPath(), failedEntry.getReason());
+    }
+    // Print all successful removals first
+    StringBuilder failureMsgBuilder = new StringBuilder("Cannot remove mount points:\n");
+    for (String path : pathsToRemove) {
+      RemoveMountTableEntriesResponse.FailureReason failureReason = failures.get(path);
+      if (failureReason != null) {
+        failureMsgBuilder.append("\t");
+        failureMsgBuilder.append(path);
+        failureMsgBuilder.append(": ");
+        failureMsgBuilder.append(getFailureReasonString(failureReason));
+        failureMsgBuilder.append("\n");
+      } else {
+        System.out.println("Successfully removed mount point " + path);
+      }
+    }
+    // Then print all failures
+    if (!failures.isEmpty()) {
+      System.err.println(failureMsgBuilder);
+    }
+  }
+
+  private static String getFailureReasonString(
+      RemoveMountTableEntriesResponse.FailureReason reason) {
+    return switch (reason) {
+      case NONEXISTENT_MOUNT_POINT -> "mount point doesn't exist";
+      case DRIVER_FAILURE -> "driver failed";
+      case ACCESS_DENIED -> "access denied";
+      default -> "unknown failure";
+    };
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -918,10 +918,10 @@ public class RouterAdmin extends Configured implements Tool {
   private static String getFailureReasonString(
       RemoveMountTableEntriesResponse.FailureReason reason) {
     return switch (reason) {
-      case NONEXISTENT_MOUNT_POINT -> "mount point doesn't exist";
-      case DRIVER_FAILURE -> "driver failed";
-      case ACCESS_DENIED -> "access denied";
-      default -> "unknown failure";
+    case NONEXISTENT_MOUNT_POINT -> "mount point doesn't exist";
+    case DRIVER_FAILURE -> "driver failed";
+    case ACCESS_DENIED -> "access denied";
+    default -> "unknown failure";
     };
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/FederationProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/FederationProtocol.proto
@@ -189,6 +189,27 @@ message RemoveMountTableEntryResponseProto{
   optional bool status = 1;
 }
 
+message RemoveMountTableEntriesRequestProto {
+  repeated string srcPaths = 1;
+}
+
+enum RemoveMountTableEntryFailureReasonProto {
+  UNKNOWN_FAILURE = 0;
+  NONEXISTENT_MOUNT_POINT = 1;
+  DRIVER_FAILURE = 2;
+  ACCESS_DENIED = 3;
+}
+
+message RemoveMountTableEntryFailureProto {
+  optional string srcPath = 1;
+  optional RemoveMountTableEntryFailureReasonProto reason = 2;
+}
+
+message RemoveMountTableEntriesResponseProto{
+  optional bool status = 1;
+  repeated RemoveMountTableEntryFailureProto failedEntries = 2;
+}
+
 message GetMountTableEntriesRequestProto {
   optional string srcPath = 1;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/RouterProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/RouterProtocol.proto
@@ -41,6 +41,11 @@ service RouterAdminProtocolService {
   rpc removeMountTableEntry(RemoveMountTableEntryRequestProto) returns(RemoveMountTableEntryResponseProto);
 
   /**
+   * Remove multiple mount table entries.
+   */
+  rpc removeMountTableEntries(RemoveMountTableEntriesRequestProto) returns(RemoveMountTableEntriesResponseProto);
+
+  /**
    * Add all mount table entries that are present in the request.
    */
   rpc addMountTableEntries(AddMountTableEntriesRequestProto) returns(AddMountTableEntriesResponseProto);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdmin.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +57,8 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.GetDisabledNamese
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetDisabledNameservicesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntriesResponse;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesRequest;
+import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryRequest;
@@ -326,6 +329,53 @@ public class TestRouterAdmin {
     // New mount table size.
     List<MountTable> entries2 = getMountTableEntries(mountTable);
     assertEquals(entries2.size(), mockMountTable.size() - 1);
+  }
+
+  @Test
+  public void testRemoveMountTables() throws IOException {
+    RouterClient client = routerContext.getAdminClient();
+    MountTableManager mountTable = client.getMountTableManager();
+
+    // Add a few mounts
+    for (int i = 0; i < 5; i++) {
+      MountTable newEntry =
+          MountTable.newInstance("/batch-remove/" + i, Collections.singletonMap("ns0", "/testdir"),
+              Time.now(), Time.now());
+      AddMountTableEntryRequest addRequest = AddMountTableEntryRequest.newInstance(newEntry);
+      AddMountTableEntryResponse addResponse = mountTable.addMountTableEntry(addRequest);
+      assertTrue(addResponse.getStatus());
+    }
+
+    assertEquals(getMountTableEntries(mountTable).size(), mockMountTable.size() + 5);
+
+    // Remove existing entries
+    RemoveMountTableEntriesRequest removeRequest = RemoveMountTableEntriesRequest.newInstance(
+        Arrays.asList("/batch-remove/0", "/batch-remove/1"));
+    RemoveMountTableEntriesResponse res = mountTable.removeMountTableEntries(removeRequest);
+    assertTrue(res.getStatus());
+    assertTrue(res.getFailedEntries().isEmpty());
+    assertEquals(getMountTableEntries(mountTable).size(), mockMountTable.size() + 3);
+
+    // Remove existing entry and non-existent entries
+    removeRequest = RemoveMountTableEntriesRequest.newInstance(
+        Arrays.asList("/batch-remove/2", "/batch-remove/20"));
+    res = mountTable.removeMountTableEntries(removeRequest);
+    assertFalse(res.getStatus());
+    assertEquals(1, res.getFailedEntries().size());
+    assertEquals("/batch-remove/20", res.getFailedEntries().get(0).getSrcPath());
+    assertEquals(RemoveMountTableEntriesResponse.FailureReason.NONEXISTENT_MOUNT_POINT,
+        res.getFailedEntries().get(0).getReason());
+    assertEquals(getMountTableEntries(mountTable).size(), mockMountTable.size() + 2);
+
+    // Remove non-existent entries
+    RemoveMountTableEntriesRequest removeRequest2 = RemoveMountTableEntriesRequest.newInstance(
+        Arrays.asList("/batch-remove/404", "/batch-remove/4000"));
+    res = mountTable.removeMountTableEntries(removeRequest2);
+    assertFalse(res.getStatus());
+    assertEquals(2, res.getFailedEntries().size());
+    for (RemoveMountTableEntriesResponse.EntryFailure f : res.getFailedEntries()) {
+      assertEquals(RemoveMountTableEntriesResponse.FailureReason.NONEXISTENT_MOUNT_POINT, f.getReason());
+    }
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdmin.java
@@ -374,7 +374,8 @@ public class TestRouterAdmin {
     assertFalse(res.getStatus());
     assertEquals(2, res.getFailedEntries().size());
     for (RemoveMountTableEntriesResponse.EntryFailure f : res.getFailedEntries()) {
-      assertEquals(RemoveMountTableEntriesResponse.FailureReason.NONEXISTENT_MOUNT_POINT, f.getReason());
+      assertEquals(RemoveMountTableEntriesResponse.FailureReason.NONEXISTENT_MOUNT_POINT,
+          f.getReason());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
@@ -466,10 +466,10 @@ public class TestRouterAdminCLI {
 
     // remove an invalid mount table
     String invalidPath = "/invalid";
-    System.setOut(new PrintStream(out));
+    System.setErr(new PrintStream(err));
     argv = new String[] {"-rm", invalidPath};
     assertEquals(0, ToolRunner.run(admin, argv));
-    assertTrue(out.toString().contains(
+    assertTrue(err.toString().contains(
         "Cannot remove mount point " + invalidPath));
   }
 


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HDFS-17723

Since each remove operation forces an update on all routers, removing a lot of mount points in one go when there are a decent number of routers can take a long time. It's better to just remove all of them in a batch and force update only once. Useful for nuking old unused mount points.

Reopened to add some small fixes and since it was bot closed

### How was this patch tested?

UTs + have been in use in production environment for over a year