### PR TITLE
HADOOP-19887. Improve GHA website workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,31 +26,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Hadoop trunk
-        uses: actions/checkout@v3
-        with:
-          repository: apache/hadoop
+        uses: actions/checkout@v6
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: 'maven'
+          check-latest: false
       - name: Build Hadoop maven plugins
-        run: cd hadoop-maven-plugins && mvn --batch-mode install
+        run: ./mvnw --batch-mode -f hadoop-maven-plugins/pom.xml install
       - name: Build Hadoop
-        run: mvn clean install -DskipTests -DskipShade
+        run: ./mvnw --batch-mode clean install -DskipTests -DskipShade
       - name: Build document
-        run: mvn clean site
+        run: ./mvnw --batch-mode clean site
       - name: Stage document
-        run: mvn site:stage -DstagingDirectory=${GITHUB_WORKSPACE}/staging/
+        run: ./mvnw --batch-mode site:stage -DstagingDirectory=${GITHUB_WORKSPACE}/staging/
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./staging/hadoop-project


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

- Upgrade actions to the latest version
- Manage Maven cache via `actions/setup-java`
- Switch `mvn` to `mvnw`, so it always picks the requested version of maven, instead of using `mvn` shipped in OS or installed by `actions/setup-java`.

### How was this patch tested?

I manually run those commands locally to ensure they work as expected.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19887)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

No AI usage.