### PR TITLE
HDFS-17912. HttpFS: honor HTTPFS_CONFIG when sourcing httpfs-env.sh

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/libexec/shellprofile.d/hadoop-httpfs.sh
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/libexec/shellprofile.d/hadoop-httpfs.sh
@@ -25,9 +25,9 @@ fi
 ## @replaceable  no
 function hdfs_subcommand_httpfs
 {
-  if [[ -f "${HADOOP_CONF_DIR}/httpfs-env.sh" ]]; then
+  if [[ -f "${HTTPFS_CONFIG:-${HADOOP_CONF_DIR}}/httpfs-env.sh" ]]; then
     # shellcheck disable=SC1090
-    . "${HADOOP_CONF_DIR}/httpfs-env.sh"
+    . "${HTTPFS_CONFIG:-${HADOOP_CONF_DIR}}/httpfs-env.sh"
   fi
 
   # shellcheck disable=SC2034


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

hadoop-httpfs.sh sourced httpfs-env.sh from HADOOP_CONF_DIR only, even though HTTPFS_CONFIG is already honored for -Dhttpfs.config.dir in the same script. Use ${HTTPFS_CONFIG:-${HADOOP_CONF_DIR}} so both paths agree. Backward compatible.

See description on https://issues.apache.org/jira/browse/HDFS-17912, please.

### How was this patch tested?

Manually test on private cluster

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
