### PR TITLE
HADOOP-19856: JDiff fails with IllegalAccessError on Java 17

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/pom.xml
@@ -299,6 +299,7 @@
                     <classpath>
                       <path refid="maven.compile.classpath"/>
                     </classpath>
+                    <arg value="-J--add-opens=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"/>
                   </javadoc>
                   <javadoc sourcepath="${basedir}/src/main/java"
                            destdir="${project.build.directory}/site/jdiff/xml"
@@ -319,6 +320,7 @@
                     <classpath>
                       <path refid="maven.compile.classpath"/>
                     </classpath>
+                    <arg value="-J--add-opens=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"/>
                   </javadoc>
                   <property name="compile_classpath" refid="maven.compile.classpath"/>
 

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -290,6 +290,7 @@
                       <classpath>
                         <path refid="maven.compile.classpath"/>
                       </classpath>
+                      <arg value="-J--add-opens=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"/>
                     </javadoc>
                     <javadoc sourcepath="${basedir}/src/main/java"
                              destdir="${project.build.directory}/site/jdiff/xml"
@@ -311,6 +312,7 @@
                       <classpath>
                         <path refid="maven.compile.classpath"/>
                       </classpath>
+                      <arg value="-J--add-opens=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"/>
                     </javadoc>
                   </target>
                 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/pom.xml
@@ -206,6 +206,7 @@
                       <classpath>
                         <path refid="maven.compile.classpath"/>
                       </classpath>
+                      <arg value="-J--add-opens=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"/>
                     </javadoc>
                     <javadoc sourcepath="${basedir}/src/main/java"
                       destdir="${project.build.directory}/site/jdiff/xml"
@@ -227,6 +228,7 @@
                       <classpath>
                         <path refid="maven.compile.classpath"/>
                       </classpath>
+                      <arg value="-J--add-opens=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"/>
                     </javadoc>
 
                   </target>


### PR DESCRIPTION
### Description of PR

Add arguments to the `javadoc` invocations to grant access to the JDK's Javadoc internals. This fixes the illegal access errors that we showing up:

```
  [javadoc] error: fatal error encountered: java.lang.IllegalAccessError: superclass access check failed: class org.apache.hadoop.classification.tools.HadoopDocEnvImpl (in unnamed module @0x6a3c1b56) cannot access class jdk.javadoc.internal.tool.DocEnvImpl (in module jdk.javadoc) because module jdk.javadoc does not export jdk.javadoc.internal.tool to unnamed module @0x6a3c1b56
  [javadoc] error: Please file a bug against the javadoc tool via the Java bug reporting page
  [javadoc]   (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com)
  [javadoc]   for duplicates. Include error messages and the following diagnostic in your report. Thank you.
  [javadoc] java.lang.IllegalAccessError: superclass access check failed: class org.apache.hadoop.classification.tools.HadoopDocEnvImpl (in unnamed module @0x6a3c1b56) cannot access class jdk.javadoc.internal.tool.DocEnvImpl (in module jdk.javadoc) because module jdk.javadoc does not export jdk.javadoc.internal.tool to unnamed module @0x6a3c1b56
  [javadoc] 	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
  [javadoc] 	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
  [javadoc] 	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
  [javadoc] 	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:524)
  [javadoc] 	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
  [javadoc] 	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:421)
  [javadoc] 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
  [javadoc] 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:420)
  [javadoc] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
  [javadoc] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
  [javadoc] 	at org.apache.hadoop.classification.tools.RootDocProcessor.process(RootDocProcessor.java:54)
  [javadoc] 	at org.apache.hadoop.classification.tools.IncludePublicAnnotationsJDiffDoclet.run(IncludePublicAnnotationsJDiffDoclet.java:141)
  [javadoc] 	at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:556)
  [javadoc] 	at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:393)
  [javadoc] 	at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:342)
  [javadoc] 	at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:63)
  [javadoc] 	at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:52)
  [javadoc] 2 errors
```

### How was this patch tested?

```
mvn clean package \
  -Pnative -Pdocs \
  -Drequire.snappy -Drequire.zstd -Drequire.openssl \
  -DskipTests -Denforcer.skip=true -DskipShade
```

Before this patch, the build wasn't actually producing the JDiff XML files. After applying the patch, I confirmed it generated the expected files:

```
cnauroth@eff55f3de04a:~/hadoop$ ls -l $(find . -name 'Apache_Hadoop_*.xml' | grep -v dev-support)
-rw-r--r-- 1 cnauroth cnauroth 2174536 Apr  2 19:26 ./hadoop-common-project/hadoop-common/target/site/jdiff/xml/Apache_Hadoop_Common_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth   96937 Apr  2 19:27 ./hadoop-hdfs-project/hadoop-hdfs/target/site/jdiff/xml/Apache_Hadoop_HDFS_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth   15633 Apr  2 19:35 ./hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/target/site/jdiff/xml/Apache_Hadoop_MapReduce_Common_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth 1349074 Apr  2 19:34 ./hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/target/site/jdiff/xml/Apache_Hadoop_MapReduce_Core_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth       0 Apr  2 19:35 ./hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/target/site/jdiff/xml/Apache_Hadoop_MapReduce_JobClient_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth 1410618 Apr  2 19:31 ./hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/target/site/jdiff/xml/Apache_Hadoop_YARN_API_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth  146678 Apr  2 19:34 ./hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/target/site/jdiff/xml/Apache_Hadoop_YARN_Client_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth  227878 Apr  2 19:31 ./hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/target/site/jdiff/xml/Apache_Hadoop_YARN_Common_3.6.0-SNAPSHOT.xml
-rw-r--r-- 1 cnauroth cnauroth   98809 Apr  2 19:32 ./hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/target/site/jdiff/xml/Apache_Hadoop_YARN_Server_Common_3.6.0-SNAPSHOT.xml
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html