### PR TITLE
HDFS-17478. libhdfs: fix 'occured' -> 'occurred' in thread_local_storage.h comments

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h
@@ -54,9 +54,9 @@
 struct ThreadLocalState {
   /* The JNIEnv associated with the current thread */
   JNIEnv *env;
-  /* The last exception stack trace that occured on this thread */
+  /* The last exception stack trace that occurred on this thread */
   char *lastExceptionStackTrace;
-  /* The last exception root cause that occured on this thread */
+  /* The last exception root cause that occurred on this thread */
   char *lastExceptionRootCause;
 };
 


### PR DESCRIPTION
### Description
Two comments in `hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h` (lines 57, 59) read `that occured on this thread`. Fixed to `occurred`. Comment-only change.

### How was this patch tested?
N/A — comment-only fix.

### For code changes:
- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?