### PR TITLE
HDFS-17909. [ARR] AsyncRouterHandlerExecutors should use bounded queue

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -85,6 +85,9 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final String DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY =
           FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "handler.count";
   public static final int DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT = 10;
+  public static final String DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE =
+      FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "queue.size";
+  public static final int DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT = 1000;
   public static final String DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY =
           FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "responder.count";
   public static final int DFS_ROUTER_ASYNCRPC_RESPONDER_COUNT_DEFAULT = 10;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -25,6 +25,8 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_OPTION;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_OPTION_DEFAULT;
@@ -58,7 +60,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -70,7 +72,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -293,11 +297,11 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   private RouterRenameOption routerRenameOption;
   /** Schedule the router federation rename jobs. */
   private BalanceProcedureScheduler fedRenameScheduler;
-  private boolean enableAsync;
-  private Map<String, Integer> nsAsyncHandlerCount = new ConcurrentHashMap<>();
-  private Map<String, ExecutorService> asyncRouterHandlerExecutors = new ConcurrentHashMap<>();
+  private final boolean enableAsync;
+  private final Map<String, ThreadPoolExecutor> asyncRouterHandlerExecutors =
+      new ConcurrentHashMap<>();
+  private ThreadPoolExecutor routerDefaultAsyncHandlerExecutor;
   private ExecutorService routerAsyncResponderExecutor;
-  private ExecutorService routerDefaultAsyncHandlerExecutor;
 
   /**
    * Construct a router RPC server.
@@ -504,34 +508,59 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
    * @param configuration the configuration.
    */
   public void initAsyncThreadPools(Configuration configuration) {
-    LOG.info("Begin initialize asynchronous handler and responder thread pool.");
-    initNsAsyncHandlerCount();
     Set<String> allConfiguredNS = FederationUtil.getAllConfiguredNS(configuration);
-    Set<String> unassignedNS = new HashSet<>();
     allConfiguredNS.add(CONCURRENT_NS);
+    Map<String, Integer> nsAsyncActiveHandlerCount = parseNsAsyncHandlerCount(configuration);
+    initAsyncHandlerThreadPools(configuration, allConfiguredNS, nsAsyncActiveHandlerCount);
+    initAsyncResponderThreadPools(configuration);
+  }
 
-    for (String nsId : allConfiguredNS) {
-      int dedicatedHandlers = nsAsyncHandlerCount.getOrDefault(nsId, 0);
-      LOG.info("Dedicated handlers {} for ns {} ", dedicatedHandlers, nsId);
-      if (dedicatedHandlers > 0) {
-        initAsyncHandlerThreadPools4Ns(nsId, dedicatedHandlers);
-        LOG.info("Assigned {} async handlers to nsId {} ", dedicatedHandlers, nsId);
-      } else {
-        unassignedNS.add(nsId);
-      }
+  private void initAsyncHandlerThreadPools(Configuration configuration,
+      Set<String> allConfiguredNS, Map<String, Integer> nsAsyncHandlerCount) {
+    LOG.info("Initializing asynchronous handler thread pools");
+    int asyncQueueSize = configuration.getInt(DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE,
+        DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT);
+    if (asyncQueueSize < 1) {
+      throw new IllegalArgumentException("Async queue size must be at least 1");
     }
-
     int asyncHandlerCountDefault = configuration.getInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY,
         DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT);
+    for (String nsId : allConfiguredNS) {
+      int dedicatedHandlers = nsAsyncHandlerCount.getOrDefault(nsId, 0);
+      if (dedicatedHandlers <= 0) {
+        dedicatedHandlers = asyncHandlerCountDefault;
+        LOG.info("Use default async handler count {} for ns {} to init Executors.",
+            asyncHandlerCountDefault, nsId);
+      } else {
+        LOG.info("Dedicated handlers {} for ns {} to init Executors", dedicatedHandlers, nsId);
+      }
 
-    if (!unassignedNS.isEmpty()) {
-      LOG.warn("Async handler unassigned ns: {}", unassignedNS);
-      LOG.info("Use default async handler count {} for unassigned ns.", asyncHandlerCountDefault);
-      for (String nsId : unassignedNS) {
-        initAsyncHandlerThreadPools4Ns(nsId, asyncHandlerCountDefault);
+      if (dedicatedHandlers > 0) {
+        int finalDedicatedHandlers = dedicatedHandlers;
+        asyncRouterHandlerExecutors.computeIfAbsent(nsId,
+            id -> {
+              LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
+              return new ThreadPoolExecutor(finalDedicatedHandlers, finalDedicatedHandlers,
+                  0L, TimeUnit.MILLISECONDS, queue,
+                  new AsyncThreadFactory("Router Async Handler for " + nsId + " #"));
+            });
+        LOG.info("Assigned {} async handlers with queue size {} to nsId {}", dedicatedHandlers,
+            asyncQueueSize, nsId);
       }
     }
 
+    if (routerDefaultAsyncHandlerExecutor == null) {
+      LOG.info("Initializing router default async handler executor, count={}",
+          asyncHandlerCountDefault);
+      LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
+      routerDefaultAsyncHandlerExecutor = new ThreadPoolExecutor(asyncHandlerCountDefault,
+          asyncHandlerCountDefault, 0L, TimeUnit.MILLISECONDS, queue,
+          new AsyncThreadFactory("Router Default Async Handler #"));
+    }
+  }
+
+  private void initAsyncResponderThreadPools(Configuration configuration) {
+    LOG.info("Initializing asynchronous responder thread pool.");
     int asyncResponderCount = configuration.getInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY,
         DFS_ROUTER_ASYNCRPC_RESPONDER_COUNT_DEFAULT);
     if (routerAsyncResponderExecutor == null) {
@@ -540,21 +569,17 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
           asyncResponderCount, new AsyncThreadFactory("Router Async Responder #"));
     }
     AsyncRpcProtocolPBUtil.setAsyncResponderExecutor(routerAsyncResponderExecutor);
-
-    if (routerDefaultAsyncHandlerExecutor == null) {
-      LOG.info("init router async default executor handler count: {}", asyncHandlerCountDefault);
-      routerDefaultAsyncHandlerExecutor = Executors.newFixedThreadPool(
-          asyncHandlerCountDefault, new AsyncThreadFactory("Router Async Default Handler #"));
-    }
   }
 
-  private void initNsAsyncHandlerCount() {
-    String configNsHandler = conf.get(DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY,
+  private Map<String, Integer> parseNsAsyncHandlerCount(Configuration config) {
+    String configNsHandler = config.get(DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY,
         DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT);
+    Map<String, Integer> nsAsyncHandlerCount = new HashMap<>();
     if (StringUtils.isEmpty(configNsHandler)) {
-      LOG.error(
-          "The value of config key: {} is empty. Will use default conf.",
+      LOG.debug("No per-namespace async handler counts configured ({}). "
+              + "Will use default handler count for all namespaces.",
           DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY);
+      return nsAsyncHandlerCount;
     }
     String[] nsHandlers = configNsHandler.split(",");
     for (String nsHandlerInfo : nsHandlers) {
@@ -567,11 +592,19 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       }
       nsAsyncHandlerCount.put(nsHandlerItems[0], Integer.parseInt(nsHandlerItems[1]));
     }
+    return nsAsyncHandlerCount;
   }
 
-  private void initAsyncHandlerThreadPools4Ns(String nsId, int dedicatedHandlers) {
-    asyncRouterHandlerExecutors.computeIfAbsent(nsId, id -> Executors.newFixedThreadPool(
-        dedicatedHandlers, new AsyncThreadFactory("Router Async Handler for " + id + " #")));
+  /**
+   * Returns the asynchronous handler executor for the specified namespace.
+   * If no executor is configured for the given namespace ID, returns the default executor.
+   * Requires async RPC pools to be initialized (async RPC enabled).
+   *
+   * @param nsId the namespace identifier
+   * @return the corresponding thread pool
+   */
+  public ThreadPoolExecutor getAsyncExecutorForNamespace(String nsId) {
+    return asyncRouterHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor);
   }
 
   /**
@@ -682,6 +715,16 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     }
     if (this.fedRenameScheduler != null) {
       fedRenameScheduler.shutDown();
+    }
+    for (ThreadPoolExecutor executor : asyncRouterHandlerExecutors.values()) {
+      executor.shutdownNow();
+    }
+    asyncRouterHandlerExecutors.clear();
+    if (routerDefaultAsyncHandlerExecutor != null) {
+      routerDefaultAsyncHandlerExecutor.shutdownNow();
+    }
+    if (routerAsyncResponderExecutor != null) {
+      routerAsyncResponderExecutor.shutdownNow();
     }
     super.serviceStop();
   }
@@ -2488,14 +2531,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
 
   public boolean isAsync() {
     return this.enableAsync;
-  }
-
-  public Map<String, ExecutorService> getAsyncRouterHandlerExecutors() {
-    return asyncRouterHandlerExecutors;
-  }
-
-  public ExecutorService getRouterAsyncHandlerDefaultExecutor() {
-    return routerDefaultAsyncHandlerExecutor;
   }
 
   private static class AsyncThreadFactory implements ThreadFactory {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -525,6 +525,9 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     }
     int asyncHandlerCountDefault = configuration.getInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY,
         DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT);
+    if (asyncHandlerCountDefault < 1) {
+      throw new  IllegalArgumentException("Async handler count must be at least 1");
+    }
     for (String nsId : allConfiguredNS) {
       int dedicatedHandlers = nsAsyncHandlerCount.getOrDefault(nsId, 0);
       if (dedicatedHandlers <= 0) {
@@ -535,18 +538,16 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
         LOG.info("Dedicated handlers {} for ns {} to init Executors", dedicatedHandlers, nsId);
       }
 
-      if (dedicatedHandlers > 0) {
-        int finalDedicatedHandlers = dedicatedHandlers;
-        asyncRouterHandlerExecutors.computeIfAbsent(nsId,
-            id -> {
-              LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
-              return new ThreadPoolExecutor(finalDedicatedHandlers, finalDedicatedHandlers,
-                  0L, TimeUnit.MILLISECONDS, queue,
-                  new AsyncThreadFactory("Router Async Handler for " + nsId + " #"));
-            });
-        LOG.info("Assigned {} async handlers with queue size {} to nsId {}", dedicatedHandlers,
-            asyncQueueSize, nsId);
-      }
+      int finalDedicatedHandlers = dedicatedHandlers;
+      asyncRouterHandlerExecutors.computeIfAbsent(nsId,
+          id -> {
+            LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
+            return new ThreadPoolExecutor(finalDedicatedHandlers, finalDedicatedHandlers,
+                0L, TimeUnit.MILLISECONDS, queue,
+                new AsyncThreadFactory("Router Async Handler for " + nsId + " #"));
+          });
+      LOG.info("Assigned {} async handlers with queue size {} to nsId {}", dedicatedHandlers,
+          asyncQueueSize, nsId);
     }
 
     if (routerDefaultAsyncHandlerExecutor == null) {
@@ -576,7 +577,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
         DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT);
     Map<String, Integer> nsAsyncHandlerCount = new HashMap<>();
     if (StringUtils.isEmpty(configNsHandler)) {
-      LOG.debug("No per-namespace async handler counts configured ({}). "
+      LOG.info("No per-namespace async handler counts configured ({}). "
               + "Will use default handler count for all namespaces.",
           DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY);
       return nsAsyncHandlerCount;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.Async.warpCompletionException;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.asyncApply;
@@ -173,13 +175,16 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
           + router.getRouterId());
     }
     String nsid = namenodes.get(0).getNameserviceId();
+    final ThreadPoolExecutor nsExecutor = router.getRpcServer().getAsyncExecutorForNamespace(nsid);
+
     // transfer threadLocalContext to worker threads of executor.
     ThreadLocalContext threadLocalContext = new ThreadLocalContext();
     asyncComplete(null);
+    // Returns a CompletableFuture with RejectedExecutionException if nsExecutor is full.
     asyncApplyUseExecutor((AsyncApplyFunction<Object, Object>) o -> {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Async invoke method : {}, {}, {}, {}", method.getName(), useObserver,
-            namenodes.toString(), params);
+        LOG.debug("Async invoke method : {}, {}, {}, {}", method.getName(), useObserver, namenodes,
+            params);
       }
       threadLocalContext.transfer();
       RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
@@ -190,8 +195,23 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
         releasePermit(nsid, ugi, method, controller);
         return object;
       });
-    }, router.getRpcServer().getAsyncRouterHandlerExecutors().getOrDefault(nsid,
-        router.getRpcServer().getRouterAsyncHandlerDefaultExecutor()));
+    }, nsExecutor);
+
+    // Catch the RejectedExecutionException and convert it to StandbyException
+    asyncCatch((ret, e) -> {
+      int queueSize = nsExecutor.getQueue().size();
+      if (nsExecutor.isShutdown()) {
+        LOG.warn("Async handler executor for namespace '{}' is shutting down; task not scheduled"
+            + " (queue size: {})", nsid, queueSize, e);
+        throw new StandbyException(
+            "Namespace '" + nsid + "' async handler is shutting down (queue size: " + queueSize
+                + ")");
+      }
+      LOG.warn("Async handler executor rejected task for namespace '{}' (queue size: {}). {}", nsid,
+          queueSize, e.getMessage());
+      throw new StandbyException(
+          "Namespace '" + nsid + "' is overloaded (queue size: " + queueSize + ")");
+    }, RejectedExecutionException.class);
     return null;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -58,7 +58,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.Async.warpCompletionException;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.asyncApply;
@@ -175,7 +174,6 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
           + router.getRouterId());
     }
     String nsid = namenodes.get(0).getNameserviceId();
-
     // transfer threadLocalContext to worker threads of executor.
     ThreadLocalContext threadLocalContext = new ThreadLocalContext();
     asyncComplete(null);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -175,7 +175,6 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
           + router.getRouterId());
     }
     String nsid = namenodes.get(0).getNameserviceId();
-    final ThreadPoolExecutor nsExecutor = router.getRpcServer().getAsyncExecutorForNamespace(nsid);
 
     // transfer threadLocalContext to worker threads of executor.
     ThreadLocalContext threadLocalContext = new ThreadLocalContext();
@@ -195,22 +194,11 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
         releasePermit(nsid, ugi, method, controller);
         return object;
       });
-    }, nsExecutor);
+    }, router.getRpcServer().getAsyncExecutorForNamespace(nsid));
 
     // Catch the RejectedExecutionException and convert it to StandbyException
     asyncCatch((ret, e) -> {
-      int queueSize = nsExecutor.getQueue().size();
-      if (nsExecutor.isShutdown()) {
-        LOG.warn("Async handler executor for namespace '{}' is shutting down; task not scheduled"
-            + " (queue size: {})", nsid, queueSize, e);
-        throw new StandbyException(
-            "Namespace '" + nsid + "' async handler is shutting down (queue size: " + queueSize
-                + ")");
-      }
-      LOG.warn("Async handler executor rejected task for namespace '{}' (queue size: {}). {}", nsid,
-          queueSize, e.getMessage());
-      throw new StandbyException(
-          "Namespace '" + nsid + "' is overloaded (queue size: " + queueSize + ")");
+      throw new StandbyException("Namespace '" + nsid + "' async handler is busy.");
     }, RejectedExecutionException.class);
     return null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -67,6 +67,16 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.async.rpc.queue.size</name>
+    <value>1000</value>
+    <description>
+      The bounded queue capacity for each per-nameservice async handler thread
+      pool. When the queue is full, new requests are rejected with a
+      StandbyException to prevent unbounded memory growth. Must be at least 1.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.async.rpc.responder.count</name>
     <value>10</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router.async;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.hdfs.protocol.OpenFilesIterator;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
+import org.apache.hadoop.hdfs.server.federation.fairness.RouterAsyncRpcFairnessPolicyController;
+import org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessPolicyController;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
+import org.apache.hadoop.hdfs.server.federation.router.RemoteMethod;
+import org.apache.hadoop.hdfs.server.federation.router.RemoteParam;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
+import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapterMockitoUtil;
+import org.apache.hadoop.ipc.StandbyException;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.LambdaTestUtils;
+
+import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
+import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_MAX_ASYNCCALL_PERMIT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
+import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+
+public class TestRouterAsyncHandlerQueueOverflow {
+  /**
+   * Federated HDFS cluster.
+   */
+  private static MiniRouterDFSCluster cluster;
+  private static String ns0;
+  private static RouterRpcServer routerRpcServer;
+  private static RouterAsyncRpcClient asyncRpcClient;
+
+  private final static int QUEUE_CAP = 2;
+  private static CountDownLatch testLatch;
+
+  @BeforeAll
+  public static void setUpCluster() throws Exception {
+    cluster = new MiniRouterDFSCluster(true, 2, 3, DEFAULT_HEARTBEAT_INTERVAL_MS, 1000);
+    cluster.startCluster();
+
+    // Making one Namenode active per nameservice
+    if (cluster.isHighAvailability()) {
+      for (String ns : cluster.getNameservices()) {
+        cluster.switchToActive(ns, NAMENODES[0]);
+        cluster.switchToStandby(ns, NAMENODES[1]);
+        cluster.switchToObserver(ns, NAMENODES[2]);
+      }
+    }
+    // Start routers with only an RPC service
+    Configuration routerConf = new RouterConfigBuilder().metrics().rpc().build();
+
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE, QUEUE_CAP);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 1);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY, 1);
+    routerConf.set(DFS_ROUTER_MONITOR_NAMENODE,
+        cluster.getNameservices().get(0) + "," + cluster.getNameservices().get(1));
+    routerConf.setClass(DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
+        RouterAsyncRpcFairnessPolicyController.class, RouterRpcFairnessPolicyController.class);
+    routerConf.setInt(DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT, 60000);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_MAX_ASYNCCALL_PERMIT_KEY, 1);
+    cluster.addRouterOverrides(routerConf);
+    cluster.startRouters();
+
+    cluster.registerNamenodes();
+    cluster.waitNamenodeRegistration();
+    cluster.waitActiveNamespaces();
+
+    testLatch = new CountDownLatch(1);
+    ns0 = cluster.getNameservices().get(0);
+    MiniRouterDFSCluster.NamenodeContext nn0 = cluster.getNamenode(ns0, null);
+    FSNamesystem spyNamesystem = NameNodeAdapterMockitoUtil.spyOnNamesystem(nn0.getNamenode());
+    // Mock one slow operation. Any public interface from FSNamesystem will do.
+    Mockito.doAnswer(invocationOnMock -> {
+      String invokePath = invocationOnMock.getArgument(1);
+      if (invokePath.startsWith("/veryBigOperation")) {
+        testLatch.await();
+      } else {
+        return invocationOnMock.callRealMethod();
+      }
+      return null;
+    }).when(spyNamesystem).getFilesBlockingDecom(anyLong(), anyString());
+
+    MiniRouterDFSCluster.RouterContext router = cluster.getRandomRouter();
+    routerRpcServer = router.getRouterRpcServer();
+    routerRpcServer.initAsyncThreadPools(routerConf);
+    asyncRpcClient = new RouterAsyncRpcClient(routerConf, router.getRouter(),
+        routerRpcServer.getNamenodeResolver(), routerRpcServer.getRPCMonitor(),
+        routerRpcServer.getRouterStateIdContext());
+  }
+
+  @AfterAll
+  public static void shutdownCluster() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testInvokeMethodQueueOverflow() throws Exception {
+    RemoteMethod method =
+        new RemoteMethod("listOpenFiles", new Class<?>[] {long.class, EnumSet.class, String.class},
+            0, EnumSet.of(OpenFilesIterator.OpenFilesType.BLOCKING_DECOMMISSION),
+            new RemoteParam());
+    UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
+    Class<?> protocol = method.getProtocol();
+    String bigPath = "/veryBigOperation";
+    Object[] params =
+        new Object[] {0, EnumSet.of(OpenFilesIterator.OpenFilesType.BLOCKING_DECOMMISSION),
+            bigPath};
+    List<? extends FederationNamenodeContext> namenodes =
+        asyncRpcClient.getOrderedNamenodes(ns0, true);
+    // Downstream namespace processing this huge request
+    asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
+    ThreadPoolExecutor nsExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0);
+    Thread.sleep(500);
+    assertEquals(0, nsExecutor.getQueue().size());
+    // Successfully sent this request downstream, but all subsequent ones will get stuck
+    assertEquals(1, nsExecutor.getCompletedTaskCount());
+
+    // Async handler handling, blocking at acquirePermit
+    asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
+    Thread.sleep(500);
+    assertEquals(0, nsExecutor.getQueue().size());
+    assertEquals(1, nsExecutor.getCompletedTaskCount());
+    // Stuck in queue
+    asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
+    assertEquals(1, nsExecutor.getQueue().size());
+    // Insert one more call, also stuck in queue
+    asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
+    assertEquals(2, nsExecutor.getQueue().size());
+    // Queue full, rejected
+    asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
+    assertEquals(2, nsExecutor.getQueue().size());
+    String expectedMsg = "Namespace '" + ns0 + "' is overloaded (queue size: " + QUEUE_CAP + ")";
+    LambdaTestUtils.intercept(StandbyException.class, expectedMsg,
+        () -> syncReturn(FileStatus.class));
+    // Unstuck the namenode so we can terminate this test
+    testLatch.countDown();
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapterMockitoUtil;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
@@ -151,16 +152,14 @@ public class TestRouterAsyncHandlerQueueOverflow {
     // Downstream namespace processing this huge request
     asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
     ThreadPoolExecutor nsExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0);
-    Thread.sleep(500);
-    assertEquals(0, nsExecutor.getQueue().size());
     // Successfully sent this request downstream, but all subsequent ones will get stuck
-    assertEquals(1, nsExecutor.getCompletedTaskCount());
+    GenericTestUtils.waitFor(() -> nsExecutor.getQueue().isEmpty(), 50, 500);
+    GenericTestUtils.waitFor(() -> nsExecutor.getCompletedTaskCount() == 1, 50, 500);
 
     // Async handler handling, blocking at acquirePermit
     asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
-    Thread.sleep(500);
-    assertEquals(0, nsExecutor.getQueue().size());
-    assertEquals(1, nsExecutor.getCompletedTaskCount());
+    GenericTestUtils.waitFor(() -> nsExecutor.getQueue().isEmpty(), 50, 500);
+    GenericTestUtils.waitFor(() -> nsExecutor.getCompletedTaskCount() == 1, 50, 500);
     // Stuck in queue
     asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
     assertEquals(1, nsExecutor.getQueue().size());


### PR DESCRIPTION
### Description of PR

When a lot of requests arrive at a router and there is a backlog due to downstream namespaces not being able to fully handle the requests, routers can go OOM if there is no limit to the queue used by the async handlers.

This situation can be simulated using the unit test attached with this patch.

```java
public static void main(String[] args) throws Exception {
    setUpCluster();
    RemoteMethod method = new RemoteMethod("listOpenFiles", new Class<?>[] {long.class, EnumSet.class, String.class}, 0, EnumSet.of(OpenFilesIterator.OpenFilesType.BLOCKING_DECOMMISSION), new RemoteParam());
    UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
    Class<?> protocol = method.getProtocol();
    String bigPath = "/veryBigOperation";
    Object[] params = new Object[] {0, EnumSet.of(OpenFilesIterator.OpenFilesType.BLOCKING_DECOMMISSION), bigPath};
    List<? extends FederationNamenodeContext> namenodes = asyncRpcClient.getOrderedNamenodes(ns0, true);
    while (true) {
      asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
      asyncReturn(Map.class);
    }
  }
```

Rising memory usage from unbounded growing queue
<img width="262" height="154" alt="image" src="https://github.com/user-attachments/assets/adbe561a-17b3-4178-9cfc-5b943428a05b" />

### How was this patch tested?

This patch has been used in our prod cluster for over a year and everything's working properly.