### PR TITLE
HADOOP-19881. Fix "port in use" detection in TestFrameDecoder

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/oncrpc/TestFrameDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/oncrpc/TestFrameDecoder.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
 import java.net.BindException;
 import java.util.ArrayList;
 import java.util.List;
@@ -263,14 +262,15 @@ public class TestFrameDecoder {
 
   /**
    * Check whether the given exception indicates that the port is already
-   * bound by another process. Handles {@link ChannelException} thrown by
-   * Netty as well as {@link BindException} that may be sneaky-thrown from
-   * {@code ChannelFuture#sync()}.
+   * bound by another process. Netty may wrap bind failures in a
+   * {@link ChannelException}, so inspect the cause chain and only treat
+   * {@link BindException}s that indicate an address-in-use condition as
+   * retryable.
    */
   private static boolean isPortInUse(Throwable t) {
     Throwable cursor = t;
     while (cursor != null) {
-      if (cursor instanceof BindException || cursor instanceof ChannelException) {
+      if (cursor instanceof BindException) {
         return true;
       }
       cursor = cursor.getCause();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/oncrpc/TestFrameDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/oncrpc/TestFrameDecoder.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.net.BindException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -235,19 +237,45 @@ public class TestFrameDecoder {
             "localhost", serverPort, 100000, 1, 2, allowInsecurePorts);
         tcpServer = new SimpleTcpServer(serverPort, program, 1);
         tcpServer.run();
-        break;          // Successfully bound a port, break out.
-      } catch (InterruptedException | ChannelException e) {
+        return serverPort;    // Successfully bound a port.
+      } catch (InterruptedException e) {
         if (tcpServer != null) {
           tcpServer.shutdown();
         }
-        if (retries-- > 0) {
-          serverPort += rand.nextInt(20); // Port in use? Try another.
-        } else {
-          throw e;     // Out of retries.
+        Thread.currentThread().interrupt();
+        throw e;
+      } catch (Exception e) {
+        // Netty's ChannelFuture#sync may "sneaky-throw" a checked exception
+        // such as java.net.BindException via PlatformDependent#throwException,
+        // which is why catching ChannelException alone is not sufficient.
+        // Only retry on port-in-use style failures; rethrow anything else.
+        if (tcpServer != null) {
+          tcpServer.shutdown();
         }
+        if (!isPortInUse(e) || retries-- <= 0) {
+          throw e;     // Not a port-in-use error, or out of retries.
+        }
+        // Port in use? Try another. Ensure we never re-pick the same port.
+        serverPort += 1 + rand.nextInt(20);
       }
     }
-    return serverPort;
+  }
+
+  /**
+   * Check whether the given exception indicates that the port is already
+   * bound by another process. Handles {@link ChannelException} thrown by
+   * Netty as well as {@link BindException} that may be sneaky-thrown from
+   * {@code ChannelFuture#sync()}.
+   */
+  private static boolean isPortInUse(Throwable t) {
+    Throwable cursor = t;
+    while (cursor != null) {
+      if (cursor instanceof BindException || cursor instanceof ChannelException) {
+        return true;
+      }
+      cursor = cursor.getCause();
+    }
+    return false;
   }
 
   static void createPortmapXDRheader(XDR xdr_out, int procedure) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

1. `BindException` was not caught — main cause of the failure shown in the log.
  Netty's `ChannelFuture#sync()` uses `PlatformDependent.throwException` to "sneaky-throw" the original cause. When the OS returns "Address already in use", the cause is `java.net.BindException` (which extends `IOException`), not `ChannelException`. The original `catch (InterruptedException | ChannelException e)` missed it entirely, so the exception propagated out of the loop and failed the test on the first attempt - exactly matching the stack trace in the failure log.

```
Error:  Tests run: 4, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.224 s <<< FAILURE! -- in org.apache.hadoop.oncrpc.TestFrameDecoder
Error:  org.apache.hadoop.oncrpc.TestFrameDecoder.testFrames -- Time elapsed: 0.013 s <<< ERROR!
java.net.BindException: Address already in use
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:567)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.netBind(ServerSocketChannelImpl.java:337)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:294)
	at io.netty.channel.socket.nio.NioServerSocketChannel.doBind(NioServerSocketChannel.java:141)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:561)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1281)
	at io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:600)
	at io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:579)
	at io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:922)
	at io.netty.channel.AbstractChannel.bind(AbstractChannel.java:259)
	at io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:384)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
	Suppressed: java.lang.RuntimeException: Rethrowing promise failure cause
		at io.netty.util.concurrent.DefaultPromise.rethrowIfFailed(DefaultPromise.java:686)
		at io.netty.util.concurrent.DefaultPromise.sync(DefaultPromise.java:420)
		at io.netty.channel.DefaultChannelPromise.sync(DefaultChannelPromise.java:119)
		at io.netty.channel.DefaultChannelPromise.sync(DefaultChannelPromise.java:30)
		at org.apache.hadoop.oncrpc.SimpleTcpServer.run(SimpleTcpServer.java:88)
		at org.apache.hadoop.oncrpc.TestFrameDecoder.startRpcServer(TestFrameDecoder.java:237)
		at org.apache.hadoop.oncrpc.TestFrameDecoder.testFrames(TestFrameDecoder.java:177)
		at java.base/java.lang.reflect.Method.invoke(Method.java:569)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

2. The port increment could be zero.
   `serverPort += rand.nextInt(20)` returns `[0, 20)`, so on retry the same busy port could be picked again. Changed to `1 + rand.nextInt(20)` so the port is always bumped.

3. `InterruptedException` was lumped with "port in use".
   An external thread interrupt should not trigger a port-bump retry. Split into its own handler that restores the interrupt flag and propagates.

Contains content generated by: Claude Opus 4.7

### How was this patch tested?

Run dozens of rounds
```
./mvnw test -pl hadoop-common-project/hadoop-common -am -Dtest=TestFrameDecoder
...
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.oncrpc.TestFrameDecoder
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.036 s -- in org.apache.hadoop.oncrpc.TestFrameDecoder
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19881)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html