### PR TITLE
HADOOP: fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h
@@ -54,9 +54,9 @@
 struct ThreadLocalState {
   /* The JNIEnv associated with the current thread */
   JNIEnv *env;
-  /* The last exception stack trace that occured on this thread */
+  /* The last exception stack trace that occurred on this thread */
   char *lastExceptionStackTrace;
-  /* The last exception root cause that occured on this thread */
+  /* The last exception root cause that occurred on this thread */
   char *lastExceptionRootCause;
 };
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitter.java
@@ -701,7 +701,7 @@ public class ManifestCommitter extends PathOutputCommitter implements
    * @param quiet should exceptions be swallowed.
    * @param overwrite should the existing file be overwritten
    * @return the path of a file, if successfully saved
-   * @throws IOException if a failure occured and quiet==false
+   * @throws IOException if a failure occurred and quiet==false
    */
   private static Path maybeSaveSummary(
       String activeStage,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitter.java
@@ -1481,7 +1481,7 @@ public abstract class AbstractS3ACommitter extends PathOutputCommitter
    * @param quiet should exceptions be swallowed.
    * @param overwrite should the existing file be overwritten
    * @return the path of a file, if successfully saved
-   * @throws IOException if a failure occured and quiet==false
+   * @throws IOException if a failure occurred and quiet==false
    */
   private static Path maybeSaveSummary(
       String activeStage,


### PR DESCRIPTION
Trivial spelling fix in three source files — `occured` → `occurred`.

All occurrences are in code comments / Javadoc:

- `hadoop-hdfs-native-client/.../libhdfs/os/thread_local_storage.h` — two struct field comments describing the last exception stack trace / root cause.
- `hadoop-aws/.../AbstractS3ACommitter.java` — `@throws IOException` Javadoc on `maybeSaveSummary`.
- `hadoop-mapreduce-client-core/.../ManifestCommitter.java` — `@throws IOException` Javadoc on `maybeSaveSummary`.

No functional changes.