### PR TITLE
HADOOP-19876. SSL protocol config is not applied to Jetty when set to default value

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -706,34 +706,32 @@ public final class HttpServer2 implements FilterContainer {
     private void setEnabledProtocols(SslContextFactory sslContextFactory) {
       String enabledProtocols = conf.get(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY,
           SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
-      if (!enabledProtocols.equals(SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT)) {
-        // Jetty 9.2.4.v20141103 and above excludes certain protocols by
-        // default. Remove the user enabled protocols from the exclude list,
-        // and add them into the include list.
-        String[] jettyExcludedProtocols =
-            sslContextFactory.getExcludeProtocols();
-        String[] enabledProtocolsArray =
-            StringUtils.getTrimmedStrings(enabledProtocols);
-        List<String> enabledProtocolsList =
-            Arrays.asList(enabledProtocolsArray);
+      // Jetty 9.2.4.v20141103 and above excludes certain protocols by
+      // default. Remove the user enabled protocols from the exclude list,
+      // and add them into the include list.
+      String[] jettyExcludedProtocols =
+          sslContextFactory.getExcludeProtocols();
+      String[] enabledProtocolsArray =
+          StringUtils.getTrimmedStrings(enabledProtocols);
+      List<String> enabledProtocolsList =
+          Arrays.asList(enabledProtocolsArray);
 
-        List<String> resetExcludedProtocols = new ArrayList<>();
-        for (String jettyExcludedProtocol: jettyExcludedProtocols) {
-          if (!enabledProtocolsList.contains(jettyExcludedProtocol)) {
-            resetExcludedProtocols.add(jettyExcludedProtocol);
-          } else {
-            LOG.debug("Removed {} from exclude protocol list",
-                jettyExcludedProtocol);
-          }
+      List<String> resetExcludedProtocols = new ArrayList<>();
+      for (String jettyExcludedProtocol: jettyExcludedProtocols) {
+        if (!enabledProtocolsList.contains(jettyExcludedProtocol)) {
+          resetExcludedProtocols.add(jettyExcludedProtocol);
+        } else {
+          LOG.debug("Removed {} from exclude protocol list",
+              jettyExcludedProtocol);
         }
-
-        sslContextFactory.setExcludeProtocols(
-            resetExcludedProtocols.toArray(new String[0]));
-        LOG.info("Reset exclude protocol list: {}", resetExcludedProtocols);
-
-        sslContextFactory.setIncludeProtocols(enabledProtocolsArray);
-        LOG.info("Enabled protocols: {}", enabledProtocols);
       }
+
+      sslContextFactory.setExcludeProtocols(
+          resetExcludedProtocols.toArray(new String[0]));
+      LOG.info("Reset exclude protocol list: {}", resetExcludedProtocols);
+
+      sslContextFactory.setIncludeProtocols(enabledProtocolsArray);
+      LOG.info("Enabled protocols: {}", enabledProtocols);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
@@ -136,8 +136,10 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
 
   private static void setupServer(Configuration conf, Configuration sslConf)
       throws IOException, URISyntaxException {
-    conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, INCLUDED_PROTOCOLS);
-    sslConf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, INCLUDED_PROTOCOLS);
+    String protocols = Shell.isJavaVersionAtLeast(11)
+        ? INCLUDED_PROTOCOLS_JDK11 : INCLUDED_PROTOCOLS;
+    conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, protocols);
+    sslConf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, protocols);
     server = new HttpServer2.Builder().setName("test")
         .addEndpoint(new URI("https://localhost")).setConf(conf)
         .keyPassword(

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServerConfigs.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServerConfigs.java
@@ -22,11 +22,15 @@ import java.util.function.Supplier;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +43,9 @@ import static org.apache.hadoop.http.TestSSLHttpServer.SSL_SERVER_TRUSTSTORE_PRO
 import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.CLIENT_KEY_STORE_PASSWORD_DEFAULT;
 import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.SERVER_KEY_STORE_PASSWORD_DEFAULT;
 import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.TRUST_STORE_PASSWORD_DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -115,6 +122,28 @@ public class TestSSLHttpServerConfigs {
         .build();
 
     return server;
+  }
+
+  private void assertServerAppliesEnabledProtocol(String protocol)
+      throws Exception {
+    HttpServer2 server = setupServer(SERVER_PWD, SERVER_PWD, TRUST_STORE_PWD);
+    try {
+      ServerConnector listener = server.getListeners().get(0);
+      SslConnectionFactory connectionFactory =
+          listener.getConnectionFactory(SslConnectionFactory.class);
+      assertNotNull(connectionFactory,
+          "Expected HTTPS listener with an SSL connection factory");
+      SslContextFactory sslContextFactory =
+          connectionFactory.getSslContextFactory();
+      assertArrayEquals(new String[] {protocol},
+          sslContextFactory.getIncludeProtocols());
+      assertFalse(Arrays.asList(sslContextFactory.getExcludeProtocols())
+              .contains(protocol),
+          "Configured enabled protocol should be removed from excluded "
+              + "protocols");
+    } finally {
+      server.stop();
+    }
   }
 
   /**
@@ -274,5 +303,32 @@ public class TestSSLHttpServerConfigs {
       GenericTestUtils.assertExceptionContains("Password must not be null",
           e.getCause());
     }
+  }
+
+  @Test
+  @Timeout(value = 120)
+  public void testDefaultEnabledProtocolIsAppliedWhenConfigUnset()
+      throws Exception {
+    setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
+    conf.unset(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY);
+    assertServerAppliesEnabledProtocol(SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+  }
+
+  @Test
+  @Timeout(value = 120)
+  public void testDefaultEnabledProtocolIsAppliedWhenConfigExplicitlySet()
+      throws Exception {
+    setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
+    conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY,
+        SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+    assertServerAppliesEnabledProtocol(SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+  }
+
+  @Test
+  @Timeout(value = 120)
+  public void testNonDefaultEnabledProtocolIsApplied() throws Exception {
+    setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
+    conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, "TLSv1.3");
+    assertServerAppliesEnabledProtocol("TLSv1.3");
   }
 }


### PR DESCRIPTION
### Description of PR

In `HttpServer2.setEnabledProtocols()`, the logic that applies SSL protocol restrictions to the Jetty SslContextFactory is gated behind a check that compares the resolved configuration value against `SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT` ("TLSv1.2"). This means that Jetty is not respecting the configuration, the condition check should be removed.

### How was this patch tested?

Tested the changes manually with `openssl s_client -connect` commands.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI tool was used.

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html