### PR TITLE
HADOOP-19868: ci: add comments from security review of new actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,6 +19,8 @@
 
 name: "Build"
 
+# Security: write privileges are safe since this is triggered
+# only by `push` (implying user has write access).
 on:
   push:
     branches:

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -25,6 +25,11 @@
 
 name: "PR update"
 
+# Security: `pull_request_target` events can be risky, but we:
+# 1. Only grant write access for checks (a.k.a. check runs).
+# 2. We are careful with untrusted inputs (i.e. don't use user-supplied
+#    variables in ways vulnerable to shell injection, etc.)
+# 3. We don't check out the fork's head ref.
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -100,10 +100,9 @@ jobs:
     # - For `push` triggers on a fork, the GITHUB_TOKEN retains write
     #   permissions, but the `push` is happening in the context of the fork, not
     #   the upstream repo.
-    # - For `pull_request_target` (risky), the write permission is
-    #   overridden by our repository's setting "Send write tokens to workflows
-    #   from pull requests" which should be disabled.
-    #   See https://issues.apache.org/jira/browse/INFRA-27839 for confirmation.
+    # - For `pull_request_target` (not used here), image repo permissions are
+    #   scoped to the repository they run on. This prevents forks from writing
+    #   to our Apache Hadoop image repo.
     permissions:
       packages: write
     outputs:

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -100,9 +100,13 @@ jobs:
     # - For `push` triggers on a fork, the GITHUB_TOKEN retains write
     #   permissions, but the `push` is happening in the context of the fork, not
     #   the upstream repo.
-    # - For `pull_request_target` (not used here), image repo permissions are
-    #   scoped to the repository they run on. This prevents forks from writing
-    #   to our Apache Hadoop image repo.
+    # - `pull_request_target` events (not used here) use the base repo's
+    #   default branch. This prevents an attacker from adding code in a pull
+    #   request which prints / leaks secrets, etc.. Also the GITHUB_TOKEN we
+    #   use to grant access to writing to the image repo. is scoped to the
+    #   repository it runs on. Even if a fork were to gain access to a
+    #   GITHUB_TOKEN with write privileges, it doesn't grant access for other
+    #   repositories to write.
     permissions:
       packages: write
     outputs:

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -42,6 +42,7 @@ on:
           Candidates: "build-only".
         default: '[ "build-only" ]'
 
+# Default to minimal permissions for workflow.
 permissions:
   packages: read
 
@@ -78,6 +79,9 @@ jobs:
     steps:
       - name: Set up Outputs
         id: variables
+        # Security: passing inputs.{os, branch} through workflow (above) inputs removes
+        # ability to do shell injection below.
+        # See: https://securitylab.github.com/resources/github-actions-untrusted-input/
         run: |
           # Convert to lowercase to meet Docker repo name requirement
           REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
@@ -86,6 +90,20 @@ jobs:
     name: Build Image ${{ inputs.os }}-${{ inputs.branch }}
     runs-on: ubuntu-24.04
     needs: [ precondition ]
+    # Security: this does not leak write access for our image repository to
+    # forked repos.
+    #
+    # We have `packages: write` permissions for our GITHUB_TOKEN below. However:
+    #
+    # - For `pull_request`, GitHub downgrades GITHUB_TOKEN permissions to
+    #   read-only.
+    # - For `push` triggers on a fork, the GITHUB_TOKEN retains write
+    #   permissions, but the `push` is happening in the context of the fork, not
+    #   the upstream repo.
+    # - For `pull_request_target` (risky), the write permission is
+    #   overridden by our repository's setting "Send write tokens to workflows
+    #   from pull requests" which should be disabled.
+    #   See https://issues.apache.org/jira/browse/INFRA-27839 for confirmation.
     permissions:
       packages: write
     outputs:

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -24,7 +24,7 @@ on:
     - cron: "*/15 * * * *"
 
 # Security: privileged (can write) workflow is only triggered via schedule,
-#  so issues associated with forks do not apply.
+# so issues associated with forks do not apply.
 jobs:
   update:
     name: "Update Build Status"

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -23,6 +23,8 @@ on:
   schedule:
     - cron: "*/15 * * * *"
 
+# Security: privileged (can write) workflow is only triggered via schedule,
+#  so issues associated with forks do not apply.
 jobs:
   update:
     name: "Update Build Status"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

No code change; comments only.

Following up on HADOOP-19858, this PR adds `# Security:` comments to add to our
github actions to explain why each workflow is safe. 

### How was this patch tested?

Comments only, but CodeQL scanning is now enabled for changes within the `.github` directory.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [na] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [na] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [na] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [na] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
