### PR TITLE
HADOOP-19869 Modernize secret manager default algorithm and key length

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -1014,11 +1014,11 @@ public class CommonConfigurationKeysPublic {
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_KEY =
     "hadoop.security.secret-manager.key-generator.algorithm";
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT =
-    "HmacSHA1";
+    "HmacSHA256";
 
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_KEY =
     "hadoop.security.secret-manager.key-length";
-  public static final int HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_DEFAULT = 64;
+  public static final int HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_DEFAULT = 256;
 
   /**
    * @see

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1058,23 +1058,26 @@
 
 <property>
   <name>hadoop.security.secret-manager.key-generator.algorithm</name>
-  <value>HmacSHA1</value>
+  <value>HmacSHA256</value>
   <description>
     The configuration key specifying the KeyGenerator algorithm used in SecretManager
     for generating secret keys. The algorithm must be a KeyGenerator algorithm supported by
-    the Java Cryptography Architecture (JCA). Common examples include "HmacSHA1",
-    "HmacSHA256", and "HmacSHA512".
+    the Java Cryptography Architecture (JCA). Common examples include "HmacSHA256" and
+    "HmacSHA512". The default was changed from "HmacSHA1" to "HmacSHA256" to provide
+    stronger security. On upgrade, in-flight short-lived tokens (job tokens, block tokens)
+    will be transparently re-issued with the new algorithm; long-lived delegation tokens
+    should be renewed or re-issued after the cluster upgrade completes.
   </description>
 </property>
 
 <property>
   <name>hadoop.security.secret-manager.key-length</name>
-  <value>64</value>
+  <value>256</value>
   <description>
-    The configuration key specifying the key length of the generated secret keys
-    in SecretManager. The key length must be appropriate for the algorithm.
-    For example, longer keys are generally more secure but may not be supported
-    by all algorithms.
+    The configuration key specifying the key length (in bits) of the generated secret keys
+    in SecretManager. The key length must be appropriate for the selected algorithm.
+    The default was changed from 64 to 256 bits to match the recommended key size for
+    HmacSHA256 and to provide adequate security margin.
   </description>
 </property>
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestCredentials.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestCredentials.java
@@ -45,13 +45,16 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCredentials {
-  private static final String DEFAULT_HMAC_ALGORITHM = "HmacSHA1";
+  private static final String DEFAULT_HMAC_ALGORITHM =
+      HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT;
   private static final File tmpDir = GenericTestUtils.getTestDir("mapred");
 
   @BeforeEach

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -186,7 +186,7 @@ public class MRAppMaster extends CompositeService {
    * Priority of the MRAppMaster shutdown hook.
    */
   public static final int SHUTDOWN_HOOK_PRIORITY = 30;
-  public static final String INTERMEDIATE_DATA_ENCRYPTION_ALGO = "HmacSHA1";
+  public static final String INTERMEDIATE_DATA_ENCRYPTION_ALGO = "HmacSHA256";
 
   private Clock clock;
   private final long startTime;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
@@ -76,6 +76,8 @@ import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT;
+
 /** Implements MapReduce locally, in-process, for debugging. */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
@@ -91,7 +93,7 @@ public class LocalJobRunner implements ClientProtocol {
   public static final String LOCAL_MAX_REDUCES =
     "mapreduce.local.reduce.tasks.maximum";
 
-  public static final String INTERMEDIATE_DATA_ENCRYPTION_ALGO = "HmacSHA1";
+  public static final String INTERMEDIATE_DATA_ENCRYPTION_ALGO = HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT;
 
   private FileSystem fs;
   private HashMap<JobID, Job> jobs = new HashMap<JobID, Job>();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.mapred.QueueACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT;
 import static org.apache.hadoop.mapred.QueueManager.toFullPropertyName;
 
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
@@ -70,7 +71,8 @@ import org.apache.hadoop.yarn.api.records.ReservationId;
 class JobSubmitter {
   protected static final Logger LOG =
       LoggerFactory.getLogger(JobSubmitter.class);
-  private static final String SHUFFLE_KEYGEN_ALGORITHM = "HmacSHA1";
+  private static final String SHUFFLE_KEYGEN_ALGORITHM =
+      HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT;
   private FileSystem jtFs;
   private ClientProtocol submitClient;
   private String submitHostName;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
@@ -1315,5 +1315,5 @@ public interface MRJobConfig {
   @Unstable
   String INPUT_FILE_MANDATORY_PREFIX = "mapreduce.job.input.file.must.";
   String SHUFFLE_KEY_LENGTH = "mapreduce.shuffle-key-length";
-  int DEFAULT_SHUFFLE_KEY_LENGTH = 64;
+  int DEFAULT_SHUFFLE_KEY_LENGTH = 256;
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -594,6 +594,16 @@
 </property>
 
 <property>
+  <name>mapreduce.shuffle-key-length</name>
+  <value>256</value>
+  <description>
+    The length in bits of the HMAC key used to authenticate shuffle transfers.
+    The default was changed from 64 to 256 bits to match the recommended key
+    size for HmacSHA256. This key is generated fresh for each job submission.
+  </description>
+</property>
+
+<property>
   <name>mapreduce.reduce.markreset.buffer.percent</name>
   <value>0.0</value>
   <description>The percentage of memory -relative to the maximum heap size- to


### PR DESCRIPTION

### Description of PR


HADOOP-19869 Modernize secret manager default algorithm and key length
   
HmacSHA256 and 256 bits.

Also import directly the algorithm in different modules, so it is consistent.

Contains content generated by Coplot + Claude Sonnet 4.6

### How was this patch tested?

updated test

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [X] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html