### PR TITLE
HADOOP-19814: Create hadoop-runner:jdk17-u2404 with Ubuntu 24.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,22 +16,21 @@
 
 ARG JAVA_VERSION=17
 
-# Ubuntu 22.04 LTS
-FROM eclipse-temurin:${JAVA_VERSION}-jammy
+# Ubuntu 24.04 LTS
+FROM eclipse-temurin:${JAVA_VERSION}-noble
 
 RUN apt update -q \
     && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
       jq \
       krb5-user \
       ncat \
-      python3-pip \
+      pipx \
       python-is-python3 \
       sudo \
     && apt clean
 
 # Robot Framework for testing
-RUN pip install robotframework \
-    && rm -fr ~/.cache/pip
+RUN pipx install robotframework
 
 #dumb init for proper init handling
 RUN set -eux; \
@@ -59,7 +58,7 @@ RUN curl -Lo /opt/byteman.jar https://repo.maven.apache.org/maven2/org/jboss/byt
 #async profiler for development profiling
 RUN set -eux; \
     ARCH="$(arch)"; \
-    v=2.8.3; \
+    v=4.3; \
     case "${ARCH}" in \
       x86_64) \
         url="https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${v}/async-profiler-${v}-linux-x64.tar.gz" \
@@ -76,8 +75,8 @@ RUN set -eux; \
 RUN mkdir -p /etc/security/keytabs \
     && chmod -R a+wr /etc/security/keytabs
 
-RUN groupadd --gid 1000 hadoop \
-    && useradd --uid 1000 hadoop --gid 100 --home /opt/hadoop \
+RUN groupadd --gid 1001 hadoop \
+    && useradd --uid 1001 hadoop --gid 100 --home /opt/hadoop \
     && mkdir -p /opt/hadoop \
     && chown hadoop:users /opt/hadoop \
     && echo "hadoop ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This creates a new base Hadoop runner image with JDK 17 and Ubuntu 24.04 to align with the release image for Hadoop 3.5.0. I have pushed a new branch: docker-hadoop-runner-jdk17-u2404, based on the latest state of docker-hadoop-runner-jdk17-u2204. The diff shown in this pull request is the incremental changes required:

* Switch to Ubuntu 24.04 for the base image.
* Switch from `pip` to `pipx` for robotframework installation, because the host Python deployment is now managed by the OS and rejects `pip` installations.
* Upgrade to latest version of async profiler.
* Change hadoop uid/gid from 1000 to 1001, because 1000 is now occupied by a "ubuntu" user.

### How was this patch tested?

I built a Hadoop 3.5.0 image (separate PR) using this image as the base and used the Docker Compose harness to test NameNode, DataNode, ResourceManager and NodeManager.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html