### PR TITLE
HDFS-3592. libhdfs should use ClientProtocol::rename2.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-tests/test_libhdfs_threaded.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-tests/test_libhdfs_threaded.c
@@ -144,6 +144,7 @@ static int doTestHdfsOperations(struct tlhThreadInfo *ti, hdfsFS fs,
                                 const struct tlhPaths *paths)
 {
     char tmp[4096];
+    char renamedFile2[PATH_MAX];
     hdfsFile file;
     int ret, expected, numEntries;
     hdfsFileInfo *fileInfo;
@@ -285,6 +286,17 @@ static int doTestHdfsOperations(struct tlhThreadInfo *ti, hdfsFS fs,
     //Non-recursive delete fails
     EXPECT_NONZERO(hdfsDelete(fs, paths->prefix, 0));
     EXPECT_ZERO(hdfsCopy(fs, paths->file1, fs, paths->file2));
+
+    EXPECT_INT_LT(snprintf(renamedFile2, sizeof(renamedFile2), "%s/file2_renamed",
+            paths->prefix), PATH_MAX);
+    EXPECT_ZERO(hdfsRename(fs, paths->file2, renamedFile2));
+    EXPECT_NONZERO(hdfsExists(fs, paths->file2));
+    EXPECT_ZERO(hdfsExists(fs, renamedFile2));
+    EXPECT_NONZERO(hdfsRename(fs, paths->file1, renamedFile2));
+    EXPECT_ZERO(hdfsExists(fs, paths->file1));
+    EXPECT_ZERO(hdfsExists(fs, renamedFile2));
+    EXPECT_ZERO(hdfsRename(fs, renamedFile2, paths->file2));
+    EXPECT_ZERO(hdfsExists(fs, paths->file2));
 
     EXPECT_ZERO(hdfsChown(fs, paths->file2, NULL, NULL));
     EXPECT_ZERO(hdfsChown(fs, paths->file2, NULL, "doop"));

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -2803,6 +2803,8 @@ int hdfsRename(hdfsFS fs, const char *oldPath, const char *newPath)
 done:
     destroyLocalReference(env, jOldPath);
     destroyLocalReference(env, jNewPath);
+    destroyLocalReference(env, jOptsArr);
+    destroyLocalReference(env, enumClass);
     destroyLocalReference(env, jRenameOptionsNone);
     return ret;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -2741,7 +2741,6 @@ int hdfsRename(hdfsFS fs, const char *oldPath, const char *newPath)
     jobjectArray jOptsArr = NULL;
     jclass enumClass = NULL;
     int ret = -1;
-    jvalue jVal;
 
     //Get the JNIEnv* corresponding to current thread
     JNIEnv* env = getJNIEnv();

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -2805,8 +2805,6 @@ done:
     destroyLocalReference(env, jOldPath);
     destroyLocalReference(env, jNewPath);
     destroyLocalReference(env, jRenameOptionsNone);
-    destroyLocalReference(env, jOldPath);
-    destroyLocalReference(env, jNewPath);
     return ret;
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -2731,11 +2731,15 @@ int hdfsRename(hdfsFS fs, const char *oldPath, const char *newPath)
     // JAVA EQUIVALENT:
     //  Path old = new Path(oldPath);
     //  Path new = new Path(newPath);
-    //  fs.rename(old, new);
+    //  fs.rename(old, new, org.apache.hadoop.fs.Options.Rename.NONE);
+    // (HDFS: ClientProtocol#rename2; see DFSClient.rename(String,String,Rename...))
 
     jobject jFS = (jobject)fs;
     jthrowable jthr;
     jobject jOldPath = NULL, jNewPath = NULL;
+    jobject jRenameOptionsNone = NULL;
+    jobjectArray jOptsArr = NULL;
+    jclass enumClass = NULL;
     int ret = -1;
     jvalue jVal;
 
@@ -2759,24 +2763,48 @@ int hdfsRename(hdfsFS fs, const char *oldPath, const char *newPath)
         goto done;
     }
 
-    // Rename the file
-    // TODO: use rename2 here?  (See HDFS-3592)
-    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, JC_FILE_SYSTEM,
-            "rename", JMETHOD2(JPARAM(HADOOP_PATH), JPARAM
-            (HADOOP_PATH), "Z"), jOldPath, jNewPath);
+    jthr = fetchEnumInstance(env, "org/apache/hadoop/fs/Options$Rename", "NONE",
+            &jRenameOptionsNone);
     if (jthr) {
         errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
-            "hdfsRename(oldPath=%s, newPath=%s): FileSystem#rename",
-            oldPath, newPath);
+            "hdfsRename: Options.Rename.NONE");
         goto done;
     }
-    if (!jVal.z) {
-        errno = EIO;
+    enumClass = (*env)->GetObjectClass(env, jRenameOptionsNone);
+    if (!enumClass) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsRename: GetObjectClass(Options.Rename)");
+        goto done;
+    }
+    jOptsArr = (*env)->NewObjectArray(env, 1, enumClass, NULL);
+    if (!jOptsArr) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsRename: NewObjectArray");
+        goto done;
+    }
+    (*env)->SetObjectArrayElement(env, jOptsArr, 0, jRenameOptionsNone);
+    if ((*env)->ExceptionCheck(env)) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsRename: SetObjectArrayElement");
+        goto done;
+    }
+
+    jthr = invokeMethod(env, NULL, INSTANCE, jFS, JC_FILE_SYSTEM,
+            "rename", JMETHOD3(JPARAM(HADOOP_PATH), JPARAM(HADOOP_PATH),
+            "[Lorg/apache/hadoop/fs/Options$Rename;", JAVA_VOID),
+            jOldPath, jNewPath, jOptsArr);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename(oldPath=%s, newPath=%s): FileSystem#rename(rename2)",
+            oldPath, newPath);
         goto done;
     }
     ret = 0;
 
 done:
+    destroyLocalReference(env, jOldPath);
+    destroyLocalReference(env, jNewPath);
+    destroyLocalReference(env, jRenameOptionsNone);
     destroyLocalReference(env, jOldPath);
     destroyLocalReference(env, jNewPath);
     return ret;


### PR DESCRIPTION
### Description of PR
Refer to HDFS-3592.
We should better use rename2 in libhdfs.