### PR TITLE
YARN-11958. Make TimelineClient connect/read timeout configurable

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3881,7 +3881,7 @@ public class YarnConfiguration extends Configuration {
   public static final boolean
       DEFAULT_TIMELINE_SERVICE_CLIENT_BEST_EFFORT = false;
 
-  /** Timeout in milliseconds for TimelineClient HTTP connect and read operations */
+  /** Timeout in milliseconds for TimelineClient HTTP connect and read operations. */
   public static final String TIMELINE_SERVICE_CLIENT_TIMEOUT_MS =
       TIMELINE_SERVICE_CLIENT_PREFIX + "timeout-ms";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3881,6 +3881,13 @@ public class YarnConfiguration extends Configuration {
   public static final boolean
       DEFAULT_TIMELINE_SERVICE_CLIENT_BEST_EFFORT = false;
 
+  /** Timeout in milliseconds for TimelineClient HTTP connect and read operations */
+  public static final String TIMELINE_SERVICE_CLIENT_TIMEOUT_MS =
+      TIMELINE_SERVICE_CLIENT_PREFIX + "timeout-ms";
+
+  public static final int
+      DEFAULT_TIMELINE_SERVICE_CLIENT_TIMEOUT_MS = 60_000;
+
   /** Flag to enable recovery of timeline service */
   public static final String TIMELINE_SERVICE_RECOVERY_ENABLED =
       TIMELINE_SERVICE_PREFIX + "recovery.enabled";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
@@ -137,7 +137,7 @@ public class TimelineClientImpl extends TimelineClient {
         PseudoAuthenticationHandler.TYPE;
     authType = conf.get(YarnConfiguration.TIMELINE_HTTP_AUTH_TYPE,
         defaultAuth);
-    LOG.info("Timeline service address: " + getTimelineServiceAddress());
+
     super.serviceInit(conf);
   }
 
@@ -151,6 +151,11 @@ public class TimelineClientImpl extends TimelineClient {
 
   @Override
   protected void serviceStart() throws Exception {
+    String protoPrefix = "http://";
+    if (YarnConfiguration.useHttps(getConfig())) {
+      protoPrefix = "https://";
+    }
+    LOG.info("Timeline service address: " + protoPrefix + getTimelineServiceAddress() + " (" + connector + ")");
     timelineWriter = createTimelineWriter(getConfig(), authUgi,
         connector.getClient(), TimelineConnector.constructResURI(getConfig(),
             timelineServiceAddress, RESOURCE_URI_STR_V1), connector.getRetryPolicy());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
@@ -155,7 +155,8 @@ public class TimelineClientImpl extends TimelineClient {
     if (YarnConfiguration.useHttps(getConfig())) {
       protoPrefix = "https://";
     }
-    LOG.info("Timeline service address: " + protoPrefix + getTimelineServiceAddress() + " (" + connector + ")");
+    LOG.info("Timeline service address: "
+        + protoPrefix + getTimelineServiceAddress() + " (" + connector + ")");
     timelineWriter = createTimelineWriter(getConfig(), authUgi,
         connector.getClient(), TimelineConnector.constructResURI(getConfig(),
             timelineServiceAddress, RESOURCE_URI_STR_V1), connector.getRetryPolicy());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineConnector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineConnector.java
@@ -77,7 +77,7 @@ public class TimelineConnector extends AbstractService {
   private static final Logger LOG =
       LoggerFactory.getLogger(TimelineConnector.class);
 
-  private int socketTimeOut = 60_000;
+  private int socketTimeOut;
 
   private SSLFactory sslFactory;
   Client client;
@@ -105,6 +105,9 @@ public class TimelineConnector extends AbstractService {
     ClientConfig cc = new ClientConfig();
     cc.register(YarnJacksonJaxbJsonProvider.class);
 
+    socketTimeOut = conf.getInt(YarnConfiguration.TIMELINE_SERVICE_CLIENT_TIMEOUT_MS,
+      YarnConfiguration.DEFAULT_TIMELINE_SERVICE_CLIENT_TIMEOUT_MS);
+
     if (YarnConfiguration.useHttps(conf)) {
       // If https is chosen, configures SSL client.
       sslFactory = getSSLFactory(conf);
@@ -131,6 +134,15 @@ public class TimelineConnector extends AbstractService {
             authUgi, authenticator, connConfigurator, token, doAsUser)));
 
     client = ClientBuilder.newClient(cc);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+            "timeout=%dms, max-retries=%d, retry-interval=%dms",
+            socketTimeOut,
+            retryPolicy.getMaxRetries(),
+            retryPolicy.getDelay().toMillis());
   }
 
   private ConnectionConfigurator defaultTimeoutConnConfigurator = conn -> {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -3061,6 +3061,14 @@
 
   <property>
     <description>
+      Timeout in milliseconds for TimelineClient HTTP connect and read operations.
+    </description>
+    <name>yarn.timeline-service.client.timeout-ms</name>
+    <value>60000</value>
+  </property>
+
+  <property>
+    <description>
     The time period for which timeline v2 client will wait for draining
     leftover entities after stop.
     </description>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineClient.java
@@ -20,9 +20,12 @@ package org.apache.hadoop.yarn.client.api.impl;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -539,6 +542,48 @@ public class TestTimelineClient {
     client.connector.client = mockJerseyClient;
     client.stop();
     verify(mockJerseyClient, times(1)).close();
+  }
+
+  @Test
+  public void testReadTimeout() throws Exception {
+    ServerSocket server = new ServerSocket(0);
+    AtomicBoolean running = new AtomicBoolean(true);
+
+    Thread t = new Thread(() -> {
+      try (Socket socket = server.accept()) {
+        while (running.get()) {
+          Thread.sleep(100);
+        }
+      } catch (Exception ignored) {}
+    });
+    t.start();
+
+    try {
+      YarnConfiguration conf = new YarnConfiguration();
+      conf.setInt(YarnConfiguration.TIMELINE_SERVICE_CLIENT_MAX_RETRIES, 0);
+      conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
+      conf.setInt(YarnConfiguration.TIMELINE_SERVICE_CLIENT_TIMEOUT_MS, 2_000);
+      conf.set(YarnConfiguration.TIMELINE_SERVICE_WEBAPP_ADDRESS, "localhost:" + server.getLocalPort());
+
+      TimelineClientImpl client = createTimelineClient(conf);
+      long start = System.currentTimeMillis();
+      try {
+        // This call should fail due to a timeout
+        client.putEntities(generateEntity());
+        fail("Timeout expected, but the call succeeded.");
+      } catch (RuntimeException ce) {
+        assertTrue(ce.getMessage().contains("java.net.SocketTimeoutException: Read timed out"),
+                "Handler exception for reason other than retry: " + ce);
+      } finally {
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed >= 2_000 && elapsed < 30_000);
+      }
+    } finally {
+      server.close();
+      running.set(false);
+      t.interrupt();
+      t.join(3000);
+    }
   }
 
   private void setupSSLConfig(YarnConfiguration conf) throws Exception {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineClient.java
@@ -563,13 +563,14 @@ public class TestTimelineClient {
       conf.setInt(YarnConfiguration.TIMELINE_SERVICE_CLIENT_MAX_RETRIES, 0);
       conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
       conf.setInt(YarnConfiguration.TIMELINE_SERVICE_CLIENT_TIMEOUT_MS, 2_000);
-      conf.set(YarnConfiguration.TIMELINE_SERVICE_WEBAPP_ADDRESS, "localhost:" + server.getLocalPort());
+      conf.set(YarnConfiguration.TIMELINE_SERVICE_WEBAPP_ADDRESS,
+          "localhost:" + server.getLocalPort());
 
-      TimelineClientImpl client = createTimelineClient(conf);
+      TimelineClientImpl timelineClient = createTimelineClient(conf);
       long start = System.currentTimeMillis();
       try {
         // This call should fail due to a timeout
-        client.putEntities(generateEntity());
+        timelineClient.putEntities(generateEntity());
         fail("Timeout expected, but the call succeeded.");
       } catch (RuntimeException ce) {
         assertTrue(ce.getMessage().contains("java.net.SocketTimeoutException: Read timed out"),


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

I found that socket timeout of `TimelineClient` is hardcoded to 60 seconds. I think this should be configurable, so I made a patch for this.


### How was this patch tested?

unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html