### PR TITLE
HDFS-16029. Fix ArrayIndexOutOfBoundsException and divide-by-zero in InstrumentationService.Timer.getValues()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/instrumentation/InstrumentationService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/instrumentation/InstrumentationService.java
@@ -226,6 +226,9 @@ public class InstrumentationService extends BaseService implements Instrumentati
       lock.lock();
       try {
         long[] values = new long[4];
+        if (last < 0) {
+          return values;
+        }
         values[LAST_TOTAL] = total[last];
         values[LAST_OWN] = own[last];
         int limit = (full) ? size : (last + 1);

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/instrumentation/TestInstrumentationService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/instrumentation/TestInstrumentationService.java
@@ -233,6 +233,24 @@ public class TestInstrumentationService extends HTestCase {
   }
 
   @Test
+  public void timerGetValuesBeforeAnyCron() throws Exception {
+    // HDFS-16029: getValues() on a fresh Timer (last == -1) must not throw
+    // ArrayIndexOutOfBoundsException or divide-by-zero; it should return zeros.
+    InstrumentationService.Timer timer = new InstrumentationService.Timer(2);
+    long[] values = timer.getValues();
+    assertEquals(4, values.length);
+    assertEquals(0, values[InstrumentationService.Timer.LAST_TOTAL]);
+    assertEquals(0, values[InstrumentationService.Timer.LAST_OWN]);
+    assertEquals(0, values[InstrumentationService.Timer.AVG_TOTAL]);
+    assertEquals(0, values[InstrumentationService.Timer.AVG_OWN]);
+
+    // toJSONString() also calls getValues() via getJSON() — must not throw either
+    String json = timer.toJSONString();
+    assertNotNull(json);
+    assertTrue(json.contains("lastTotal"));
+  }
+
+  @Test
   public void sampler() throws Exception {
     final long value[] = new long[1];
     Instrumentation.Variable<Long> var = new Instrumentation.Variable<Long>() {


### PR DESCRIPTION
## Summary
- `InstrumentationService.Timer.getValues()` throws `ArrayIndexOutOfBoundsException` (index -1) and would divide by zero when called on a freshly constructed `Timer` before any `Cron` has been recorded (`last == -1`).
- Fix: return an all-zeros array immediately when `last < 0`, matching the suggestion in the JIRA ticket. This is the same defensive pattern used in `Sampler.getRate()` which guards against `last == 0`.

## Test
- Added `timerGetValuesBeforeAnyCron()` to `TestInstrumentationService` — creates a fresh `Timer(2)`, asserts `getValues()` returns zeros without exception, and also asserts `toJSONString()` does not throw.
- All 7 tests in `TestInstrumentationService` pass.