### PR TITLE
HDFS-17914. Prevent DFSInputStream from issuing 0-byte reads

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1230,7 +1230,9 @@ public class DFSInputStream extends FSInputStream
         long beginReadMS = Time.monotonicNow();
         int nread = 0;
         int ret;
-        while (true) {
+        // Stop once the slice is filled; an extra read with remaining()==0
+        // can trigger wasted slow-lane I/O in SCR.
+        while (tmp.hasRemaining()) {
           ret = reader.read(tmp);
           if (ret <= 0) {
             break;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
@@ -23,11 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -362,6 +367,45 @@ public class TestDFSInputStream {
     } finally {
       DFSClientFaultInjector.set(oldFaultInjector);
       IOUtils.closeStream(out);
+    }
+  }
+
+  @Test
+  @Timeout(value = 60)
+  public void testAvoidsEmptyBufferRead() throws IOException {
+    Configuration conf = new Configuration();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {
+      DistributedFileSystem fs = cluster.getFileSystem();
+      DFSClient client = fs.getClient();
+      Path file = new Path("/preadFile");
+      int fileLength = 8192;
+      DFSTestUtil.createFile(fs, file, fileLength, (short) 1, 0L);
+
+      AtomicInteger emptyBufferReads = new AtomicInteger(0);
+      try (DFSInputStream in = new DFSInputStream(client, file.toString(),
+          true, null) {
+        @Override
+        protected BlockReader getBlockReader(LocatedBlock targetBlock,
+            long offsetInBlock, long length, InetSocketAddress targetAddr,
+            StorageType storageType, DatanodeInfo datanode)
+            throws IOException {
+          BlockReader real = super.getBlockReader(targetBlock, offsetInBlock,
+              length, targetAddr, storageType, datanode);
+          BlockReader wrapped = mock(BlockReader.class, delegatesTo(real));
+          doAnswer(inv -> {
+            if (!((ByteBuffer) inv.getArgument(0)).hasRemaining()) {
+              emptyBufferReads.incrementAndGet();
+            }
+            return real.read(inv.getArgument(0));
+          }).when(wrapped).read(any(ByteBuffer.class));
+          return wrapped;
+        }
+      }) {
+        byte[] dest = new byte[fileLength];
+        assertEquals(fileLength, in.read(0L, dest, 0, dest.length));
+        assertEquals(0, emptyBufferReads.get(),
+            "DFSInputStream should not call BlockReader.read with an empty buffer");
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Avoid empty buffer read in DFSInputStream#actualGetFromOneDataNode by terminating the loop once the buffer is filled.

### How was this patch tested?
Added new test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html