### PR TITLE
YARN-11835: DockerContainerDeletionTask never calls deletionTaskFinished(), causing NM recovery store accumulation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
@@ -56,6 +56,7 @@ public class DockerContainerDeletionTask extends DeletionTask
     LinuxContainerExecutor exec = ((LinuxContainerExecutor)
         getDeletionService().getContainerExecutor());
     exec.removeDockerContainer(containerId);
+    deletionTaskFinished();
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/TestDockerContainerDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/TestDockerContainerDeletionTask.java
@@ -18,11 +18,17 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task
 
 import org.apache.hadoop.yarn.proto.YarnServerNodemanagerRecoveryProtos;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
+import org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor;
+import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test the attributes of the {@link DockerContainerDeletionTask} class.
@@ -51,6 +57,19 @@ public class TestDockerContainerDeletionTask {
   @Test
   public void testGetContainerId() {
     assertEquals(CONTAINER_ID, deletionTask.getContainerId());
+  }
+
+  @Test
+  public void testRunCallsDeletionTaskFinished() throws IOException {
+    LinuxContainerExecutor exec = mock(LinuxContainerExecutor.class);
+    NMStateStoreService stateStore = mock(NMStateStoreService.class);
+    when(deletionService.getContainerExecutor()).thenReturn(exec);
+    when(deletionService.getStateStore()).thenReturn(stateStore);
+
+    deletionTask.run();
+
+    verify(exec).removeDockerContainer(CONTAINER_ID);
+    verify(stateStore).removeDeletionTask(ID);
   }
 
   @Test


### PR DESCRIPTION
## YARN-11835

### Problem

`DockerContainerDeletionTask.run()` never calls `deletionTaskFinished()`, so every Docker container deletion task written to the NM recovery store (RocksDB/LevelDB) accumulates indefinitely and is replayed on every NodeManager restart.

`FileDeletionTask.run()` has always had this call; it was simply missing from `DockerContainerDeletionTask`.

### Fix

Added the missing `deletionTaskFinished()` call at the end of `DockerContainerDeletionTask.run()`:

```java
public void run() {
    LinuxContainerExecutor exec = ((LinuxContainerExecutor)
        getDeletionService().getContainerExecutor());
    exec.removeDockerContainer(containerId);
    deletionTaskFinished(); // was missing — tasks accumulated in recovery store forever
}
```

### Note on error handling

The reviewer on a related patch asked whether we should wrap `removeDockerContainer` in try/catch and set `setSuccess(false)` on failure, mirroring the pattern in `FileDeletionTask.run()`.

`FileDeletionTask` uses that pattern because `deleteAsUser` throws checked exceptions (`IOException | InterruptedException`) that must be handled. `removeDockerContainer`, however, already catches `ContainerExecutionException` internally and never propagates any exception — adding a try/catch here would be dead code that can never trigger. The simpler form is therefore correct.

### Testing

Added `testRunCallsDeletionTaskFinished()` to `TestDockerContainerDeletionTask`:
- Verifies `removeDockerContainer(containerId)` is called.
- Verifies `stateStore.removeDeletionTask(taskId)` is called — the observable effect of `deletionTaskFinished()` — confirming the task removes itself from the recovery store.

Also tested on our production environment.