### PR TITLE
HADOOP-19866. Upgrade bouncycastle to 1.84 for security (#8443)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -493,9 +493,9 @@ com.microsoft.azure:azure-cosmosdb-gateway:2.4.5
 com.microsoft.azure:azure-data-lake-store-sdk:2.3.9
 com.microsoft.azure:azure-keyvault-core:1.0.0
 com.microsoft.sqlserver:mssql-jdbc:6.2.1.jre7
-org.bouncycastle:bcpkix-jdk18on:1.82
-org.bouncycastle:bcprov-jdk18on:1.82
-org.bouncycastle:bcutil-jdk18on:1.82
+org.bouncycastle:bcpkix-jdk18on:1.84
+org.bouncycastle:bcprov-jdk18on:1.84
+org.bouncycastle:bcutil-jdk18on:1.84
 org.checkerframework:checker-qual:3.8.0
 org.codehaus.mojo:animal-sniffer-annotations:1.24
 org.jruby.jcodings:jcodings:1.0.13

--- a/hadoop-cloud-storage-project/hadoop-cos/src/site/markdown/cloud-storage/index.md
+++ b/hadoop-cloud-storage-project/hadoop-cos/src/site/markdown/cloud-storage/index.md
@@ -86,7 +86,7 @@ Linux kernel 2.6+
 - joda-time (version 2.9.9 recommended)
 - httpClient (version 4.5.1 or later recommended)
 - Jackson: jackson-core, jackson-databind, jackson-annotations (version 2.9.8 or later)
-- bcprov-jdk18on (version 1.82 recommended)
+- bcprov-jdk18on (version 1.84 recommended)
 
 
 #### Configure Properties

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -113,7 +113,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <guice.version>4.2.3</guice.version>
 
-    <bouncycastle.version>1.82</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0.AM26</apacheds.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Includes CVE fixes

CVE-2025-14813 - GOSTCTR implementation unable to process more than 255 blocks correctly. CVE-2026-0636 - LDAP Injection Vulnerability in LDAPStoreHelper.java. CVE-2026-3505 - Unbounded PGP AEAD chunk size leads to pre-auth resource exhaustion. CVE-2026-5588 - PKIX draft CompositeVerifier accepts empty signature sequence as valid. CVE-2026-5598 - Non-constant time comparisons risk private key leakage in FrodoKEM.


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html