### PR TITLE
HDFS-17917. Fix empty block list enqueue in markedDeleteQueue

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -5343,13 +5343,12 @@ public class BlockManager implements BlockStatsMXBean {
 
     @Override
     public void run() {
+      metrics = NameNode.getNameNodeMetrics();
       LOG.info("Start MarkedDeleteBlockScrubber thread");
       while (namesystem.isRunning() &&
           !Thread.currentThread().isInterrupted()) {
         if (!markedDeleteQueue.isEmpty() || checkToDeleteIterator()) {
           try {
-            metrics = NameNode.getNameNodeMetrics();
-            metrics.setDeleteBlocksQueued(markedDeleteQueue.size());
             isSleep = false;
             long startTime = Time.monotonicNow();
             remove(startTime);
@@ -5357,6 +5356,7 @@ public class BlockManager implements BlockStatsMXBean {
                 !Thread.currentThread().isInterrupted()) {
               List<BlockInfo> markedDeleteList = markedDeleteQueue.poll();
               if (markedDeleteList != null) {
+                metrics.decrDeleteBlocksQueued();
                 toDeleteIterator = markedDeleteList.listIterator();
               }
               remove(startTime);
@@ -5742,9 +5742,13 @@ public class BlockManager implements BlockStatsMXBean {
   }
 
   public void addBLocksToMarkedDeleteQueue(List<BlockInfo> blockInfos) {
+    if (blockInfos == null || blockInfos.isEmpty()) {
+      return;
+    }
+    NameNodeMetrics metrics = NameNode.getNameNodeMetrics();
+    metrics.incrDeleteBlocksQueued();
+    metrics.incrPendingDeleteBlocksCount(blockInfos.size());
     markedDeleteQueue.add(blockInfos);
-    NameNode.getNameNodeMetrics().
-        incrPendingDeleteBlocksCount(blockInfos.size());
   }
 
   public long nextGenerationStamp(boolean legacyBlock) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
@@ -345,12 +345,16 @@ public class NameNodeMetrics {
     blockOpsQueued.set(size);
   }
 
-  public void setDeleteBlocksQueued(int size) {
-    deleteBlocksQueued.set(size);
-  }
-
   public void incrPendingDeleteBlocksCount(int size) {
     pendingDeleteBlocksCount.incr(size);
+  }
+
+  public void incrDeleteBlocksQueued() {
+    deleteBlocksQueued.incr();
+  }
+
+  public void decrDeleteBlocksQueued() {
+    deleteBlocksQueued.decr();
   }
 
   public void decrPendingDeleteBlocksCount() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -2338,4 +2338,50 @@ public class TestBlockManager {
       DataNodeFaultInjector.set(oldInjector);
     }
   }
+
+  @Test
+  public void testDoesNotEnqueueBlocksWhenDeletingEmptyDir() throws Exception {
+    Configuration conf = new Configuration();
+    // Pause the MarkedDeleteBlockScrubber so the queue state can be observed
+    // deterministically right after the delete call.
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_BLOCK_DELETION_UNLOCK_INTERVAL_MS,
+        TimeUnit.HOURS.toMillis(1));
+
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {
+      cluster.waitActive();
+      BlockManager blockManager = cluster.getNamesystem().getBlockManager();
+      DistributedFileSystem fs = cluster.getFileSystem();
+
+      Path dir = new Path("/test/dir");
+      fs.mkdirs(new Path(dir, "leaf"));
+      fs.delete(dir, true);
+
+      assertTrue(blockManager.getMarkedDeleteQueue().isEmpty(),
+          "Deleting an empty directory must not enqueue an empty block list");
+    }
+  }
+
+  @Test
+  public void testEnqueueBlocksWhenDeletingFile() throws Exception {
+    Configuration conf = new Configuration();
+    // Pause the MarkedDeleteBlockScrubber so we can observe the enqueued batch
+    // before the background thread drains it.
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_BLOCK_DELETION_UNLOCK_INTERVAL_MS,
+        TimeUnit.HOURS.toMillis(1));
+
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {
+      cluster.waitActive();
+      BlockManager blockManager = cluster.getNamesystem().getBlockManager();
+      DistributedFileSystem fs = cluster.getFileSystem();
+
+      Path file = new Path("/test/file");
+      DFSTestUtil.createFile(fs, file, 1024L, (short) 1, 0L);
+      DFSTestUtil.waitReplication(fs, file, (short) 1);
+
+      fs.delete(file, false);
+
+      assertEquals(1, blockManager.getMarkedDeleteQueue().size(),
+          "Deleting a file with blocks should enqueue exactly one batch");
+    }
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When deleting empty directory, empty list is added to markedDeleteQueue.
I think this is unnecessary. and markedDeleteQueue.size() is O(n) operation, so it is costly.

### How was this patch tested?

unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html