### PR TITLE
HDFS-17906. Fix issue that DataNodes get stuck in infinite loop when meet InvalidBlockReportLeaseException.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1119,7 +1119,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final int     DFS_NAMENODE_MAX_FULL_BLOCK_REPORT_LEASES_DEFAULT = 6;
   public static final String  DFS_NAMENODE_FULL_BLOCK_REPORT_LEASE_LENGTH_MS = "dfs.namenode.full.block.report.lease.length.ms";
   public static final long    DFS_NAMENODE_FULL_BLOCK_REPORT_LEASE_LENGTH_MS_DEFAULT = 5L * 60L * 1000L;
-  public static final String  DFS_BLOCKREPORT_REJECT_INVALID_LEASE_KEY = "dfs.blockreport.reject.invalid.lease";
+  public static final String  DFS_BLOCKREPORT_REJECT_INVALID_LEASE_KEY
+      = "dfs.blockreport.reject.invalid.lease";
   public static final boolean DFS_BLOCKREPORT_REJECT_INVALID_LEASE_DEFAULT = true;
   public static final String  DFS_CACHEREPORT_INTERVAL_MSEC_KEY = "dfs.cachereport.intervalMsec";
   public static final long    DFS_CACHEREPORT_INTERVAL_MSEC_DEFAULT = 10 * 1000;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1119,6 +1119,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final int     DFS_NAMENODE_MAX_FULL_BLOCK_REPORT_LEASES_DEFAULT = 6;
   public static final String  DFS_NAMENODE_FULL_BLOCK_REPORT_LEASE_LENGTH_MS = "dfs.namenode.full.block.report.lease.length.ms";
   public static final long    DFS_NAMENODE_FULL_BLOCK_REPORT_LEASE_LENGTH_MS_DEFAULT = 5L * 60L * 1000L;
+  public static final String  DFS_BLOCKREPORT_REJECT_INVALID_LEASE_KEY = "dfs.blockreport.reject.invalid.lease";
+  public static final boolean DFS_BLOCKREPORT_REJECT_INVALID_LEASE_DEFAULT = true;
   public static final String  DFS_CACHEREPORT_INTERVAL_MSEC_KEY = "dfs.cachereport.intervalMsec";
   public static final long    DFS_CACHEREPORT_INTERVAL_MSEC_DEFAULT = 10 * 1000;
   public static final String  DFS_BLOCK_INVALIDATE_LIMIT_KEY = "dfs.block.invalidate.limit";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -205,6 +205,7 @@ public class BlockManager implements BlockStatsMXBean {
 
   private final long startupDelayBlockDeletionInMs;
   private final BlockReportLeaseManager blockReportLeaseManager;
+  private final boolean rejectInvalidBlockReportLease;
   private ObjectName mxBeanName;
 
   /** Used by metrics */
@@ -596,6 +597,10 @@ public class BlockManager implements BlockStatsMXBean {
     this.pendingRecoveryBlocks = new PendingRecoveryBlocks(blockRecoveryTimeout);
 
     this.blockReportLeaseManager = new BlockReportLeaseManager(conf);
+
+    this.rejectInvalidBlockReportLease = conf.getBoolean(
+        DFSConfigKeys.DFS_BLOCKREPORT_REJECT_INVALID_LEASE_KEY,
+        DFSConfigKeys.DFS_BLOCKREPORT_REJECT_INVALID_LEASE_DEFAULT);
 
     this.bmSafeMode = new BlockManagerSafeMode(this, namesystem, haEnabled,
         conf);
@@ -5535,6 +5540,10 @@ public class BlockManager implements BlockStatsMXBean {
 
   public BlockReportLeaseManager getBlockReportLeaseManager() {
     return blockReportLeaseManager;
+  }
+
+  public boolean shouldRejectInvalidBlockReportLease() {
+    return rejectInvalidBlockReportLease;
   }
 
   @Override // BlockStatsMXBean

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1664,7 +1664,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
                 blocks, context));
         }
       } else {
-        throw new InvalidBlockReportLeaseException(context.getReportId(), context.getLeaseId());
+        if (bm.shouldRejectInvalidBlockReportLease()) {
+          throw new InvalidBlockReportLeaseException(
+              context.getReportId(), context.getLeaseId());
+        }
       }
     } catch (UnregisteredNodeException une) {
       LOG.warn("Datanode {} is attempting to report but not register yet.",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -887,6 +887,27 @@
 </property>
 
 <property>
+  <name>dfs.blockreport.reject.invalid.lease</name>
+  <value>true</value>
+  <description>
+    NameNode-side configuration. When set to true (default), the NameNode
+    throws an InvalidBlockReportLeaseException back to the DataNode if a
+    block report is rejected due to an invalid or expired lease. This allows
+    DataNodes that include HDFS-16942 to immediately reset their lease state
+    and retry.
+
+    During a rolling upgrade where the NameNode has been upgraded but
+    DataNodes are still running an older version without HDFS-16942, set
+    this to false. Old DataNodes cannot handle InvalidBlockReportLeaseException
+    and will get stuck in an infinite loop of rejected block reports, unable
+    to ever send a successful full block report. Setting this to false
+    reverts to the pre-HDFS-16942 behavior of silently skipping the rejected
+    report. Once all DataNodes have been upgraded, this should be set back
+    to true (or removed to use the default).
+  </description>
+</property>
+
+<property>
   <name>dfs.datanode.directoryscan.interval</name>
   <value>21600</value>
   <description>Interval in seconds for Datanode to scan data directories and

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.BlockListAsLongs;
@@ -52,6 +53,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -205,6 +207,65 @@ public class TestBlockReportLease {
       }
       assertNotNull(exception);
       assertEquals(InvalidBlockReportLeaseException.class, exception.getCause().getClass());
+    }
+  }
+
+  /**
+   * Test that when dfs.blockreport.reject.invalid.lease is set to false,
+   * the NameNode does not throw InvalidBlockReportLeaseException for an
+   * expired lease. This is needed for rolling upgrade compatibility where
+   * old DataNodes cannot handle InvalidBlockReportLeaseException and would
+   * get stuck in an infinite loop of rejected block reports.
+   */
+  @Test
+  public void testNoExceptionWhenRejectInvalidLeaseDisabled() throws Exception {
+    HdfsConfiguration conf = new HdfsConfiguration();
+    conf.setBoolean(
+        DFSConfigKeys.DFS_BLOCKREPORT_REJECT_INVALID_LEASE_KEY, false);
+    Random rand = new Random();
+
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1).build()) {
+      cluster.waitActive();
+
+      FSNamesystem fsn = cluster.getNamesystem();
+      BlockManager blockManager = fsn.getBlockManager();
+      BlockManager spyBlockManager = spy(blockManager);
+      fsn.setBlockManagerForTesting(spyBlockManager);
+      String poolId = cluster.getNamesystem().getBlockPoolId();
+
+      NamenodeProtocols rpcServer = cluster.getNameNodeRpc();
+
+      DataNode dn = cluster.getDataNodes().get(0);
+      DatanodeDescriptor datanodeDescriptor = spyBlockManager
+          .getDatanodeManager().getDatanode(dn.getDatanodeId());
+
+      DatanodeRegistration dnRegistration = dn.getDNRegistrationForBP(poolId);
+      StorageReport[] storages = dn.getFSDataset().getStorageReports(poolId);
+
+      // Send heartbeat and request full block report lease
+      HeartbeatResponse hbResponse = rpcServer.sendHeartbeat(
+          dnRegistration, storages, 0, 0, 0, 0, 0, null, true,
+          SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
+
+      // Remove the lease to simulate expiration
+      spyBlockManager.getBlockReportLeaseManager()
+          .removeLease(datanodeDescriptor);
+
+      // Trigger sendBlockReport with the now-invalid lease
+      BlockReportContext brContext = new BlockReportContext(1, 0,
+          rand.nextLong(), hbResponse.getFullBlockReportLeaseId());
+      DatanodeStorage[] datanodeStorages
+          = new DatanodeStorage[storages.length];
+      for (int i = 0; i < storages.length; i++) {
+        datanodeStorages[i] = storages[i].getStorage();
+      }
+      StorageBlockReport[] reports = createReports(datanodeStorages, 100);
+
+      // Should NOT throw InvalidBlockReportLeaseException
+      DatanodeCommand cmd = rpcServer.blockReport(
+          dnRegistration, poolId, reports, brContext);
+      assertNull(cmd);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
@@ -247,7 +247,8 @@ public class TestBlockReportLease {
       HeartbeatResponse hbResponse = rpcServer.sendHeartbeat(
           dnRegistration, storages, 0, 0, 0, 0, 0, null, true,
           SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
-
+      assertTrue(hbResponse.getFullBlockReportLeaseId() != 0,
+          "Expected heartbeat to grant a non-zero full block report lease");
       // Remove the lease to simulate expiration
       spyBlockManager.getBlockReportLeaseManager()
           .removeLease(datanodeDescriptor);


### PR DESCRIPTION
### Description of PR

https://github.com/apache/hadoop/pull/5460#discussion_r3051817271

HDFS-16942 introduced `InvalidBlockReportLeaseException`, which the NameNode now throws back to the DataNode via RPC when a block report is rejected due to an invalid lease. On a DataNode that also includes HDFS-16942, the exception is caught and `fullBlockReportLeaseId` is reset to 0, allowing the DN to request a new lease on the next heartbeat and retry.

However, during a rolling upgrade where the NameNode has been upgraded (with HDFS-16942) but DataNodes are still running an older version (without HDFS-16942), the old DataNode code does not have the `InvalidBlockReportLeaseException` handling branch in `BPServiceActor.offerService()`. This causes the DN to enter an infinite failure loop where it can never successfully send a full block report.

Root Cause

In `BPServiceActor.offerService()`, the logic works as follows:

1. The DN requests a block report lease during heartbeat only when `fullBlockReportLeaseId == 0`:

```java
boolean requestBlockReportLease = (fullBlockReportLeaseId == 0) &&
        scheduler.isBlockReportDue(startTime);
```

2. After sending the block report, `fullBlockReportLeaseId` is reset to 0:

```java
if ((fullBlockReportLeaseId != 0) || forceFullBr) {
    cmds = blockReport(fullBlockReportLeaseId);
    fullBlockReportLeaseId = 0;  // not reached if blockReport() throws
}
```

3. When the upgraded NN throws `InvalidBlockReportLeaseException`, `blockReport()` propagates the exception. The `fullBlockReportLeaseId = 0` line after the call is never executed.

4. The exception is caught by the generic `RemoteException` catch block. The old DN code does not recognize `InvalidBlockReportLeaseException`, so `fullBlockReportLeaseId` remains set to the stale invalid value.

5. On the next heartbeat iteration, because `fullBlockReportLeaseId != 0`, `requestBlockReportLease` is `false` — the DN does not request a new lease. It then attempts `blockReport()` again with the same stale lease, which the NN rejects again. This repeats indefinitely.


### How was this patch tested?
Add test

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html