### PR TITLE
HADOOP-19857. Enable unit tests on GHA

### DIFF
--- a/.github/gha-tests/README.md
+++ b/.github/gha-tests/README.md
@@ -45,16 +45,16 @@ $ ./start-build-env.sh
 Run single test suite inside container
 ```
 $ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
-$ ./mvnw -pl :hadoop-common -am clean install -DskipTests
-$ ./mvnw -pl :hadoop-common test -Dtest=TestIPC
+$ ./mvnw $MAVEN_ARGS -pl :hadoop-common -am clean install -DskipTests
+$ ./mvnw $MAVEN_ARGS -pl :hadoop-common test -Dtest=TestIPC
 ```
 
 Run all tests inside container and save the log to a file, then extract the failed
 test cases from the log file. This might take a dozen of hours, be patient.
 ```
 $ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
-$ ./mvnw clean install -DskipTests
-$ ./mvnw test --fail-at-end -Dmaven.test.failure.ignore=true \
+$ ./mvnw $MAVEN_ARGS clean install -DskipTests
+$ ./mvnw $MAVEN_ARGS test --fail-at-end -Dmaven.test.failure.ignore=true \
     -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt \
     2>&1 | tee ~/hadoop-test.`date '+%Y%m%d'`.log
 $ cat hadoop-test.`date '+%Y%m%d'`.log | \

--- a/.github/gha-tests/README.md
+++ b/.github/gha-tests/README.md
@@ -1,3 +1,20 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
 ### Initial test list for GitHub Actions (GHA)
 
 Run GHA workflow repeatedly, and if a test fail or abort one time, add it into `exclude-tests.txt`.

--- a/.github/gha-tests/README.md
+++ b/.github/gha-tests/README.md
@@ -25,6 +25,14 @@ them from the excluded list once they are stable. Stability assessment: when del
 tests from `exclude-tests.txt`, the GHA workflow was successfully executed 5 times
 consecutively.
 
+### Slow tests
+
+Test classes takes more than 60s to complete in module `hadoop-hdfs-project/hadoop-hdfs`
+are marked as slow tests, by adding JUnit5 annotation `@Tag("slow")` to the test class.
+
+Slow tests are executed in a dedicated GHA job and roughly take 2.5 hours to complete.
+Contributors are encouraged to diagnose and improve the slow tests to speed up the CI.
+
 ### Run test locally
 
 Create a standard build environment using Docker.

--- a/.github/gha-tests/README.md
+++ b/.github/gha-tests/README.md
@@ -15,11 +15,15 @@
    limitations under the License.
 -->
 
-### Initial test list for GitHub Actions (GHA)
+### Excluded tests for GitHub Actions (GHA)
 
-Run GHA workflow repeatedly, and if a test fail or abort one time, add it into `exclude-tests.txt`.
+Initial excluded tests: run the GHA workflow, if a test fails or aborts, add it
+to `exclude-tests.txt`. Repeat until 5 consecutive successes.
 
-Contributors are encouraged to diagnose and improve the excluded test cases, and remove them from the excluded list once they are stable.
+Contributors are encouraged to diagnose and improve the excluded tests, and remove
+them from the excluded list once they are stable. Stability assessment: when deleting
+tests from `exclude-tests.txt`, the GHA workflow was successfully executed 5 times
+consecutively.
 
 ### Run test locally
 
@@ -37,8 +41,8 @@ $ ./mvnw $MAVEN_ARGS -pl :hadoop-common -am clean install -DskipTests
 $ ./mvnw $MAVEN_ARGS -pl :hadoop-common test -Dtest=TestIPC
 ```
 
-Run all tests inside container and save the log to a file, then extract the failed test cases from the log file.
-This might take a dozen of hours, be patient.
+Run all tests inside container and save the log to a file, then extract the failed
+test cases from the log file. This might take a dozen of hours, be patient.
 ```
 $ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
 $ ./mvnw $MAVEN_ARGS clean install -DskipTests

--- a/.github/gha-tests/README.md
+++ b/.github/gha-tests/README.md
@@ -45,16 +45,16 @@ $ ./start-build-env.sh
 Run single test suite inside container
 ```
 $ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
-$ ./mvnw $MAVEN_ARGS -pl :hadoop-common -am clean install -DskipTests
-$ ./mvnw $MAVEN_ARGS -pl :hadoop-common test -Dtest=TestIPC
+$ ./mvnw -pl :hadoop-common -am clean install -DskipTests
+$ ./mvnw -pl :hadoop-common test -Dtest=TestIPC
 ```
 
 Run all tests inside container and save the log to a file, then extract the failed
 test cases from the log file. This might take a dozen of hours, be patient.
 ```
 $ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
-$ ./mvnw $MAVEN_ARGS clean install -DskipTests
-$ ./mvnw $MAVEN_ARGS test --fail-at-end -Dmaven.test.failure.ignore=true \
+$ ./mvnw clean install -DskipTests
+$ ./mvnw test --fail-at-end -Dmaven.test.failure.ignore=true \
     -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt \
     2>&1 | tee ~/hadoop-test.`date '+%Y%m%d'`.log
 $ cat hadoop-test.`date '+%Y%m%d'`.log | \

--- a/.github/gha-tests/README.md
+++ b/.github/gha-tests/README.md
@@ -1,0 +1,34 @@
+### Initial test list for GitHub Actions (GHA)
+
+Run GHA workflow repeatedly, and if a test fail or abort one time, add it into `exclude-tests.txt`.
+
+Contributors are encouraged to diagnose and improve the excluded test cases, and remove them from the excluded list once they are stable.
+
+### Run test locally
+
+Create a standard build environment using Docker.
+```
+$ cd <hadoop source code directory>
+$ ./start-build-env.sh
+... (wait for the container to start)
+```
+
+Run single test suite inside container
+```
+$ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
+$ ./mvnw $MAVEN_ARGS -pl :hadoop-common -am clean install -DskipTests
+$ ./mvnw $MAVEN_ARGS -pl :hadoop-common test -Dtest=TestIPC
+```
+
+Run all tests inside container and save the log to a file, then extract the failed test cases from the log file.
+This might take a dozen of hours, be patient.
+```
+$ export MAVEN_ARGS="-Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.test.libhadoop"
+$ ./mvnw $MAVEN_ARGS clean install -DskipTests
+$ ./mvnw $MAVEN_ARGS test --fail-at-end -Dmaven.test.failure.ignore=true \
+    -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt \
+    2>&1 | tee ~/hadoop-test.`date '+%Y%m%d'`.log
+$ cat hadoop-test.`date '+%Y%m%d'`.log | \
+    grep -E 'surefire:3.5.3:test|<<< FAILURE! - in' | \
+    grep -o -E 'surefire:3.5.3:test.*|org.apache.hadoop.*'
+```

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -28,6 +28,7 @@
 **/org/apache/hadoop/hdfs/TestDFSUtil.java
 **/org/apache/hadoop/hdfs/TestFileCreation.java
 **/org/apache/hadoop/hdfs/TestPread.java
+**/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithValidator.java
@@ -37,6 +38,7 @@
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
+**/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
 **/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -63,6 +65,7 @@
 
 # hadoop-yarn-server-resourcemanager
 **/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+**/org/apache/hadoop/yarn/server/resourcemanager/TestRMRestart.java
 **/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/TestMetricsInvariantChecker.java
 **/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestLeveldbRMStateStore.java
 **/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulingWithAllocationRequestId.java
@@ -77,6 +80,7 @@
 # hadoop-yarn-server-nodemanager
 **/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
 **/org/apache/hadoop/yarn/server/nodemanager/TestNodeManagerResync.java
+**/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -48,13 +48,15 @@
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
-**/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
-**/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+**/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
+**/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+**/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectivesWithViewDFS.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectives.java
 **/org/apache/hadoop/hdfs/server/namenode/TestReconstructStripedBlocks.java
 **/org/apache/hadoop/hdfs/server/namenode/TestFileTruncate.java
+**/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandbyWithQJM.java
 **/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
 **/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
 **/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -28,7 +28,9 @@
 **/org/apache/hadoop/hdfs/TestDFSUtil.java
 **/org/apache/hadoop/hdfs/TestFileCreation.java
 **/org/apache/hadoop/hdfs/TestPread.java
+**/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
+**/org/apache/hadoop/hdfs/TestReconstructStripedFileWithValidator.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -38,9 +40,10 @@
 **/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
-**/org/apache/hadoop/hdfs/server/namenode/TestReconstructStripedBlocks.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectivesWithViewDFS.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectives.java
+**/org/apache/hadoop/hdfs/server/namenode/TestReconstructStripedBlocks.java
+**/org/apache/hadoop/hdfs/server/namenode/TestFileTruncate.java
 **/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
 **/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
 **/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -89,11 +92,12 @@
 **/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
 
 # hadoop-yarn-client
-**/org/apache/hadoop/yarn/client/TestResourceTrackerOnHA.java
 **/org/apache/hadoop/yarn/client/TestApplicationClientProtocolOnHA.java
 **/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolForTimelineV2.java
 **/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolOnHA.java
+**/org/apache/hadoop/yarn/client/TestResourceTrackerOnHA.java
 **/org/apache/hadoop/yarn/client/TestRMFailover.java
+**/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
 
 # hadoop-mapreduce-client-shuffle
 **/org/apache/hadoop/mapred/TestShuffleChannelHandler.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -39,6 +39,7 @@
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithValidator.java
 **/org/apache/hadoop/hdfs/TestReplaceDatanodeFailureReplication.java
+**/org/apache/hadoop/hdfs/client/impl/TestBlockReaderLocal.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -50,6 +51,7 @@
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
 **/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
+**/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
 **/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
 **/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectivesWithViewDFS.java
@@ -95,6 +97,7 @@
 **/org/apache/hadoop/yarn/server/nodemanager/TestNodeManagerResync.java
 **/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
 **/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+**/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -29,6 +29,7 @@
 **/org/apache/hadoop/hdfs/TestFileCreation.java
 **/org/apache/hadoop/hdfs/TestPread.java
 **/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
+**/org/apache/hadoop/hdfs/TestMaintenanceState.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithValidator.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -28,6 +28,7 @@
 **/org/apache/hadoop/hdfs/TestDFSUtil.java
 **/org/apache/hadoop/hdfs/TestFileCreation.java
 **/org/apache/hadoop/hdfs/TestPread.java
+**/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -40,6 +40,7 @@
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
+**/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
 **/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -144,6 +145,7 @@
 **/org/apache/hadoop/mapreduce/TestLargeSort.java
 
 # hadoop-hdfs-rbf
+**/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
 **/org/apache/hadoop/hdfs/server/federation/router/TestRouterFaultTolerant.java
 **/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
 **/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -20,6 +20,7 @@
 # hadoop-common
 **/org/apache/hadoop/ha/TestZKFailoverController.java
 **/org/apache/hadoop/ha/TestZKFailoverControllerStress.java
+**/org/apache/hadoop/io/wrappedio/impl/TestWrappedStatistics.java
 **/org/apache/hadoop/ipc/TestRPC.java
 **/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
 **/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -85,13 +85,14 @@
 **/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
 **/org/apache/hadoop/yarn/server/nodemanager/TestNodeManagerResync.java
 **/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
+**/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitor.java
 **/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestFpgaDiscoverer.java
-**/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
 
 # hadoop-yarn-server-tests
 **/org/apache/hadoop/yarn/server/TestRMNMSecretKeys.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -27,6 +27,7 @@
 # hadoop-hdfs
 **/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
 **/org/apache/hadoop/hdfs/TestBlockStoragePolicy.java
+**/org/apache/hadoop/hdfs/TestDecommission.java
 **/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
 **/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
 **/org/apache/hadoop/hdfs/TestDFSClientRetries.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -1,0 +1,176 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# hadoop-common
+**/org/apache/hadoop/ha/TestZKFailoverController.java
+**/org/apache/hadoop/ipc/TestRPC.java
+**/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+
+# hadoop-hdfs
+**/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
+**/org/apache/hadoop/hdfs/TestDFSClientRetries.java
+**/org/apache/hadoop/hdfs/TestDFSUtil.java
+**/org/apache/hadoop/hdfs/TestFileCreation.java
+**/org/apache/hadoop/hdfs/TestPread.java
+**/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
+**/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
+**/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+**/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
+**/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+**/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
+**/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
+**/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
+**/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+**/org/apache/hadoop/hdfs/server/namenode/TestReconstructStripedBlocks.java
+**/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectivesWithViewDFS.java
+**/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectives.java
+**/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
+**/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
+**/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+**/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
+**/org/apache/hadoop/hdfs/web/TestWebHdfsTimeouts.java
+**/org/apache/hadoop/hdfs/web/TestFSMainOperationsWebHdfs.java
+
+# hadoop-hdfs-httpfs
+**/org/apache/hadoop/fs/http/client/TestHttpFSWithHttpFSFileSystem.java
+
+# hadoop-yarn-common
+**/org/apache/hadoop/yarn/util/TestProcfsBasedProcessTree.java
+**/org/apache/hadoop/yarn/webapp/TestWebApp.java
+
+# hadoop-yarn-server-common
+**/org/apache/hadoop/yarn/server/federation/store/sql/TestFederationSQLServerScriptAccuracy.java
+
+# hadoop-yarn-server-resourcemanager
+**/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+**/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/TestMetricsInvariantChecker.java
+**/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestLeveldbRMStateStore.java
+**/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulingWithAllocationRequestId.java
+**/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java
+
+# hadoop-yarn-server-router
+**/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+**/org/apache/hadoop/yarn/server/router/webapp/TestFederationWebApp.java
+**/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
+**/org/apache/hadoop/yarn/server/router/subcluster/fair/TestYarnFederationWithFairScheduler.java
+
+# hadoop-yarn-server-nodemanager
+**/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
+**/org/apache/hadoop/yarn/server/nodemanager/TestNodeManagerResync.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitor.java
+**/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestFpgaDiscoverer.java
+**/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+
+# hadoop-yarn-server-tests
+**/org/apache/hadoop/yarn/server/TestRMNMSecretKeys.java
+
+# hadoop-yarn-services-core
+**/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
+
+# hadoop-yarn-client
+**/org/apache/hadoop/yarn/client/TestResourceTrackerOnHA.java
+**/org/apache/hadoop/yarn/client/TestApplicationClientProtocolOnHA.java
+**/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolForTimelineV2.java
+**/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolOnHA.java
+**/org/apache/hadoop/yarn/client/TestRMFailover.java
+
+# hadoop-mapreduce-client-shuffle
+**/org/apache/hadoop/mapred/TestShuffleChannelHandler.java
+
+# hadoop-mapreduce-client-app
+**/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
+
+# hadoop-mapreduce-client-jobclient
+**/org/apache/hadoop/mapred/TestJobSysDirWithDFS.java
+**/org/apache/hadoop/mapred/TestMerge.java
+**/org/apache/hadoop/mapred/TestMiniMRChildTask.java
+**/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
+**/org/apache/hadoop/mapred/TestReduceFetchFromPartialMem.java
+**/org/apache/hadoop/mapred/TestMiniMRWithDFSWithDistinctUsers.java
+**/org/apache/hadoop/mapred/TestLazyOutput.java
+**/org/apache/hadoop/mapred/TestJobName.java
+**/org/apache/hadoop/mapred/TestMiniMRClasspath.java
+**/org/apache/hadoop/mapred/TestJobCounters.java
+**/org/apache/hadoop/mapred/TestMRTimelineEventHandling.java
+**/org/apache/hadoop/mapred/TestMiniMRClientCluster.java
+**/org/apache/hadoop/mapred/TestClusterMRNotification.java
+**/org/apache/hadoop/mapred/TestJobCleanup.java
+**/org/apache/hadoop/mapred/TestReduceFetch.java
+**/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
+**/org/apache/hadoop/mapreduce/TestMRJobClient.java
+**/org/apache/hadoop/mapreduce/lib/output/TestJobOutputCommitter.java
+**/org/apache/hadoop/mapreduce/TestChild.java
+**/org/apache/hadoop/mapreduce/v2/TestMROldApiJobs.java
+**/org/apache/hadoop/mapreduce/v2/TestMiniMRProxyUser.java
+**/org/apache/hadoop/mapreduce/v2/TestMRJobsWithHistoryService.java
+**/org/apache/hadoop/mapreduce/v2/TestMRAMWithNonNormalizedCapabilities.java
+**/org/apache/hadoop/mapreduce/v2/TestUberAM.java
+**/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecution.java
+**/org/apache/hadoop/mapreduce/v2/TestMRJobsWithProfiler.java
+**/org/apache/hadoop/mapreduce/security/TestMRCredentials.java
+**/org/apache/hadoop/mapreduce/security/TestBinaryTokenFile.java
+**/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
+**/org/apache/hadoop/mapreduce/TestMapReduceLazyOutput.java
+**/org/apache/hadoop/mapreduce/TestLargeSort.java
+
+# hadoop-hdfs-rbf
+**/org/apache/hadoop/hdfs/server/federation/router/TestRouterFaultTolerant.java
+**/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+**/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
+**/org/apache/hadoop/hdfs/server/federation/router/security/token/TestSQLDelegationTokenSecretManagerImpl.java
+
+# hadoop-yarn-server-timelineservice-documentstore
+**/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineWriterImpl.java
+**/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreCollectionCreator.java
+**/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/TestCosmosDBDocumentStoreReader.java
+**/org/apache/hadoop/yarn/server/timelineservice/documentstore/writer/cosmosdb/TestCosmosDBDocumentStoreWriter.java
+**/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineReaderImpl.java
+
+# hadoop-yarn-applications-catalog-webapp
+# skip module because it uses com.github.searls:jasmine-maven-plugin:2.1:test and requires Web Browser
+
+# hadoop-streaming
+**/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
+**/org/apache/hadoop/streaming/TestMultipleCachefiles.java
+**/org/apache/hadoop/streaming/TestSymLink.java
+**/org/apache/hadoop/streaming/TestFileArgs.java
+
+# hadoop-gridmix
+**/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
+**/org/apache/hadoop/mapred/gridmix/TestLoadJob.java
+**/org/apache/hadoop/mapred/gridmix/TestSleepJob.java
+**/org/apache/hadoop/mapred/gridmix/TestDistCacheEmulation.java
+
+# hadoop-extras
+**/org/apache/hadoop/tools/TestDistCh.java
+
+# hadoop-sls
+**/org/apache/hadoop/yarn/sls/TestSLSDagAMSimulator.java
+**/org/apache/hadoop/yarn/sls/TestSLSGenericSynth.java
+**/org/apache/hadoop/yarn/sls/TestSLSStreamAMSynth.java
+**/org/apache/hadoop/yarn/sls/TestSLSRunner.java
+**/org/apache/hadoop/yarn/sls/TestReservationSystemInvariants.java
+**/org/apache/hadoop/yarn/sls/appmaster/TestAMSimulator.java
+
+# hadoop-aws
+**/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -54,6 +54,7 @@
 **/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
 **/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
 **/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+**/org/apache/hadoop/hdfs/server/namenode/ha/TestUpdateBlockTailing.java
 **/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
 **/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectivesWithViewDFS.java
@@ -168,6 +169,7 @@
 **/org/apache/hadoop/hdfs/server/federation/router/TestRouterFaultTolerant.java
 **/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
 **/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
+**/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRPCMultipleDestinationMountTableResolver.java
 **/org/apache/hadoop/hdfs/server/federation/router/security/token/TestSQLDelegationTokenSecretManagerImpl.java
 
 # hadoop-yarn-server-timelineservice-documentstore

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -73,6 +73,7 @@
 **/org/apache/hadoop/yarn/server/resourcemanager/TestRMRestart.java
 **/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/TestMetricsInvariantChecker.java
 **/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestLeveldbRMStateStore.java
+**/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacityOverTimePolicy.java
 **/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulingWithAllocationRequestId.java
 **/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestContinuousScheduling.java
 **/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -26,6 +26,7 @@
 
 # hadoop-hdfs
 **/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
+**/org/apache/hadoop/hdfs/TestBlockStoragePolicy.java
 **/org/apache/hadoop/hdfs/TestDFSClientRetries.java
 **/org/apache/hadoop/hdfs/TestDFSUtil.java
 **/org/apache/hadoop/hdfs/TestFileCreation.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -43,6 +43,7 @@
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+**/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFSStriped.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -19,8 +19,10 @@
 
 # hadoop-common
 **/org/apache/hadoop/ha/TestZKFailoverController.java
+**/org/apache/hadoop/ha/TestZKFailoverControllerStress.java
 **/org/apache/hadoop/ipc/TestRPC.java
 **/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+**/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
 
 # hadoop-hdfs
 **/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -52,6 +52,7 @@
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
 **/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
 **/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
+**/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
 **/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
 **/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
 **/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectivesWithViewDFS.java
@@ -74,6 +75,7 @@
 **/org/apache/hadoop/yarn/webapp/TestWebApp.java
 
 # hadoop-yarn-server-common
+**/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
 **/org/apache/hadoop/yarn/server/federation/store/sql/TestFederationSQLServerScriptAccuracy.java
 
 # hadoop-yarn-server-resourcemanager

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -74,6 +74,7 @@
 **/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/TestMetricsInvariantChecker.java
 **/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestLeveldbRMStateStore.java
 **/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulingWithAllocationRequestId.java
+**/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestContinuousScheduling.java
 **/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java
 
 # hadoop-yarn-server-router

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -18,12 +18,8 @@
 #
 
 # hadoop-common
-**/org/apache/hadoop/ha/TestZKFailoverController.java
-**/org/apache/hadoop/ha/TestZKFailoverControllerStress.java
-**/org/apache/hadoop/io/wrappedio/impl/TestWrappedStatistics.java
 **/org/apache/hadoop/ipc/TestRPC.java
 **/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
-**/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
 
 # hadoop-hdfs
 **/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
@@ -48,6 +44,7 @@
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFSStriped.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
+**/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
 **/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -161,6 +161,7 @@
 
 # hadoop-hdfs-rbf
 **/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
+**/org/apache/hadoop/hdfs/server/federation/router/TestRouterClientRejectOverload.java
 **/org/apache/hadoop/hdfs/server/federation/router/TestRouterFaultTolerant.java
 **/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
 **/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java

--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -27,15 +27,17 @@
 # hadoop-hdfs
 **/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
 **/org/apache/hadoop/hdfs/TestBlockStoragePolicy.java
+**/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
+**/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
 **/org/apache/hadoop/hdfs/TestDFSClientRetries.java
 **/org/apache/hadoop/hdfs/TestDFSUtil.java
 **/org/apache/hadoop/hdfs/TestFileCreation.java
-**/org/apache/hadoop/hdfs/TestPread.java
-**/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
 **/org/apache/hadoop/hdfs/TestMaintenanceState.java
+**/org/apache/hadoop/hdfs/TestPread.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
 **/org/apache/hadoop/hdfs/TestReconstructStripedFileWithValidator.java
+**/org/apache/hadoop/hdfs/TestReplaceDatanodeFailureReplication.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -190,9 +190,14 @@ jobs:
       max-parallel: 6
       matrix:
         include:
-          - comment: hdfs
+          - comment: hdfs - slow
             modules:
               -pl :hadoop-hdfs
+              -Dgroups=slow
+          - comment: hdfs - other
+            modules:
+              -pl :hadoop-hdfs
+              -DexcludedGroups=slow
           - comment: yarn-server-rm
             modules:
               -pl :hadoop-yarn-server-resourcemanager

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -69,6 +69,7 @@ env:
     -Drequire.snappy
     -Drequire.valgrind
     -Dmaven.test.failure.ignore=false
+    -Dsurefire.rerunFailingTestsCount=2
 
 jobs:
   precondition:

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -177,7 +177,7 @@ jobs:
           check-latest: false
       - name: Build
         shell: bash
-        run: ./mvnw $MAVEN_ARGS clean install -DskipTests
+        run: ./mvnw clean install -DskipTests
   build-and-test:
     if: (!cancelled()) && contains(fromJSON(inputs.jobs), 'build-and-test')
     name: Test ${{ matrix.comment }} (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
@@ -309,10 +309,10 @@ jobs:
           check-latest: false
       - name: Build (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
         shell: bash
-        run: ./mvnw $MAVEN_ARGS ${{ matrix.modules }} clean install -am -DskipTests
+        run: ./mvnw ${{ matrix.modules }} clean install -am -DskipTests
       - name: Test (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
         shell: bash
-        run: ./mvnw $MAVEN_ARGS ${{ matrix.modules }} test -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt
+        run: ./mvnw ${{ matrix.modules }} test -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -39,8 +39,8 @@ on:
         type: string
         description: >-
           Jobs to run, and should be in JSON Array format.
-          Candidates: "build-only".
-        default: '[ "build-only" ]'
+          Candidates: "build-only", "build-and-test".
+        default: '[ "build-and-test" ]'
 
 # Default to minimal permissions for workflow.
 permissions:
@@ -177,3 +177,141 @@ jobs:
       - name: Build
         shell: bash
         run: ./mvnw $MAVEN_ARGS clean install -DskipTests
+  build-and-test:
+    if: (!cancelled()) && contains(fromJSON(inputs.jobs), 'build-and-test')
+    name: Test ${{ matrix.comment }} (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
+    runs-on: ubuntu-24.04
+    needs: [ precondition, build-image ]
+    container:
+      image: ${{ needs.precondition.outputs.build_image_url }}
+      options: --user ${{ needs.build-image.outputs.uid }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        include:
+          - comment: hdfs
+            modules:
+              -pl :hadoop-hdfs
+          - comment: yarn-server-rm
+            modules:
+              -pl :hadoop-yarn-server-resourcemanager
+          - comment: mr
+            modules:
+              -pl :hadoop-mapreduce-client-core
+              -pl :hadoop-mapreduce-client-common
+              -pl :hadoop-mapreduce-client-shuffle
+              -pl :hadoop-mapreduce-client-jobclient
+              -pl :hadoop-mapreduce-client-app
+              -pl :hadoop-mapreduce-client-hs
+              -pl :hadoop-mapreduce-client-hs-plugins
+              -pl :hadoop-mapreduce-client-nativetask
+              -pl :hadoop-mapreduce-client-uploader
+              -pl :hadoop-mapreduce-examples
+          - comment: common
+            modules:
+              -pl :hadoop-common
+              -pl :hadoop-yarn-server-nodemanager
+              -pl :hadoop-yarn-client
+              -pl :hadoop-distcp
+          - comment: hdfs-rbf
+            modules:
+              -pl :hadoop-hdfs-rbf
+              -pl :hadoop-yarn-applications-distributedshell
+              -pl :hadoop-yarn-services-core
+          - comment: other
+            modules:
+              -pl :hadoop-minikdc
+              -pl :hadoop-auth
+              -pl :hadoop-auth-examples
+              -pl :hadoop-nfs
+              -pl :hadoop-kms
+              -pl :hadoop-registry
+              -pl :hadoop-hdfs-client
+              -pl :hadoop-hdfs-native-client
+              -pl :hadoop-hdfs-httpfs
+              -pl :hadoop-hdfs-nfs
+              -pl :hadoop-yarn-api
+              -pl :hadoop-yarn-common
+              -pl :hadoop-yarn-server-common
+              -pl :hadoop-yarn-server-applicationhistoryservice
+              -pl :hadoop-yarn-server-timelineservice
+              -pl :hadoop-yarn-server-web-proxy
+              -pl :hadoop-yarn-server-tests
+              -pl :hadoop-yarn-server-sharedcachemanager
+              -pl :hadoop-yarn-server-timeline-pluginstorage
+              -pl :hadoop-yarn-server-timelineservice-hbase-common
+              -pl :hadoop-yarn-server-timelineservice-hbase-client
+              -pl :hadoop-yarn-server-timelineservice-hbase-server-2
+              -pl :hadoop-yarn-server-timelineservice-hbase-tests
+              -pl :hadoop-yarn-server-router
+              -pl :hadoop-yarn-server-timelineservice-documentstore
+              -pl :hadoop-yarn-server-globalpolicygenerator
+              -pl :hadoop-yarn-applications-unmanaged-am-launcher
+              -pl :hadoop-yarn-services-api
+              -pl :hadoop-yarn-registry
+              -pl org.apache.hadoop.applications.mawo:hadoop-yarn-applications-mawo-core
+              -pl :hadoop-yarn-csi
+              -pl :hadoop-minicluster
+              -pl :hadoop-federation-balance
+              -pl :hadoop-streaming
+              -pl :hadoop-client
+              -pl :hadoop-dynamometer-workload
+              -pl :hadoop-dynamometer-infra
+              -pl :hadoop-dynamometer-blockgen
+              -pl :hadoop-dynamometer-dist
+              -pl :hadoop-archives
+              -pl :hadoop-archive-logs
+              -pl :hadoop-rumen
+              -pl :hadoop-gridmix
+              -pl :hadoop-datajoin
+              -pl :hadoop-extras
+              -pl :hadoop-aws
+              -pl :hadoop-kafka
+              -pl :hadoop-aliyun
+              -pl :hadoop-sls
+              -pl :hadoop-resourceestimator
+              -pl :hadoop-azure
+              -pl :hadoop-azure-datalake
+              -pl :hadoop-fs2img
+              -pl :hadoop-tools-dist
+              -pl :hadoop-benchmark
+              -pl :hadoop-compat-bench
+              -pl :hadoop-client-api
+              -pl :hadoop-client-runtime
+              -pl :hadoop-client-minicluster
+              -pl :hadoop-client-integration-tests
+              -pl :hadoop-cos
+              -pl :hadoop-tos
+              -pl :hadoop-huaweicloud
+              -pl :hadoop-cloud-storage
+              -pl :hadoop-dist
+          # skipped modules
+          # -pl :hadoop-yarn-applications-catalog-webapp
+    steps:
+      - name: Checkout Hadoop repository
+        uses: actions/checkout@v6
+        # In order to fetch changed files
+        with:
+          fetch-depth: 0
+      - name: Setup JDK ${{ inputs.java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: ${{ inputs.java }}
+          cache: 'maven'
+          check-latest: false
+      - name: Build (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
+        shell: bash
+        run: ./mvnw $MAVEN_ARGS ${{ matrix.modules }} clean install -am -DskipTests
+      - name: Test (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
+        shell: bash
+        run: ./mvnw $MAVEN_ARGS ${{ matrix.modules }} test -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-logs-${{ matrix.comment }}-java${{ inputs.java }})-${{ inputs.os }}-${{ inputs.branch }}
+          path: |
+            **/target/*.log
+            **/target/*.xml

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -187,7 +187,7 @@ jobs:
       options: --user ${{ needs.build-image.outputs.uid }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 8
       matrix:
         include:
           - comment: hdfs - slow

--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -177,7 +177,7 @@ jobs:
           check-latest: false
       - name: Build
         shell: bash
-        run: ./mvnw clean install -DskipTests
+        run: ./mvnw $MAVEN_ARGS clean install -DskipTests
   build-and-test:
     if: (!cancelled()) && contains(fromJSON(inputs.jobs), 'build-and-test')
     name: Test ${{ matrix.comment }} (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
@@ -309,10 +309,10 @@ jobs:
           check-latest: false
       - name: Build (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
         shell: bash
-        run: ./mvnw ${{ matrix.modules }} clean install -am -DskipTests
+        run: ./mvnw $MAVEN_ARGS ${{ matrix.modules }} clean install -am -DskipTests
       - name: Test (Java ${{ inputs.java }}) ${{ inputs.os }}-${{ inputs.branch }}
         shell: bash
-        run: ./mvnw ${{ matrix.modules }} test -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt
+        run: ./mvnw $MAVEN_ARGS ${{ matrix.modules }} test -Dsurefire.excludesFile=$PWD/.github/gha-tests/exclude-tests.txt
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7

--- a/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_stop_daemon.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_stop_daemon.bats
@@ -31,7 +31,9 @@ load hadoop-functions_test_helper
 }
 
 @test "hadoop_stop_daemon_force_kill" {
-  skip "Skip on GitHub Actions now"
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    skip "Skipped on GitHub Actions"
+  fi
 
   HADOOP_STOP_TIMEOUT=4
 

--- a/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_stop_daemon.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_stop_daemon.bats
@@ -31,6 +31,7 @@ load hadoop-functions_test_helper
 }
 
 @test "hadoop_stop_daemon_force_kill" {
+  skip "Skip on GitHub Actions now"
 
   HADOOP_STOP_TIMEOUT=4
 

--- a/hadoop-common-project/hadoop-common/src/test/scripts/start-build-env.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/start-build-env.bats
@@ -69,6 +69,7 @@ export -f stat
 # Verify that host directories get mounted without z option
 # and INFO messages get printed out
 @test "start-build-env.sh (Docker without z mount option)" {
+  skip "Skip on GitHub Actions now"
   if [ "$(uname -s)" != "Linux" ]; then
     skip "Not on Linux platform"
   fi
@@ -89,6 +90,7 @@ export -f stat
 
 # Verify that host directories get mounted with z option
 @test "start-build-env.sh (Docker with z mount option)" {
+  skip "Skip on GitHub Actions now"
   if [ "$(uname -s)" != "Linux" ]; then
     skip "Not on Linux platform"
   fi

--- a/hadoop-common-project/hadoop-common/src/test/scripts/start-build-env.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/start-build-env.bats
@@ -69,7 +69,9 @@ export -f stat
 # Verify that host directories get mounted without z option
 # and INFO messages get printed out
 @test "start-build-env.sh (Docker without z mount option)" {
-  skip "Skip on GitHub Actions now"
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    skip "Skipped on GitHub Actions"
+  fi
   if [ "$(uname -s)" != "Linux" ]; then
     skip "Not on Linux platform"
   fi
@@ -90,7 +92,9 @@ export -f stat
 
 # Verify that host directories get mounted with z option
 @test "start-build-env.sh (Docker with z mount option)" {
-  skip "Skip on GitHub Actions now"
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    skip "Skipped on GitHub Actions"
+  fi
   if [ "$(uname -s)" != "Linux" ]; then
     skip "Not on Linux platform"
   fi

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <hadoop.component>hdfs</hadoop.component>
+    <surefire.fork.timeout>3600</surefire.fork.timeout>
   </properties>
 
   <dependencies>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/cli/TestHDFSCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/cli/TestHDFSCLI.java
@@ -30,8 +30,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.security.authorize.PolicyProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("slow")
 public class TestHDFSCLI extends CLITestHelperDFS {
 
   protected MiniDFSCluster dfsCluster = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientProtocolForPipelineRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientProtocolForPipelineRecovery.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdfs.tools.DFSAdmin;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This tests pipeline recovery related client protocol works correct or not.
  */
+@Tag("slow")
 public class TestClientProtocolForPipelineRecovery {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestClientProtocolForPipelineRecovery.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStream.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.io.erasurecode.rawcoder.RawErasureDecoder;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -68,6 +69,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 @Timeout(300)
+@Tag("slow")
 public class TestDFSStripedInputStream {
 
   public static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStreamWithFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStreamWithFailure.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test striped file write operation with data node failures with fixed
  * parameter test cases.
  */
+@Tag("slow")
 public class TestDFSStripedOutputStreamWithFailure extends
     TestDFSStripedOutputStreamWithFailureBase{
   public static final Logger LOG = LoggerFactory.getLogger(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStreamWithFailureWithRandomECPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStreamWithFailureWithRandomECPolicy.java
@@ -20,11 +20,13 @@ package org.apache.hadoop.hdfs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.io.erasurecode.ECSchema;
+import org.junit.jupiter.api.Tag;
 
 /**
  * This tests write operation of DFS striped file with a random erasure code
  * policy except for the default policy under Datanode failure conditions.
  */
+@Tag("slow")
 public class TestDFSStripedOutputStreamWithFailureWithRandomECPolicy extends
     TestDFSStripedOutputStreamWithFailure {
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
@@ -89,6 +89,7 @@ import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.slf4j.Logger;
@@ -98,6 +99,7 @@ import org.slf4j.event.Level;
 /**
  * This class tests the decommissioning of nodes.
  */
+@Tag("slow")
 public class TestDecommission extends AdminStatesBaseTest {
   public static final Logger LOG = LoggerFactory.getLogger(TestDecommission
       .class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement
 import org.apache.hadoop.hdfs.server.blockmanagement
     .DatanodeAdminMonitorInterface;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * config to enable the alternative monitor version.
  */
 
+@Tag("slow")
 public class TestDecommissionWithBackoffMonitor extends TestDecommission {
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
@@ -80,6 +81,7 @@ import org.slf4j.LoggerFactory;
  * This class tests the decommissioning of datanode with striped blocks.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag("slow")
 public class TestDecommissionWithStriped {
   private static final Logger LOG = LoggerFactory
       .getLogger(TestDecommissionWithStriped.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStripedBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStripedBackoffMonitor.java
@@ -22,11 +22,13 @@ import org.apache.hadoop.hdfs.server.blockmanagement
     .DatanodeAdminBackoffMonitor;
 import org.apache.hadoop.hdfs.server.blockmanagement
     .DatanodeAdminMonitorInterface;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Class to run all the stripped decommission tests with the
  * DatanodeAdminBackoffMonitor.
  */
+@Tag("slow")
 public class TestDecommissionWithStripedBackoffMonitor
     extends TestDecommissionWithStriped{
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -132,6 +132,7 @@ import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.hadoop.util.functional.RemoteIterators;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.InOrder;
@@ -140,6 +141,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+@Tag("slow")
 public class TestDistributedFileSystem {
   private static final Random RAN = new Random();
   private static final Logger LOG = LoggerFactory.getLogger(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptedTransfer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptedTransfer.java
@@ -62,7 +62,9 @@ import org.apache.hadoop.hdfs.security.token.block.DataEncryptionKey;
 import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
+import org.junit.jupiter.api.Tag;
 
+@Tag("slow")
 public class TestEncryptedTransfer {
   {
     GenericTestUtils.setLogLevel(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptionZones.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptionZones.java
@@ -106,6 +106,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.util.XMLUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -158,6 +159,7 @@ import org.xml.sax.helpers.DefaultHandler;
 import javax.xml.parsers.SAXParser;
 
 @Timeout(120)
+@Tag("slow")
 public class TestEncryptionZones {
   static final Logger LOG = LoggerFactory.getLogger(TestEncryptionZones.class);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptionZonesWithKMS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestEncryptionZonesWithKMS.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -44,6 +45,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.UUID;
 
+@Tag("slow")
 public class TestEncryptionZonesWithKMS extends TestEncryptionZones {
 
   private MiniKMS miniKMS;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileChecksum.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileChecksum.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import org.junit.jupiter.api.Tag;
 
 /**
  * This test serves a prototype to demo the idea proposed so far. It creates two
@@ -57,6 +58,7 @@ import static org.mockito.Mockito.mock;
  * layout. For simple, it assumes 6 data blocks in both files and the block size
  * are the same.
  */
+@Tag("slow")
 public class TestFileChecksum {
   private static final Logger LOG = LoggerFactory
       .getLogger(TestFileChecksum.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestGetBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestGetBlocks.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocol;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.LambdaTestUtils;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class tests if getblocks request works correctly.
  */
+@Tag("slow")
 public class TestGetBlocks {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestBlockManager.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecovery2.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecovery2.java
@@ -55,11 +55,13 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 
+@Tag("slow")
 public class TestLeaseRecovery2 {
   
   public static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecoveryStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecoveryStriped.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 import org.slf4j.Logger;
@@ -61,6 +62,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Tag("slow")
 public class TestLeaseRecoveryStriped {
   public static final Logger LOG = LoggerFactory
       .getLogger(TestLeaseRecoveryStriped.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMaintenanceState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMaintenanceState.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.ToolRunner;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,7 @@ import java.util.function.Supplier;
 /**
  * This class tests node maintenance.
  */
+@Tag("slow")
 public class TestMaintenanceState extends AdminStatesBaseTest {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestMaintenanceState.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReadStripedFileWithDecodingCorruptData.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReadStripedFileWithDecodingCorruptData.java
@@ -30,11 +30,13 @@ import java.util.Collection;
 
 import static org.apache.hadoop.hdfs.ReadStripedFileWithDecodingHelper.initializeCluster;
 import static org.apache.hadoop.hdfs.ReadStripedFileWithDecodingHelper.tearDownCluster;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Test online recovery with corrupt files. This test is parameterized.
  */
 @Timeout(300)
+@Tag("slow")
 public class TestReadStripedFileWithDecodingCorruptData {
   static final Logger LOG =
       LoggerFactory.getLogger(TestReadStripedFileWithDecodingCorruptData.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReadStripedFileWithDecodingDeletedData.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReadStripedFileWithDecodingDeletedData.java
@@ -30,12 +30,14 @@ import java.util.Collection;
 
 import static org.apache.hadoop.hdfs.ReadStripedFileWithDecodingHelper.initializeCluster;
 import static org.apache.hadoop.hdfs.ReadStripedFileWithDecodingHelper.tearDownCluster;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Test online recovery with files with deleted blocks. This test is
  * parameterized.
  */
 @Timeout(300)
+@Tag("slow")
 public class TestReadStripedFileWithDecodingDeletedData {
   static final Logger LOG =
       LoggerFactory.getLogger(TestReadStripedFileWithDecodingDeletedData.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReconstructStripedFileWithRandomECPolicy.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs;
 
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
  * This test extends TestReconstructStripedFile to use a random
  * (non-default) EC policy.
  */
+@Tag("slow")
 public class TestReconstructStripedFileWithRandomECPolicy extends
     TestReconstructStripedFile {
   private static final Logger LOG = LoggerFactory.getLogger(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReplaceDatanodeFailureReplication.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReplaceDatanodeFailureReplication.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdfs.protocol.datatransfer.ReplaceDatanodeOnFailure.Pol
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test;
  * MIN_REPLICATION is set to 0 or less than zero, an exception will be thrown
  * if a replacement could not be found.
  */
+@Tag("slow")
 public class TestReplaceDatanodeFailureReplication {
   static final Logger LOG = LoggerFactory
       .getLogger(TestReplaceDatanodeFailureReplication.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.hdfs.tools.DFSAdmin;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -72,6 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * This class tests rolling upgrade.
  */
+@Tag("slow")
 public class TestRollingUpgrade {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestRollingUpgrade.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestStateAlignmentContextWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestStateAlignmentContextWithHA.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -58,6 +59,7 @@ import java.util.concurrent.TimeUnit;
  * These tests check that after a single RPC call a client will have caught up
  * to the most recent alignment state of the server.
  */
+@Tag("slow")
 public class TestStateAlignmentContextWithHA {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestStateAlignmentContextWithHA.class.getName());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestViewDistributedFileSystem.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.functional.ConsumerRaisingIOE;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("slow")
 public class TestViewDistributedFileSystem extends TestDistributedFileSystem{
   @Override
   HdfsConfiguration getTestConfiguration() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -44,6 +45,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 @Timeout(300)
+@Tag("slow")
 public class TestWriteReadStripedFile {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestWriteReadStripedFile.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -59,6 +60,7 @@ import java.util.Random;
 /**
  * Unit test for Journal Node formatting upon re-installation and syncing.
  */
+@Tag("slow")
 public class TestJournalNodeSync {
   private Configuration conf;
   private MiniQJMHACluster qjmhaCluster;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -84,6 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Some long running Balancer tasks.
  */
+@Tag("slow")
 public class TestBalancerLongRunningTasks {
 
   private static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -89,6 +89,7 @@ import org.apache.hadoop.util.GSet;
 import org.apache.hadoop.util.LightWeightGSet;
 import org.slf4j.event.Level;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -136,6 +137,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Tag("slow")
 public class TestBlockManager {
   private DatanodeStorageInfo[] storages;
   private List<DatanodeDescriptor> nodes;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlocksWithNotEnoughRacks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlocksWithNotEnoughRacks.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.util.HostsFileWriter;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
@@ -51,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Tag("slow")
 public class TestBlocksWithNotEnoughRacks {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestBlocksWithNotEnoughRacks.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery2.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery2.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -90,6 +91,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test part 2 for sync all replicas in block recovery.
  */
+@Tag("slow")
 public class TestBlockRecovery2 {
 
   private static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
@@ -65,12 +65,14 @@ import org.apache.hadoop.hdfs.server.datanode.VolumeScanner.Statistics;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+@Tag("slow")
 public class TestBlockScanner {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestBlockScanner.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeRollingUpgrade.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.tools.DFSAdmin;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -58,6 +59,7 @@ import org.mockito.Mockito;
  * Ensure that the DataNode correctly handles rolling upgrade
  * finalize and rollback.
  */
+@Tag("slow")
 public class TestDataNodeRollingUpgrade {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDataNodeRollingUpgrade.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
@@ -59,12 +59,14 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test reporting of DN volume failure counts and metrics.
  */
 @Timeout(120)
+@Tag("slow")
 public class TestDataNodeVolumeFailureReporting {
 
   private static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetCache.java
@@ -88,6 +88,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
@@ -98,6 +99,7 @@ import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_FSDATASETCACHE_MAX_THREADS_PER_VOLUME_KEY;
 
 @NotThreadSafe
+@Tag("slow")
 public class TestFsDatasetCache {
   private static final org.slf4j.Logger LOG =
       LoggerFactory.getLogger(TestFsDatasetCache.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -87,6 +87,7 @@ import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -140,6 +141,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 
+@Tag("slow")
 public class TestFsDatasetImpl {
 
   private static final Logger LOG = LoggerFactory.getLogger(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestSpaceReservation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestSpaceReservation.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Daemon;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -74,6 +75,7 @@ import javax.management.ObjectName;
  * Ensure that the DN reserves disk space equivalent to a full block for
  * replica being written (RBW) & Replica being copied from another DN.
  */
+@Tag("slow")
 public class TestSpaceReservation {
   static final Logger LOG = LoggerFactory.getLogger(TestSpaceReservation.class);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
@@ -109,6 +109,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.ToolRunner;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -117,6 +118,7 @@ import org.slf4j.LoggerFactory;
 import java.util.function.Supplier;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 
+@Tag("slow")
 public class TestMover {
   private static final Logger LOG = LoggerFactory.getLogger(TestMover.class);
   private static final int DEFAULT_BLOCK_SIZE = 100;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestStorageMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestStorageMover.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotTestHelper;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.util.Preconditions;
@@ -74,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test the data migration tool (for Archival Storage)
  */
+@Tag("slow")
 public class TestStorageMover {
   static final Logger LOG = LoggerFactory.getLogger(TestStorageMover.class);
   static {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeleteRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeleteRace.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -77,6 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * whole duration.
  */
 @Timeout(60 * 3)
+@Tag("slow")
 public class TestDeleteRace {
   private static final int BLOCK_SIZE = 4096;
   private static final Logger LOG = LoggerFactory.getLogger(TestDeleteRace.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDiskspaceQuotaUpdate.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDiskspaceQuotaUpdate.java
@@ -57,12 +57,14 @@ import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+@Tag("slow")
 public class TestDiskspaceQuotaUpdate {
   private static final int BLOCKSIZE = 1024;
   private static final short REPLICATION = 4;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLog.java
@@ -94,6 +94,7 @@ import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.spi.LoggingEvent;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -112,6 +113,7 @@ import org.slf4j.LoggerFactory;
  */
 @MethodSource("data")
 @ParameterizedClass
+@Tag("slow")
 public class TestEditLog {
 
   static {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.util.FakeTimer;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
@@ -77,6 +78,7 @@ import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
 @MethodSource("data")
 @ParameterizedClass
+@Tag("slow")
 public class TestFSEditLogLoader {
 
   public static Collection<Object[]> data() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImage.java
@@ -81,12 +81,14 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Tag("slow")
 public class TestFSImage {
 
   private static final String HADOOP_2_7_ZER0_BLOCK_SIZE_TGZ =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImageWithAcl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImageWithAcl.java
@@ -37,8 +37,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("slow")
 public class TestFSImageWithAcl {
   private static Configuration conf;
   private static MiniDFSCluster cluster;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
@@ -122,6 +122,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -130,6 +131,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A JUnit test for doing fsck.
  */
+@Tag("slow")
 public class TestFsck {
   private static final org.slf4j.Logger LOG =
       LoggerFactory.getLogger(TestFsck.class.getName());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeFile.java
@@ -74,12 +74,14 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
+@Tag("slow")
 public class TestINodeFile {
   // Re-enable symlinks for tests, see HADOOP-10020 and HADOOP-10052
   static {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestListCorruptFileBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestListCorruptFileBlocks.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.util.StringUtils;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -58,6 +59,7 @@ import org.slf4j.Logger;
  * with a block # from a previous call and validate that the subsequent
  * blocks/files are also returned.
  */
+@Tag("slow")
 public class TestListCorruptFileBlocks {
   static final Logger LOG = NameNode.stateChangeLog;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestPersistentStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestPersistentStoragePolicySatisfier.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
 import org.apache.hadoop.hdfs.server.namenode.sps.StoragePolicySatisfier;
 import org.apache.hadoop.hdfs.server.sps.ExternalSPSContext;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test persistence of satisfying files/directories.
  */
+@Tag("slow")
 public class TestPersistentStoragePolicySatisfier {
   private static Configuration conf;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestReencryption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestReencryption.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
@@ -79,6 +80,7 @@ import org.slf4j.event.Level;
  * Test class for re-encryption.
  */
 @Timeout(180)
+@Tag("slow")
 public class TestReencryption {
 
   protected static final org.slf4j.Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestReencryptionWithKMS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestReencryptionWithKMS.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.crypto.key.kms.server.MiniKMS;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test class for re-encryption with minikms.
  */
+@Tag("slow")
 public class TestReencryptionWithKMS extends TestReencryption{
 
   private MiniKMS miniKMS;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFSNLockBenchmarkThroughput.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFSNLockBenchmarkThroughput.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
 import org.apache.hadoop.util.ToolRunner;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * To test {@link FSNLockBenchmarkThroughput}.
  */
+@Tag("slow")
 public class TestFSNLockBenchmarkThroughput {
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
@@ -59,12 +59,14 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 
+@Tag("slow")
 public class TestBootstrapStandby {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestBootstrapStandby.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencingWithReplication.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencingWithReplication.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Stress-test for potential bugs when replication is changing
  * on blocks during a failover.
  */
+@Tag("slow")
 public class TestDNFencingWithReplication {
   static {
     GenericTestUtils.setLogLevel(FSNamesystem.AUDIT_LOG, Level.WARN);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestEditLogTailer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestEditLogTailer.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.FakeTimer;
 import org.slf4j.event.Level;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -69,6 +70,7 @@ import org.mockito.Mockito;
 
 @MethodSource("data")
 @ParameterizedClass
+@Tag("slow")
 public class TestEditLogTailer {
   static {
     GenericTestUtils.setLogLevel(FSEditLog.LOG, Level.DEBUG);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureToReadEdits.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureToReadEdits.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil.ExitException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -65,6 +66,7 @@ import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
 @MethodSource("data")
 @ParameterizedClass
+@Tag("slow")
 public class TestFailureToReadEdits {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestFailureToReadEdits.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
@@ -81,6 +82,7 @@ import java.util.function.Supplier;
 /**
  * Tests that exercise safemode in an HA cluster.
  */
+@Tag("slow")
 public class TestHASafeMode {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestHASafeMode.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -79,6 +79,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -87,6 +88,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Test main functionality of ObserverNode.
  */
+@Tag("slow")
 public class TestObserverNode {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestObserverNode.class.getName());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestPipelinesFailover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestPipelinesFailover.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -68,6 +69,7 @@ import java.util.function.Supplier;
 /**
  * Test cases regarding pipeline recovery during NN failover.
  */
+@Tag("slow")
 public class TestPipelinesFailover {
   static {
     GenericTestUtils.setLogLevel(LoggerFactory.getLogger(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRetryCacheWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRetryCacheWithHA.java
@@ -93,9 +93,11 @@ import org.apache.hadoop.util.LightWeightCache;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+@Tag("slow")
 public class TestRetryCacheWithHA {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestRetryCacheWithHA.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -73,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
+@Tag("slow")
 public class TestStandbyCheckpoints {
   private static final int NUM_DIRS_IN_LOG = 200000;
   protected static int NUM_NNS = 3;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOpenFilesWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOpenFilesWithSnapshot.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -55,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("slow")
 public class TestOpenFilesWithSnapshot {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOpenFilesWithSnapshot.class.getName());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRandomOpsWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRandomOpsWithSnapshots.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -56,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Testing random FileSystem operations with random Snapshot operations.
  */
+@Tag("slow")
 public class TestRandomOpsWithSnapshots {
 
   private static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -67,6 +68,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 /** Testing rename with snapshots. */
+@Tag("slow")
 public class TestRenameWithSnapshots {
   static {
     SnapshotTestHelper.disableLogs();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -71,6 +72,7 @@ import org.junit.jupiter.api.Timeout;
  * created. The snapshotted directory is changed and verification is done to
  * ensure snapshots remain unchanges.
  */
+@Tag("slow")
 public class TestSnapshot {
   {
     GenericTestUtils.setLogLevel(INode.LOG, Level.TRACE);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -76,6 +77,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Tests snapshot deletion.
  */
+@Tag("slow")
 public class TestSnapshotDeletion {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestSnapshotDeletion.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestStoragePolicySatisfierWithStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestStoragePolicySatisfierWithStripedFile.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.sps.ExternalSPSContext;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -61,6 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * to be moved and finding its expected target locations in order to satisfy the
  * storage policy.
  */
+@Tag("slow")
 public class TestStoragePolicySatisfierWithStripedFile {
 
   private static final Logger LOG = LoggerFactory

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
@@ -100,6 +100,7 @@ import org.apache.hadoop.util.ExitUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -112,6 +113,7 @@ import java.util.function.Supplier;
 /**
  * Tests the external sps service plugins.
  */
+@Tag("slow")
 public class TestExternalStoragePolicySatisfier {
   private static final String ONE_SSD = "ONE_SSD";
   private static final String COLD = "COLD";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.namenode.ha.BootstrapStandby;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Tag("slow")
 public class TestDFSAdminWithHA {
 
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFS.java
@@ -144,6 +144,7 @@ import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -161,6 +162,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Test WebHDFS */
+@Tag("slow")
 public class TestWebHDFS {
   static final Logger LOG = LoggerFactory.getLogger(TestWebHDFS.class);
   

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -540,16 +540,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- The fork value is deliberately set to 0 to avoid VM crash while running tests
-       on Jenkins, removing this leads to tests crashing silently due to VM crash -->
-      <!-- TODO: we should investigate and address the crash issue and re-enable fork,
-                 otherwise, JPMS args does not take effect -->
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>0</forkCount>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -540,6 +540,16 @@
           </execution>
         </executions>
       </plugin>
+      <!-- The fork value is deliberately set to 0 to avoid VM crash while running tests
+       on Jenkins, removing this leads to tests crashing silently due to VM crash -->
+      <!-- TODO: we should investigate and address the crash issue and re-enable fork,
+                 otherwise, JPMS args does not take effect -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>0</forkCount>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR enables running unit tests in parallel on GitHub Actions, with ~150 test suites(classes) excluded due to flaky or consistently failing on GHA that need to be fixed later, all of the remaining test suites take ~2.5 hours to complete. As a comparison, Jenkins takes ~30 hours.

### How was this patch tested?

GHA report.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19857)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.