### PR TITLE
HADOOP-19814: Create Hadoop 3.5.0 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/apache/hadoop-runner:jdk11-u2204
-ARG HADOOP_VERSION=3.4.3
+FROM ghcr.io/apache/hadoop-runner:jdk17-u2404
+ARG HADOOP_VERSION=3.5.0
 ARG BASE_URL=https://dlcdn.apache.org/hadoop/common
 ARG TARGETPLATFORM
 WORKDIR /opt/hadoop

--- a/config
+++ b/config
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.XML_fs.default.name=hdfs://namenode
 CORE-SITE.XML_fs.defaultFS=hdfs://namenode
 HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:8020
 HDFS-SITE.XML_dfs.replication=1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
 services:
    namenode:
       build: .


### PR DESCRIPTION
### Description of PR

Create a Hadoop 3.5.0 Docker image. I pushed a new branch, docker-hadoop-3.5.0, based on current docker-hadoop-3.4.3. This pull request shows the incremental changes required:

* Upgrade to a new base image with JDK 17 + Ubuntu 24.04 for alignment with the release image.
* Change Hadoop version number from 3.4.3 to 3.5.0.
* Remove `fs.default.name` from test core-site.xml to avoid log spam about deprecation of this property in 3.5.0.
* Remove `version` from docker-compose.yaml to avoid deprecation warning.

This won't actually build successfully until we publish the new hadoop-runner:jdk17-u2404 base image, though you can build locally.

### How was this patch tested?

I used the Docker Compose harness to test NameNode, DataNode, ResourceManager and NodeManager.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html