### PR TITLE
HDFS-17918. WebHDFS client-side failover fails during NameNode fsimage loading in HA

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -521,7 +521,7 @@ public class NameNode extends ReconfigurableBase implements
   public void queueExternalCall(ExternalCall<?> extCall)
       throws IOException, InterruptedException {
     if (rpcServer == null) {
-      NameNodeUtils.throwNamenodeStartupModeException(this);
+      throw NameNodeUtils.startupModeException(this);
     }
     rpcServer.getClientRpcServer().queueCall(extCall);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -521,7 +521,7 @@ public class NameNode extends ReconfigurableBase implements
   public void queueExternalCall(ExternalCall<?> extCall)
       throws IOException, InterruptedException {
     if (rpcServer == null) {
-      throw new RetriableException("Namenode is in startup mode");
+      NameNodeUtils.throwNamenodeStartupModeException(this);
     }
     rpcServer.getClientRpcServer().queueCall(extCall);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeUtils.java
@@ -24,9 +24,12 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSUtilClient;
+import org.apache.hadoop.ipc.RetriableException;
+import org.apache.hadoop.ipc.StandbyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
 
@@ -116,6 +119,14 @@ public final class NameNodeUtils {
     } else {
       // the port is missing or 0. Figure out real bind address later.
       return null;
+    }
+  }
+
+  public static void throwNamenodeStartupModeException(NameNode namenode) throws IOException {
+    if (namenode.isStandbyState()){
+      throw new StandbyException("Namenode is in startup mode");
+    } else {
+      throw new RetriableException("Namenode is in startup mode");
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeUtils.java
@@ -44,6 +44,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 public final class NameNodeUtils {
   public static final Logger LOG = LoggerFactory.getLogger(NameNodeUtils.class);
 
+  public static final String STARTUP_MODE = "Namenode is in startup mode";
+
   /**
    * Return the namenode address that will be used by clients to access this
    * namenode or name service. This needs to be called before the config
@@ -122,11 +124,18 @@ public final class NameNodeUtils {
     }
   }
 
-  public static void throwNamenodeStartupModeException(NameNode namenode) throws IOException {
-    if (namenode.isStandbyState()){
-      throw new StandbyException("Namenode is in startup mode");
+  /**
+   * Build the exception to throw when the NameNode receives a request while
+   * its RPC server is not yet available (e.g. fsimage loading). Returns a
+   * {@link StandbyException} when this NameNode is not in active state so the
+   * client fails over to the peer NameNode; otherwise a
+   * {@link RetriableException} so the client retries against the same node.
+   */
+  public static IOException startupModeException(NameNode namenode) {
+    if (!namenode.isActiveState()) {
+      return new StandbyException(STARTUP_MODE);
     } else {
-      throw new RetriableException("Namenode is in startup mode");
+      return new RetriableException(STARTUP_MODE);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
@@ -116,7 +116,6 @@ import org.apache.hadoop.hdfs.web.resources.*;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.ExternalCall;
-import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.net.Node;
 import org.apache.hadoop.net.NodeBase;
 import org.apache.hadoop.security.Credentials;
@@ -185,11 +184,11 @@ public class NamenodeWebHdfsMethods {
 
   private static NamenodeProtocols getRPCServer(NameNode namenode)
       throws IOException {
-     final NamenodeProtocols np = namenode.getRpcServer();
-     if (np == null) {
-       NameNodeUtils.throwNamenodeStartupModeException(namenode);
-     }
-     return np;
+    final NamenodeProtocols np = namenode.getRpcServer();
+    if (np == null) {
+      NameNodeUtils.throwNamenodeStartupModeException(namenode);
+    }
+    return np;
   }
 
   protected ClientProtocol getRpcClientProtocol() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
@@ -186,7 +186,7 @@ public class NamenodeWebHdfsMethods {
       throws IOException {
     final NamenodeProtocols np = namenode.getRpcServer();
     if (np == null) {
-      NameNodeUtils.throwNamenodeStartupModeException(namenode);
+      throw NameNodeUtils.startupModeException(namenode);
     }
     return np;
   }
@@ -195,7 +195,7 @@ public class NamenodeWebHdfsMethods {
     final NameNode namenode = (NameNode)context.getAttribute("name.node");
     final ClientProtocol cp = namenode.getRpcServer();
     if (cp == null) {
-      NameNodeUtils.throwNamenodeStartupModeException(namenode);
+      throw NameNodeUtils.startupModeException(namenode);
     }
     return cp;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.server.namenode.NameNodeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -186,7 +187,7 @@ public class NamenodeWebHdfsMethods {
       throws IOException {
      final NamenodeProtocols np = namenode.getRpcServer();
      if (np == null) {
-       throw new RetriableException("Namenode is in startup mode");
+       NameNodeUtils.throwNamenodeStartupModeException(namenode);
      }
      return np;
   }
@@ -195,7 +196,7 @@ public class NamenodeWebHdfsMethods {
     final NameNode namenode = (NameNode)context.getAttribute("name.node");
     final ClientProtocol cp = namenode.getRpcServer();
     if (cp == null) {
-      throw new RetriableException("Namenode is in startup mode");
+      NameNodeUtils.throwNamenodeStartupModeException(namenode);
     }
     return cp;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSForHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSForHA.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -49,11 +50,13 @@ import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifie
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenSecretManager;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
+import org.apache.hadoop.hdfs.server.namenode.NameNodeUtils;
 import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.hdfs.web.resources.ExceptionHandler;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
@@ -366,7 +369,7 @@ public class TestWebHDFSForHA {
         fail("Expected StandbyException");
       } catch (Exception e) {
         if (e instanceof StandbyException) {
-          GenericTestUtils.assertExceptionContains("Namenode is in startup mode", e);
+          GenericTestUtils.assertExceptionContains(NameNodeUtils.STARTUP_MODE, e);
         } else {
           fail("Expected StandbyException");
         }
@@ -378,5 +381,21 @@ public class TestWebHDFSForHA {
         cluster.shutdown();
       }
     }
+  }
+
+  /**
+   * Active NameNode in startup mode must yield a RetriableException so the
+   * client keeps retrying the same node instead of failing over.
+   */
+  @Test
+  public void testStartupModeExceptionWhenActive() {
+    NameNode active = mock(NameNode.class);
+    when(active.isActiveState()).thenReturn(true);
+
+    IOException ex = NameNodeUtils.startupModeException(active);
+    assertTrue(ex instanceof RetriableException,
+        "Active NameNode in startup mode should yield RetriableException, got "
+            + ex.getClass().getName());
+    GenericTestUtils.assertExceptionContains(NameNodeUtils.STARTUP_MODE, ex);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSForHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSForHA.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -56,6 +57,7 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.junit.jupiter.api.Test;
@@ -325,6 +327,50 @@ public class TestWebHDFSForHA {
           this.wait();
         }
         assertTrue(resultMap.get("mkdirs"));
+      }
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  /**
+   * Make sure a StandbyException is thrown when rpcServer is null in
+   * NamenodeWebHdfsMethods in HA Setup.
+   */
+  @Test
+  @Timeout(120)
+  public void testThrowStandbyExceptionWhileNNStartup() throws Exception {
+    final Configuration conf = DFSTestUtil.newHAConfiguration(LOGICAL_NAME);
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).nnTopology(topo)
+          .numDataNodes(0).build();
+      HATestUtil.setFailoverConfigurations(cluster, conf, LOGICAL_NAME);
+      cluster.waitActive();
+      cluster.transitionToActive(1);
+
+      final NameNode namenode = cluster.getNameNode(0);
+      final NamenodeProtocols rpcServer = namenode.getRpcServer();
+      Whitebox.setInternalState(namenode, "rpcServer", null);
+
+      String standbyHttpAddress = namenode.getHttpAddress().getHostName() + ":" + namenode.getHttpAddress().getPort();
+      URI webhdfsUri = URI.create(WebHdfsConstants.WEBHDFS_SCHEME + "://" + standbyHttpAddress);
+      FileSystem fs = FileSystem.get(webhdfsUri, conf);
+
+      Path foo = new Path("/foo");
+      try {
+        fs.mkdirs(foo);
+        fail("Expected StandbyException");
+      } catch (Exception e) {
+        if (e instanceof StandbyException) {
+          GenericTestUtils.assertExceptionContains("Namenode is in startup mode", e);
+        } else {
+          fail("Expected StandbyException");
+        }
+      } finally {
+        Whitebox.setInternalState(namenode, "rpcServer", rpcServer);
       }
     } finally {
       if (cluster != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSForHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSForHA.java
@@ -355,7 +355,8 @@ public class TestWebHDFSForHA {
       final NamenodeProtocols rpcServer = namenode.getRpcServer();
       Whitebox.setInternalState(namenode, "rpcServer", null);
 
-      String standbyHttpAddress = namenode.getHttpAddress().getHostName() + ":" + namenode.getHttpAddress().getPort();
+      String standbyHttpAddress = namenode.getHttpAddress().getHostName()
+          + ":" + namenode.getHttpAddress().getPort();
       URI webhdfsUri = URI.create(WebHdfsConstants.WEBHDFS_SCHEME + "://" + standbyHttpAddress);
       FileSystem fs = FileSystem.get(webhdfsUri, conf);
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When NameNode is configured with HA and NameNode 1 is restarting and loading fsimage, accessing WebHDFS does not trigger client-side failover.

During fsimage loading after NameNode restart in HA configuration, WebHDFS returns RetriableException instead of StandbyException. Because of this, the client-side failover does not work and the client keeps retrying the same NameNode. Eventually the client fails because it cannot find the active NameNode.
 
```
$ hdfs dfs -ls swebhdfs://blue
2023-07-14 12:23:55,890 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 0 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 0ms.
2023-07-14 12:23:55,929 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 1 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 731ms.
2023-07-14 12:23:56,697 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 2 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 1475ms.
2023-07-14 12:23:58,207 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 3 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 5061ms.
2023-07-14 12:24:03,304 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 4 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 7898ms.
2023-07-14 12:24:11,235 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 5 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 18847ms.
2023-07-14 12:24:30,117 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 6 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 20826ms.
2023-07-14 12:24:50,979 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 7 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 10374ms.
2023-07-14 12:25:01,385 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 8 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 16640ms.
2023-07-14 12:25:18,059 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 9 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 15514ms.
2023-07-14 12:25:33,610 INFO web.WebHdfsFileSystem: Retrying connect to namenode: blue-nn1.host/10.10.10.10:9470. Already retried 10 time(s); retry policy is org.apache.hadoop.io.retry.RetryPolicies$FailoverOnNetworkExceptionRetry@95e33cc, delay 10745ms.
ls: Namenode is in startup mode
```

### How was this patch tested?

Added unit test. Also verified on a real HA cluster that client-side failover works correctly after the fix.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html