### PR TITLE
 YARN-11961. JSON fallback for DTOs not in serialization allowlists.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ExcludeRootJSONProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ExcludeRootJSONProvider.java
@@ -29,6 +29,7 @@ import javax.ws.rs.ext.Provider;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlRootElement;
 
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 import org.eclipse.persistence.jaxb.rs.MOXyJsonProvider;
@@ -48,6 +49,10 @@ import org.apache.hadoop.conf.Configuration;
  * to determine which classes should be serialized
  * and deserialized without a root element in the resulting JSON.
  * </p>
+ *
+ * <p>Additionally, any {@link XmlRootElement}-annotated type that is listed neither as
+ * wrapped nor unwrapped in {@link ClassSerialisationConfig} is handled here as
+ * <b>unwrapped</b> JSON.</p>
  *
  * During marshalling and unmarshalling, this provider sets the MOXy-specific properties:
  * <ul>
@@ -107,9 +112,26 @@ public class ExcludeRootJSONProvider extends MOXyJsonProvider {
   @Override
   public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations,
       MediaType mediaType) {
-    boolean match = classSerialisationConfig.getUnWrappedClasses().contains(type);
+    if (classSerialisationConfig.getWrappedClasses().contains(type)) {
+      return false;
+    }
+    boolean match = classSerialisationConfig.getUnWrappedClasses().contains(type)
+        || isUnwrappedFallbackCandidate(type);
     LOG.trace("ExcludeRootJSONProvider compatibility with {} is {}", type, match);
     return match;
+  }
+
+  /**
+   * JAX-RS entities not listed as unwrapped in {@link ClassSerialisationConfig} but with
+   * {@link XmlRootElement} use unwrapped JSON here (same MOXy flags as explicitly unwrapped
+   * types).
+   */
+  private static boolean isUnwrappedFallbackCandidate(Class<?> type) {
+    if (!type.isAnnotationPresent(XmlRootElement.class)) {
+      return false;
+    }
+    LOG.trace("Unwrapped JSON fallback applies for {}", type.getName());
+    return true;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/TestExcludeRootJSONProviderFallback.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/TestExcludeRootJSONProviderFallback.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.webapp.jsonprovider;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.Annotation;
+
+import javax.ws.rs.core.MediaType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.junit.Test;
+
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ClusterInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NewApplication;
+
+/**
+ * Basic checks that {@link ExcludeRootJSONProvider} selects JSON for unlisted
+ * {@link XmlRootElement} types (fallback) and respects wrapped / unwrapped lists.
+ */
+public class TestExcludeRootJSONProviderFallback {
+
+  /** Not on {@link ClassSerialisationConfig} lists; for this test only. */
+  @XmlRootElement(name = "testRoot")
+  public static final class UnlistedJaxbRoot {
+    private String value;
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
+
+  private final ExcludeRootJSONProvider provider = new ExcludeRootJSONProvider();
+
+  @Test
+  public void testFallbackAcceptsUnlistedJaxbRootElement() {
+    assertTrue(isJsonCompatible(UnlistedJaxbRoot.class));
+  }
+
+  @Test
+  public void testExplicitUnwrappedStillAccepted() {
+    assertTrue(isJsonCompatible(NewApplication.class));
+  }
+
+  @Test
+  public void testWrappedTypeRejected() {
+    assertFalse(isJsonCompatible(ClusterInfo.class));
+  }
+
+  @Test
+  public void testNonJaxbTypeRejected() {
+    assertFalse(isJsonCompatible(String.class));
+  }
+
+  private boolean isJsonCompatible(Class<?> type) {
+    return provider.isReadable(type, type, new Annotation[0], MediaType.APPLICATION_JSON_TYPE)
+        && provider.isWriteable(type, type, new Annotation[0], MediaType.APPLICATION_JSON_TYPE);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/TestExcludeRootJSONProviderFallback.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/TestExcludeRootJSONProviderFallback.java
@@ -18,15 +18,15 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp.jsonprovider;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Annotation;
 
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ClusterInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NewApplication;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Jersey/MOXy only binds DTOs that appear on the RM webapp’s wrapped/unwrapped class lists. DTOs with @XmlRootElement that are missing from both lists can fail JSON negotiation. Extend ExcludeRootJSONProvider so unlisted JAXB root types are treated as unwrapped JSON.





### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html