### PR TITLE
HADOOP-19883. Upgrade Maven to 3.9.15

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -17,7 +17,7 @@
 #
 wrapperVersion=3.3.4
 distributionType=source
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
-distributionSha256Sum=0d7125e8c91097b36edb990ea5934e6c68b4440eef4ea96510a0f6815e7eeadb
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionSha256Sum=b0d9292f06c5faded31ddcb6cb69099f316d6fea40a7778624b259bad9fed18a
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
 wrapperSha256Sum=4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -5,7 +5,7 @@ Requirements:
 
 * Unix System
 * JDK 17
-* Maven 3.9.11 or later (optional, a compatible version is automatically downloaded if using ./mvnw)
+* Maven 3.9.15 or later (optional, a compatible version is automatically downloaded if using ./mvnw)
 * Boost 1.86.0 (if compiling native code)
 * Protocol Buffers 3.25.5 (if compiling native code)
 * CMake 3.19 or newer (if compiling native code)
@@ -75,9 +75,9 @@ Installing required packages for clean install of Ubuntu 24.04 LTS Desktop.
   Install an up-to-date version of Maven manually, or use mvnw command, which will download one and validate it before execution.
 
   Following commands can be used to download and install required version of Maven manually if mvnw is not used:
-  $ curl -L https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.tar.gz > apache-maven-3.9.11-bin.tar.gz
-  $ tar -zxvf apache-maven-3.9.11-bin.tar.gz -C /opt
-  $ sudo ln -s /opt/apache-maven-3.9.11/bin/mvn /usr/bin
+  $ curl -L https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.tar.gz > apache-maven-3.9.15-bin.tar.gz
+  $ tar -zxvf apache-maven-3.9.15-bin.tar.gz -C /opt
+  $ sudo ln -s /opt/apache-maven-3.9.15/bin/mvn /usr/bin
 * Native libraries
   $ sudo apt-get -y install build-essential autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev libsasl2-dev
 * Protocol Buffers 3.25.5 (required to build native code)
@@ -549,7 +549,7 @@ Requirements:
 
 * Windows 10
 * JDK 17
-* Maven 3.9.11 or later (maven.apache.org, optional, a compatible version is automatically downloaded if using mvnw.cmd)
+* Maven 3.9.15 or later (maven.apache.org, optional, a compatible version is automatically downloaded if using mvnw.cmd)
 * Boost 1.86.0 (boost.org)
 * Protocol Buffers 3.25.5 (https://github.com/protocolbuffers/protobuf/tags)
 * CMake 3.19 or newer (cmake.org)

--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -62,8 +62,8 @@ RUN powershell Invoke-WebRequest -URI https://cdn.azul.com/zulu/bin/zulu8.62.0.1
 RUN powershell Expand-Archive -Path $Env:TEMP\zulu8.62.0.19-ca-jdk8.0.332-win_x64.zip -DestinationPath "C:\Java"
 
 # Install Apache Maven.
-RUN powershell Invoke-WebRequest -URI https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -OutFile $Env:TEMP\apache-maven-3.9.11-bin.zip
-RUN powershell Expand-Archive -Path $Env:TEMP\apache-maven-3.9.11-bin.zip -DestinationPath "C:\Maven"
+RUN powershell Invoke-WebRequest -URI https://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.zip -OutFile $Env:TEMP\apache-maven-3.9.15-bin.zip
+RUN powershell Expand-Archive -Path $Env:TEMP\apache-maven-3.9.15-bin.zip -DestinationPath "C:\Maven"
 
 # Install CMake 3.19.0.
 RUN powershell Invoke-WebRequest -URI https://cmake.org/files/v3.19/cmake-3.19.0-win64-x64.zip -OutFile $Env:TEMP\cmake-3.19.0-win64-x64.zip
@@ -141,7 +141,7 @@ ENV MAVEN_OPTS '-Xmx2048M -Xss128M'
 ENV IS_WINDOWS 1
 RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 RUN setx PATH "%PATH%;%JAVA_HOME%\bin"
-RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.9.11\bin"
+RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.9.15\bin"
 RUN setx PATH "%PATH%;C:\CMake\cmake-3.19.0-win64-x64\bin"
 RUN setx PATH "%PATH%;C:\ZStd"
 RUN setx PATH "%PATH%;C:\Program Files\Git\usr\bin"

--- a/dev-support/docker/pkg-resolver/install-maven.sh
+++ b/dev-support/docker/pkg-resolver/install-maven.sh
@@ -27,22 +27,22 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-default_version="3.9.11"
+default_version="3.9.15"
 version_to_install=$default_version
 if [ -n "$2" ]; then
   version_to_install="$2"
 fi
 
-if [ "$version_to_install" != "3.9.11" ]; then
+if [ "$version_to_install" != "3.9.15" ]; then
   echo "WARN: Don't know how to install version $version_to_install, installing the default version $default_version instead"
   version_to_install=$default_version
 fi
 
-if [ "$version_to_install" == "3.9.11" ]; then
+if [ "$version_to_install" == "3.9.15" ]; then
   mkdir -p /opt/maven /tmp/maven &&
-    curl -L -s -S https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.tar.gz \
-      -o /tmp/maven/apache-maven-3.9.11-bin.tar.gz &&
-    tar xzf /tmp/maven/apache-maven-3.9.11-bin.tar.gz --strip-components 1 -C /opt/maven
+    curl -L -s -S https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.tar.gz \
+      -o /tmp/maven/apache-maven-3.9.15-bin.tar.gz &&
+    tar xzf /tmp/maven/apache-maven-3.9.15-bin.tar.gz --strip-components 1 -C /opt/maven
 else
   echo "ERROR: Don't know how to install version $version_to_install"
   exit 1

--- a/dev-support/win-paths-eg.cmd
+++ b/dev-support/win-paths-eg.cmd
@@ -38,7 +38,7 @@ SET MAVEN_OPTS=-Dmaven.repo.local=C:\Tools\m2
 @REM command path
 @REM
 
-SET MAVEN_HOME=C:\Tools\apache-maven-3.9.11
+SET MAVEN_HOME=C:\Tools\apache-maven-3.9.15
 SET JAVA_HOME=C:\Tools\jdk
 SET MSVS=C:\Program Files (x86)\Microsoft Visual Studio 12.0
 SET PROTO_BIN=C:\Tools\protobuf-2.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     for an open-ended enforcement
     -->
     <enforced.java.version>[${javac.version},)</enforced.java.version>
-    <enforced.maven.version>[3.9.11,)</enforced.maven.version>
+    <enforced.maven.version>[3.9.15,)</enforced.maven.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

A regular toolchain upgrading, contains bug and CVE fixes.

Notable Changes in Maven 3.9.11 => 3.9.15

[Maven 3.9.12](https://maven.apache.org/docs/3.9.12/release-notes.html)
- Remove usage of terminally deprecated methods in Guice (eliminates warnings on JDK 25+)
- Simplify plugin prefix resolution — avoids unnecessary lookups when prefix is already mapped
- Verify Java version requirements for plugins before execution — clear error if not met
- Resolver 1.9.25: refined locking (increased lock-name selectivity for parallel builds), lock timeouts increased from 30s => 15min

[Maven 3.9.13](https://maven.apache.org/docs/3.9.13/release-notes.html)
- Plugin prerequisites check now properly supports ranges for Java 8 (or 1.8)
- Fixed Plexus Security Dispatcher warnings on Java 26+
- Updated plugin versions in default bindings
- Resolver 1.9.27: reverted parallel PUT change, HTTP 410 treated as 404, Apache HTTP transport proxy fixes, fixed locally cached artifacts escaping RRF

[Maven 3.9.14](https://maven.apache.org/docs/3.9.14/release-notes.html)
- Quickfix: removed testing libraries accidentally included in 3.9.13 distribution (GH-11762)

[Maven 3.9.15](https://maven.apache.org/docs/3.9.15/release-notes.html)
- Upgraded plexus-utils to 3.6.1 (addresses CVE)
- Upgraded jansi to 2.4.3 (color console output works on Java 26+)

Contains content generated by: deepseek-v4-pro

### How was this patch tested?

Pass CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19883)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html