### PR TITLE
YARN-11960. Fix NodeManager OOM caused by large client.json

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2726,6 +2726,15 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_DOCKER_DEFAULT_TMPFS_MOUNTS =
       DOCKER_CONTAINER_RUNTIME_PREFIX + "default-tmpfs-mounts";
 
+  /**
+   * Maximum allowed file size in bytes for the Docker client configuration
+   * file (config.json). If the file size exceeds this value, the container
+   * launch will be rejected. See yarn-default.xml for the default value.
+   */
+  public static final String NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES =
+      DOCKER_CONTAINER_RUNTIME_PREFIX + "client-config-file-max-size-bytes";
+  public static final int DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES = 1024;
+
   /** The mode in which the Java Container Sandbox should run detailed by
    *  the JavaSandboxLinuxContainerRuntime. */
   public static final String YARN_CONTAINER_SANDBOX =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2729,11 +2729,12 @@ public class YarnConfiguration extends Configuration {
   /**
    * Maximum allowed file size in bytes for the Docker client configuration
    * file (config.json). If the file size exceeds this value, the container
-   * launch will be rejected. See yarn-default.xml for the default value.
+   * launch will be rejected.
    */
   public static final String NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES =
       DOCKER_CONTAINER_RUNTIME_PREFIX + "client-config-file-max-size-bytes";
-  public static final int DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES = 1024;
+  public static final int DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES =
+      16 * 1024;
 
   /** The mode in which the Java Container Sandbox should run detailed by
    *  the JavaSandboxLinuxContainerRuntime. */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/DockerClientConfigHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/DockerClientConfigHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.yarn.util;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.commons.io.IOUtils;
@@ -27,6 +28,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.DockerCredentialTokenIdentifier;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -80,19 +82,37 @@ public final class DockerClientConfigHandler {
    */
   public static Credentials readCredentialsFromConfigFile(Path configFile,
       Configuration conf, String applicationId) throws IOException {
-    // Read the config file
-    String contents = null;
+
+    int configFileMaxSizeByte = conf.getInt(
+        YarnConfiguration.NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES,
+        YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES);
+    if (configFileMaxSizeByte <= 0) {
+      LOG.warn("Invalid value {} for {}, falling back to default {} bytes.",
+          configFileMaxSizeByte,
+          YarnConfiguration.NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES,
+          YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES);
+      configFileMaxSizeByte =
+          YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;
+    }
+
+    // Read the config file. Check the file size up front so
+    // a large config.json cannot OOM the NodeManager via IOUtils.toString.
     configFile = new Path(configFile.toUri());
     FileSystem fs = configFile.getFileSystem(conf);
-    if (fs != null) {
-      FSDataInputStream fileHandle = fs.open(configFile);
-      if (fileHandle != null) {
-        contents = IOUtils.toString(fileHandle, StandardCharsets.UTF_8);
-      }
+    FileStatus status = fs.getFileStatus(configFile);
+    if (status.getLen() > configFileMaxSizeByte) {
+      throw new IOException("Docker client config " + configFile + " ("
+          + status.getLen() + " bytes) is larger than maximum allowed size ("
+          + configFileMaxSizeByte + " bytes)");
+    }
+
+    String contents;
+    try (FSDataInputStream fileHandle = fs.open(configFile)) {
+      contents = IOUtils.toString(fileHandle, StandardCharsets.UTF_8);
     }
     if (contents == null) {
-      throw new IOException("Failed to read Docker client configuration: "
-          + configFile);
+      throw new IOException(
+          "Failed to read Docker client configuration: " + configFile);
     }
 
     // Parse the JSON and create the Tokens/Credentials.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/DockerClientConfigHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/DockerClientConfigHandler.java
@@ -110,7 +110,7 @@ public final class DockerClientConfigHandler {
     try (FSDataInputStream fileHandle = fs.open(configFile)) {
       contents = IOUtils.toString(fileHandle, StandardCharsets.UTF_8);
     }
-    if (contents == null) {
+    if (contents == null || contents.trim().isEmpty()) {
       throw new IOException(
           "Failed to read Docker client configuration: " + configFile);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2340,10 +2340,10 @@
     <description>
       Maximum allowed file size in bytes for the Docker client configuration file
       (config.json). If the file size exceeds this value, the container launch
-      will be rejected. Default is 1024 bytes.
+      will be rejected. Default is 16 KiB.
     </description>
     <name>yarn.nodemanager.runtime.linux.docker.client-config-file-max-size-bytes</name>
-    <value>1024</value>
+    <value>16384</value>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2337,6 +2337,16 @@
   </property>
 
   <property>
+    <description>
+      Maximum allowed file size in bytes for the Docker client configuration file
+      (config.json). If the file size exceeds this value, the container launch
+      will be rejected. Default is 1024 bytes.
+    </description>
+    <name>yarn.nodemanager.runtime.linux.docker.client-config-file-max-size-bytes</name>
+    <value>1024</value>
+  </property>
+
+  <property>
     <description>The runC image tag to manifest plugin
       class to be used.</description>
     <name>yarn.nodemanager.runtime.linux.runc.image-tag-to-manifest-plugin</name>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java
@@ -910,7 +910,7 @@ public class DockerLinuxContainerRuntime extends OCIContainerRuntime {
                 containerIdStr);
       } catch (IOException e) {
         throw new RuntimeException(
-            "Fail to read additional docker client config file from " + clientConfig);
+            "Failed to read additional docker client config file: " + clientConfig, e);
       }
     }
     return additionalDockerCredentials;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -118,7 +118,9 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.OCIContainerRuntime.CONTAINER_PID_NAMESPACE_SUFFIX;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.OCIContainerRuntime.RUN_PRIVILEGED_CONTAINER_SUFFIX;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.OCIContainerRuntime.formatOciEnvKey;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -2510,6 +2512,75 @@ public class TestDockerContainerRuntime {
       throws ContainerExecutionException, PrivilegedOperationException, IOException {
     initHttps(pHttps);
     testLaunchContainer(null, getDockerClientConfigFile());
+  }
+
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchContainerWithBigDockerClientConfig(boolean pHttps) throws Exception {
+    initHttps(pHttps);
+    int maxSize = YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;
+    int invalidSize = maxSize + 1;
+
+    File file = new File(tmpPath, "docker-client-config-big");
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+      bw.write("x".repeat(invalidSize));
+    }
+    initHttps(pHttps);
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> testLaunchContainer(null, file));
+    assertNotNull(e.getCause(), "Wrapped IOException cause expected");
+    assertThat(e.getCause().getMessage())
+        .contains("(" + invalidSize + " bytes) is larger than maximum allowed size ("
+            + maxSize + " bytes)");
+  }
+
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchContainerWithDockerClientConfigAtMaxSize(boolean pHttps) throws Exception {
+    initHttps(pHttps);
+    int maxSize = YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;
+
+    // Exactly maxSize bytes must be accepted (boundary check). The content
+    // does not need to be valid JSON: readCredentialsFromConfigFile parses
+    // JSON only after the size gate, so a JSON-parse failure here would
+    // already prove the size gate let the file through.
+    File file = new File(tmpPath, "docker-client-config-boundary");
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+      bw.write(TestDockerClientConfigHandler.JSON);
+      bw.write("x".repeat(maxSize - TestDockerClientConfigHandler.JSON.length()));
+    }
+    // The handler should not reject on size. Any failure must come from
+    // downstream container launch wiring, not the size guard.
+    try {
+      testLaunchContainer(null, file);
+    } catch (RuntimeException re) {
+      if (re.getCause() != null && re.getCause().getMessage() != null) {
+        assertThat(re.getCause().getMessage())
+            .doesNotContain("is larger than maximum allowed size");
+      }
+    }
+  }
+
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchContainerWithInvalidMaxSizeFallsBackToDefault(boolean pHttps)
+      throws Exception {
+    initHttps(pHttps);
+
+    conf.setInt(YarnConfiguration.NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES, -1);
+    int defaultMax = YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;
+    int invalidSize = defaultMax + 1;
+
+    File file = new File(tmpPath, "docker-client-neg-max");
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+      bw.write("x".repeat(invalidSize));
+    }
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> testLaunchContainer(null, file));
+    assertNotNull(e.getCause(), "Wrapped IOException cause expected");
+    assertThat(e.getCause().getMessage())
+        .contains("(" + invalidSize + " bytes) is larger than maximum allowed size ("
+            + defaultMax + " bytes)");
   }
 
   public void testLaunchContainer(ByteBuffer tokens, File dockerConfigFile)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.Contai
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeConstants;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeContext;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -2514,10 +2515,9 @@ public class TestDockerContainerRuntime {
     testLaunchContainer(null, getDockerClientConfigFile());
   }
 
-  @ParameterizedTest(name = "https={0}")
-  @MethodSource("data")
-  public void testLaunchContainerWithBigDockerClientConfig(boolean pHttps) throws Exception {
-    initHttps(pHttps);
+  @Test
+  public void testLaunchContainerWithBigDockerClientConfig() throws Exception {
+    initHttps(false);
     int maxSize = YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;
     int invalidSize = maxSize + 1;
 
@@ -2525,7 +2525,6 @@ public class TestDockerContainerRuntime {
     try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
       bw.write("x".repeat(invalidSize));
     }
-    initHttps(pHttps);
     RuntimeException e = assertThrows(RuntimeException.class,
         () -> testLaunchContainer(null, file));
     assertNotNull(e.getCause(), "Wrapped IOException cause expected");
@@ -2534,38 +2533,37 @@ public class TestDockerContainerRuntime {
             + maxSize + " bytes)");
   }
 
-  @ParameterizedTest(name = "https={0}")
-  @MethodSource("data")
-  public void testLaunchContainerWithDockerClientConfigAtMaxSize(boolean pHttps) throws Exception {
-    initHttps(pHttps);
+  @Test
+  public void testLaunchContainerWithDockerClientConfigAtMaxSize() throws Exception {
+    initHttps(false);
     int maxSize = YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;
 
-    // Exactly maxSize bytes must be accepted (boundary check). The content
-    // does not need to be valid JSON: readCredentialsFromConfigFile parses
-    // JSON only after the size gate, so a JSON-parse failure here would
-    // already prove the size gate let the file through.
+    // Build a valid Docker client config JSON of exactly maxSize bytes by
+    // padding whitespace after the opening brace (JSON ignores whitespace
+    // between tokens). This verifies the boundary is accepted by the size
+    // gate and that the resulting content still parses as JSON downstream.
+    String base = TestDockerClientConfigHandler.JSON;
+    int padLen = maxSize - base.length();
+    assertTrue(padLen >= 0,
+        "Base JSON (" + base.length() + " bytes) must fit within maxSize ("
+            + maxSize + " bytes) for this test to be meaningful");
+    String content = "{" + " ".repeat(padLen) + base.substring(1);
+    assertEquals(maxSize, content.getBytes(StandardCharsets.UTF_8).length,
+        "Padded JSON must be exactly maxSize bytes");
+
     File file = new File(tmpPath, "docker-client-config-boundary");
     try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
-      bw.write(TestDockerClientConfigHandler.JSON);
-      bw.write("x".repeat(maxSize - TestDockerClientConfigHandler.JSON.length()));
+      bw.write(content);
     }
-    // The handler should not reject on size. Any failure must come from
-    // downstream container launch wiring, not the size guard.
-    try {
-      testLaunchContainer(null, file);
-    } catch (RuntimeException re) {
-      if (re.getCause() != null && re.getCause().getMessage() != null) {
-        assertThat(re.getCause().getMessage())
-            .doesNotContain("is larger than maximum allowed size");
-      }
-    }
+    // Must NOT throw the size-gate error. Container launch should proceed
+    // through the normal path with this boundary-sized valid config.
+    testLaunchContainer(null, file);
   }
 
-  @ParameterizedTest(name = "https={0}")
-  @MethodSource("data")
-  public void testLaunchContainerWithInvalidMaxSizeFallsBackToDefault(boolean pHttps)
+  @Test
+  public void testLaunchContainerWithInvalidMaxSizeFallsBackToDefault()
       throws Exception {
-    initHttps(pHttps);
+    initHttps(false);
 
     conf.setInt(YarnConfiguration.NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES, -1);
     int defaultMax = YarnConfiguration.DEFAULT_NM_DOCKER_CLIENT_CONFIG_MAX_SIZE_BYTES;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

In Spark or MapReduce jobs, when accessing private Docker registry, Docker config.json path can be set by below environment variable:

```
YARN_CONTAINER_RUNTIME_DOCKER_CLIENT_CONFIG=hdfs://ns/user/foo/config.json 
```

NodeManager reads this file and writes to local filesystem as config.json. But current implementation reads whole file to memory and do JSON parsing, then writes it. 
If large file is configured, NodeManager can occur OOM. 
So file size limit should be added.

### How was this patch tested?

unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html