### PR TITLE
HADOOP-19884. Upgrade zstd-jni to 1.5.7-8

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -452,7 +452,7 @@ hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/com
 hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/util/tree.h
 hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/compat/{fstatat|openat|unlinkat}.h
 
-com.github.luben:zstd-jni:1.5.6-4
+com.github.luben:zstd-jni:1.5.7-8
 dnsjava:dnsjava:3.6.1
 org.codehaus.woodstox:stax2-api:4.2.1
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -155,7 +155,7 @@
     <netty4.version>4.1.130.Final</netty4.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <lz4-java.version>1.10.4</lz4-java.version>
-    <zstd-jni.version>1.5.6-4</zstd-jni.version>
+    <zstd-jni.version>1.5.7-8</zstd-jni.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
 
     <!-- Maven protoc compiler -->


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This upgrade contains two parts: the underlying zstd v1.5.7 and the JNI wrapper changes.

https://github.com/facebook/zstd/releases/tag/v1.5.7

> Zstandard v1.5.7 is a significant release, featuring over 500 commits accumulated over the past year. 

Full changelog in zstd-jni

https://github.com/luben/zstd-jni/compare/v1.5.6-4...v1.5.7-7

### How was this patch tested?

Pass existing tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19884)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.