### PR TITLE
HDFS-17903. Remove reference to dead wiki URL

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyState.java
@@ -93,9 +93,8 @@ public class StandbyState extends HAState {
         (op == OperationCategory.READ && context.allowStaleReads())) {
       return;
     }
-    String faq = ". Visit https://s.apache.org/sbnn-error";
     String msg = "Operation category " + op + " is not supported in state "
-        + context.getState() + faq;
+        + context.getState() + ".";
     if (op == OperationCategory.WRITE && isObserver) {
       // If observer receives a write call, return active retry
       // exception to inform client to retry on active.


### PR DESCRIPTION
### Description of PR

The referred FAQ URL https://s.apache.org/sbnn-error is long gone. It's better to remove it from the logs.

### How was this patch tested?

Trivial patch