### PR TITLE
HADOOP-19859. Speed up GHA jobs by image cache

### DIFF
--- a/.github/workflows/build_image_cache.yml
+++ b/.github/workflows/build_image_cache.yml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Image Cache
+
+on:
+  # Run jobs when a commit is merged
+  push:
+    branches:
+      - 'trunk'
+      - 'branch-*'
+    paths:
+      - 'dev-support/docker/**'
+  workflow_dispatch:
+
+jobs:
+  build-image-cache-ubuntu_24:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/tmpl_build_image_cache.yml
+    with:
+      os: ubuntu_24
+  build-image-cache-debian_13:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/tmpl_build_image_cache.yml
+    with:
+      os: debian_13
+  build-image-cache-rockylinux_8:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/tmpl_build_image_cache.yml
+    with:
+      os: rockylinux_8

--- a/.github/workflows/build_image_cache.yml
+++ b/.github/workflows/build_image_cache.yml
@@ -17,6 +17,8 @@
 
 name: Image Cache
 
+# Security: write privileges are safe since this is triggered only by
+# `push` and `workflow_dispatch` (implying user has write access).
 on:
   # Run jobs when a commit is merged
   push:

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -131,6 +131,7 @@ jobs:
           file: ./dev-support/docker/Dockerfile_${{ inputs.os }}
           push: true
           tags: ${{ needs.precondition.outputs.build_image_url }}-base
+          cache-from: type=registry,ref=ghcr.io/apache/hadoop/gha-build-${{ inputs.os }}-image-cache:${{ inputs.branch }}
       - name: User-specific Dockerfile
         run: |
           USER_ID=$(id -u "${USER}")

--- a/.github/workflows/tmpl_build_image_cache.yml
+++ b/.github/workflows/tmpl_build_image_cache.yml
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build Image Cache
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        description: Operating system to create build image cache for.
+        default: ubuntu_24
+
+permissions:
+  packages: read
+
+jobs:
+  main:
+    name: build-image-cache-${{ inputs.os }}-${{ github.ref_name }}
+    if: github.repository == 'apache/hadoop'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout Hadoop repository
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Login to DockerHub
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image cache for ${{ inputs.os }}-${{ github.ref_name }}
+        id: docker_build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ./dev-support/docker/
+          file: ./dev-support/docker/Dockerfile_${{ inputs.os }}
+          push: true
+          tags: ghcr.io/apache/hadoop/gha-build-${{ inputs.os }}-image-cache:${{ github.ref_name }}-static
+          cache-from: type=registry,ref=ghcr.io/apache/hadoop/gha-build-${{ inputs.os }}-image-cache:${{ github.ref_name }}
+          cache-to: type=registry,ref=ghcr.io/apache/hadoop/gha-build-${{ inputs.os }}-image-cache:${{ github.ref_name }},mode=max
+      - name: Image digest for ${{ inputs.os }}-${{ github.ref_name }}
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/tmpl_build_image_cache.yml
+++ b/.github/workflows/tmpl_build_image_cache.yml
@@ -26,6 +26,7 @@ on:
         description: Operating system to create build image cache for.
         default: ubuntu_24
 
+# Default to minimal permissions for workflow.
 permissions:
   packages: read
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR adds image cache for the GHA workflow, when cache-hit, the build image step likely decreases from ~15min to ~1min.

Image cache is created on pushing a commit to `apache/hadoop` repo, when `dev-support/docker/**` changes or manually trigger, and since this is a public repo, it can be leveraged by forked repos to read to speed up their image building workflows.

### How was this patch tested?

Tested on my forked repo.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19859)?
- [na] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [na] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.