### PR TITLE
HDFS-17629. The IP address is incorrectly displayed in the IPv6 environment.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/histogram-hostip.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/histogram-hostip.js
@@ -26,7 +26,14 @@ function open_hostip_list(x0, x1) {
     }
     //More than 100% do not care,so not record in 95%-100% bar
     if (index > x0 && index <= x1) {
-      ips.push(dn.infoAddr.split(":")[0]);
+      var infoAddrParts = dn.infoAddr.split("]:");
+      if (infoAddrParts.length > 1) {
+        // IPv6 url [xxxx:xxxx:...]:port — strip leading '['
+        ips.push(infoAddrParts[0].substring(1));
+      } else {
+        // IPv4 url host:port
+        ips.push(dn.infoAddr.split(":")[0]);
+      }
     }
   }
   var ipsText = '';


### PR DESCRIPTION
## Summary
- In `histogram-hostip.js`, `open_hostip_list()` extracted the host from `dn.infoAddr` using `split(":")[0]`. For an IPv6 `infoAddr` of the form `[2001:db8::1]:9864` this yields `[2001` instead of the full IPv6 address.
- Fix mirrors the logic already used in `dfshealth.js`: split on `]:` first; if more than one part the address is IPv6 and we strip the leading `[` from part `[0]`; otherwise fall back to the original IPv4 `split(":")[0]` path.

## Test
- JavaScript-only change; verified manually that IPv4 (`host:port`) continues to extract the host, and IPv6 (`[addr]:port`) now correctly extracts the full address without brackets.