### PR TITLE
YARN-11956: Register RMQueueAclInfo for RM REST JSON serialization

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ClassSerialisationConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ClassSerialisationConfig.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeToLabelsInfo
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodesInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.QueueAclInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.QueueAclsInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.RMQueueAclInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationDeleteRequestInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationDeleteResponseInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationListInfo;
@@ -153,7 +154,7 @@ public class ClassSerialisationConfig {
           ClusterMetricsInfo.class, ConfigVersionInfo.class, ContainerInfo.class,
           FairSchedulerQueueInfoList.class, FifoSchedulerInfo.class, NewReservation.class,
           NodeInfo.class, NodesInfo.class, QueueAclInfo.class, QueueAclsInfo.class,
-          RemoteExceptionData.class, ReservationDeleteRequestInfo.class,
+          RMQueueAclInfo.class, RemoteExceptionData.class, ReservationDeleteRequestInfo.class,
           ReservationDeleteResponseInfo.class, ReservationSubmissionRequestInfo.class,
           ReservationUpdateRequestInfo.class, ReservationUpdateResponseInfo.class,
           ResourceInfo.class, ResourceInformationsInfo.class, SchedulerInfo.class,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ClassSerialisationConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ClassSerialisationConfig.java
@@ -154,7 +154,7 @@ public class ClassSerialisationConfig {
           ClusterMetricsInfo.class, ConfigVersionInfo.class, ContainerInfo.class,
           FairSchedulerQueueInfoList.class, FifoSchedulerInfo.class, NewReservation.class,
           NodeInfo.class, NodesInfo.class, QueueAclInfo.class, QueueAclsInfo.class,
-          RMQueueAclInfo.class, RemoteExceptionData.class, ReservationDeleteRequestInfo.class,
+          RemoteExceptionData.class, ReservationDeleteRequestInfo.class,
           ReservationDeleteResponseInfo.class, ReservationSubmissionRequestInfo.class,
           ReservationUpdateRequestInfo.class, ReservationUpdateResponseInfo.class,
           ResourceInfo.class, ResourceInformationsInfo.class, SchedulerInfo.class,
@@ -167,7 +167,7 @@ public class ClassSerialisationConfig {
           ContainerLaunchContextInfo.class, DelegationToken.class, LabelsToNodesInfo.class,
           LocalResourceInfo.class, NewApplication.class, NodeLabelsInfo.class,
           NodeToLabelsEntryList.class, NodeToLabelsInfo.class, ReservationListInfo.class,
-          ResourceOptionInfo.class, SchedConfUpdateInfo.class);
+          ResourceOptionInfo.class, RMQueueAclInfo.class, SchedConfUpdateInfo.class);
 
   private final Set<Class<?>> wrappedClasses;
   private final Set<Class<?>> unWrappedClasses;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11956: Register RMQueueAclInfo for RM REST JSON serialization

The RM queue access REST call (…/queues/{queue}/access?user=…) returns RMQueueAclInfo, which was missing from the MOXy JSON allowlist in ClassSerialisationConfig, so Accept: application/json could fail with no MessageBodyWriter. Register RMQueueAclInfo there so that endpoint can return JSON.

### How was this patch tested?

tested manually: 
curl -sS -H 'Accept: application/json' \
'http://localhost:8088/ws/v1/cluster/queues/default/access?user=yarn' 

With the fix: HTTP 200, JSON body ( unwrapped, no rmQueueAclInfo wrapper )
Without the fix: error response mentioning MessageBodyWriter not found for RMQueueAclInfo 
### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html