### PR TITLE
HADOOP-19786 dependcy-check-version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <checkstyle.version>11.1.0</checkstyle.version>
-    <dependency-check-maven.version>7.1.1</dependency-check-maven.version>
+    <dependency-check-maven.version>12.2.0</dependency-check-maven.version>
     <spotbugs.version>4.9.7</spotbugs.version>
     <spotbugs-maven-plugin.version>4.9.7.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>
@@ -526,6 +526,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>${dependency-check-maven.version}</version>
+          <configuration>
+            <!-- often misidentied native binaries as .net native binaries then looks for .Net tooling to scan them -->
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+            <!-- requires separate sonatype account and sometimes fails if not present -->
+            <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?

$ mvn org.owasp:dependency-check-maven:check
[INFO] Writing HTML report to: /home/edward/hadoop/hadoop-common-project/hadoop-common/target/dependency-check-report.html
[WARNING] 

One or more dependencies were identified with known vulnerabilities in Apache Hadoop Common:

jetty-io-9.4.58.v20250814.jar (pkg:maven/org.eclipse.jetty/jetty-io@9.4.58.v20250814, cpe:2.3:a:eclipse:jetty:9.4.58:20250814:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.4.58:20250814:*:*:*:*:*:*, cpe:2.3:a:mortbay_jetty:jetty:9.4.58:20250814:*:*:*:*:*:*) : CVE-2025-11143
jetty-server-9.4.58.v20250814.jar (pkg:maven/org.eclipse.jetty/jetty-server@9.4.58.v20250814, cpe:2.3:a:eclipse:jetty:9.4.58:20250814:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.4.58:20250814:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty_http_server:9.4.58:20250814:*:*:*:*:*:*, cpe:2.3:a:mortbay_jetty:jetty:9.4.58:20250814:*:*:*:*:*:*) : CVE-2025-11143
netty-transport-4.1.130.Final.jar (pkg:maven/io.netty/netty-transport@4.1.130.Final, cpe:2.3:a:netty:netty:4.1.130:*:*:*:*:*:*:*) : CVE-2026-33871, CVE-2026-33870
protobuf-java-2.5.0.jar (pkg:maven/com.google.protobuf/protobuf-java@2.5.0, cpe:2.3:a:google:protobuf-java:2.5.0:*:*:*:*:*:*:*) : CVE-2024-7254, CVE-2022-3171, CVE-2021-22569


See the dependency-check report for more details.




### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html