### PR TITLE
HDFS-17796. WebHDFS: map storage-capacity exceptions to HTTP 507

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/ExceptionHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/ExceptionHandler.java
@@ -23,11 +23,13 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
+import org.apache.hadoop.fs.ClusterStorageCapacityExceededException;
 import org.apache.hadoop.hdfs.web.JsonUtil;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.token.SecretManager;
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -37,6 +39,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.INSUFFICIENT_STORAGE;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -72,6 +75,9 @@ class ExceptionHandler {
       s = FORBIDDEN;
     } else if (e instanceof FileNotFoundException) {
       s = NOT_FOUND;
+    } else if (e instanceof ClusterStorageCapacityExceededException
+        || e instanceof DiskOutOfSpaceException) {
+      s = INSUFFICIENT_STORAGE;
     } else if (e instanceof IOException) {
       s = FORBIDDEN;
     } else if (e instanceof UnsupportedOperationException) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/resources/ExceptionHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/resources/ExceptionHandler.java
@@ -29,11 +29,13 @@ import javax.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hadoop.fs.ClusterStorageCapacityExceededException;
 import org.apache.hadoop.hdfs.web.JsonUtil;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.glassfish.jersey.server.ContainerException;
@@ -45,6 +47,28 @@ import org.glassfish.hk2.api.MultiException;
 public class ExceptionHandler implements ExceptionMapper<Exception> {
   public static final Logger LOG =
       LoggerFactory.getLogger(ExceptionHandler.class);
+
+  /**
+   * HTTP 507 Insufficient Storage (RFC 4918). Not present in JAX-RS 2.1's
+   * {@link Response.Status} enum, so we define it here.
+   */
+  static final Response.StatusType INSUFFICIENT_STORAGE =
+      new Response.StatusType() {
+        @Override
+        public int getStatusCode() {
+          return 507;
+        }
+
+        @Override
+        public Response.Status.Family getFamily() {
+          return Response.Status.Family.SERVER_ERROR;
+        }
+
+        @Override
+        public String getReasonPhrase() {
+          return "Insufficient Storage";
+        }
+      };
 
   private static Exception toCause(Exception e) {
     final Throwable t = e.getCause();    
@@ -101,13 +125,16 @@ public class ExceptionHandler implements ExceptionMapper<Exception> {
     }
     
     //Map response status
-    final Response.Status s;
+    final Response.StatusType s;
     if (e instanceof SecurityException) {
       s = Response.Status.FORBIDDEN;
     } else if (e instanceof AuthorizationException) {
       s = Response.Status.FORBIDDEN;
     } else if (e instanceof FileNotFoundException) {
       s = Response.Status.NOT_FOUND;
+    } else if (e instanceof ClusterStorageCapacityExceededException
+        || e instanceof DiskOutOfSpaceException) {
+      s = INSUFFICIENT_STORAGE;
     } else if (e instanceof IOException) {
       s = Response.Status.FORBIDDEN;
     } else if (e instanceof UnsupportedOperationException) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/TestExceptionHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/TestExceptionHandler.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode.web.webhdfs;
+
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import org.apache.hadoop.hdfs.protocol.DSQuotaExceededException;
+import org.apache.hadoop.hdfs.protocol.NSQuotaExceededException;
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link ExceptionHandler}, with focus on HDFS-17796: writes that
+ * fail because of insufficient storage should return HTTP 507 instead of the
+ * generic 403 / 500 the handler used to produce.
+ */
+public class TestExceptionHandler {
+
+  @Test
+  public void testDSQuotaExceededMapsTo507() {
+    DefaultFullHttpResponse resp = ExceptionHandler.exceptionCaught(
+        new DSQuotaExceededException("disk quota exceeded"));
+    assertEquals(507, resp.status().code());
+  }
+
+  @Test
+  public void testNSQuotaExceededMapsTo507() {
+    // NSQuotaExceededException also extends ClusterStorageCapacityExceededException
+    // via QuotaExceededException, so it gets the new mapping for free.
+    DefaultFullHttpResponse resp = ExceptionHandler.exceptionCaught(
+        new NSQuotaExceededException("namespace quota exceeded"));
+    assertEquals(507, resp.status().code());
+  }
+
+  @Test
+  public void testDiskOutOfSpaceMapsTo507() {
+    DefaultFullHttpResponse resp = ExceptionHandler.exceptionCaught(
+        new DiskOutOfSpaceException("no space left on device"));
+    assertEquals(507, resp.status().code());
+  }
+
+  @Test
+  public void testGenericIOExceptionStillMapsTo403() {
+    DefaultFullHttpResponse resp = ExceptionHandler.exceptionCaught(
+        new IOException("some unrelated IO failure"));
+    assertEquals(403, resp.status().code());
+  }
+
+  @Test
+  public void testFileNotFoundStillMapsTo404() {
+    DefaultFullHttpResponse resp = ExceptionHandler.exceptionCaught(
+        new FileNotFoundException("missing"));
+    assertEquals(404, resp.status().code());
+  }
+
+  @Test
+  public void testIllegalArgumentStillMapsTo400() {
+    DefaultFullHttpResponse resp = ExceptionHandler.exceptionCaught(
+        new IllegalArgumentException("bad param"));
+    assertEquals(400, resp.status().code());
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/resources/TestExceptionHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/resources/TestExceptionHandler.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.web.resources;
+
+import org.apache.hadoop.hdfs.protocol.DSQuotaExceededException;
+import org.apache.hadoop.hdfs.protocol.NSQuotaExceededException;
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link ExceptionHandler}, with focus on HDFS-17796: the NameNode
+ * WebHDFS handler should map storage-capacity exceptions to HTTP 507 instead
+ * of the generic 403 / 500 it returned before.
+ */
+public class TestExceptionHandler {
+
+  private ExceptionHandler newHandler() {
+    ExceptionHandler eh = new ExceptionHandler();
+    eh.initResponse(mock(HttpServletResponse.class));
+    return eh;
+  }
+
+  @Test
+  public void testDSQuotaExceededMapsTo507() {
+    Response resp = newHandler().toResponse(
+        new DSQuotaExceededException("disk quota exceeded"));
+    assertEquals(507, resp.getStatus());
+  }
+
+  @Test
+  public void testNSQuotaExceededMapsTo507() {
+    // NSQuotaExceededException also extends ClusterStorageCapacityExceededException
+    // via QuotaExceededException, so it shares the new mapping.
+    Response resp = newHandler().toResponse(
+        new NSQuotaExceededException("namespace quota exceeded"));
+    assertEquals(507, resp.getStatus());
+  }
+
+  @Test
+  public void testDiskOutOfSpaceMapsTo507() {
+    Response resp = newHandler().toResponse(
+        new DiskOutOfSpaceException("no space left on device"));
+    assertEquals(507, resp.getStatus());
+  }
+
+  @Test
+  public void testGenericIOExceptionStillMapsTo403() {
+    Response resp = newHandler().toResponse(
+        new IOException("some unrelated IO failure"));
+    assertEquals(403, resp.getStatus());
+  }
+
+  @Test
+  public void testFileNotFoundStillMapsTo404() {
+    Response resp = newHandler().toResponse(new FileNotFoundException("missing"));
+    assertEquals(404, resp.getStatus());
+  }
+
+  @Test
+  public void testIllegalArgumentStillMapsTo400() {
+    Response resp = newHandler().toResponse(new IllegalArgumentException("bad"));
+    assertEquals(400, resp.getStatus());
+  }
+}


### PR DESCRIPTION
### Description of PR

JIRA: [HDFS-17796](https://issues.apache.org/jira/browse/HDFS-17796)

WebHDFS write failures caused by storage-capacity limits today surface as a generic HTTP 403 (or, when the channel times out before the handler runs, 500). Clients have no way to distinguish "out of space" from permission denial or transient server failure.

Both ExceptionHandlers, NameNode-side (`o.a.h.hdfs.web.resources.ExceptionHandler`) and DataNode-side (`o.a.h.hdfs.server.datanode.web.webhdfs.ExceptionHandler`), currently fall through to the generic `IOException -> FORBIDDEN (403)` mapping for the storage-capacity exception family.

### Fix

Add a typed mapping ahead of the generic `IOException` branch:

- `ClusterStorageCapacityExceededException` (and subclasses, including `DSQuotaExceededException` / `NSQuotaExceededException`)
- `DiskChecker.DiskOutOfSpaceException`

both map to **HTTP 507 Insufficient Storage** (RFC 4918).

JAX-RS 2.1's `Response.Status` enum does not include 507, so the NN-side handler defines a small `Response.StatusType` constant. The DN-side handler uses Netty's built-in `HttpResponseStatus.INSUFFICIENT_STORAGE`.

### How was this patch tested?

Two new unit tests, one per handler package:

- `org.apache.hadoop.hdfs.web.resources.TestExceptionHandler`
- `org.apache.hadoop.hdfs.server.datanode.web.webhdfs.TestExceptionHandler`

```
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```

Each suite covers `DSQuotaExceededException`, `NSQuotaExceededException`, `DiskOutOfSpaceException`, plus regression checks for the existing mappings (`IOException -> 403`, `FileNotFound -> 404`, `IllegalArgument -> 400`).

### Out of scope

HDFS-17796 also asks for cleanup of incomplete files left behind by failed writes. That part is intentionally not included here. It requires plumbing the file path through `HdfsWriter` so the handler can attempt a best-effort delete on failure, and is best handled in a follow-up PR so the status-code fix can land independently.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? (no new dependencies)
