### PR TITLE
YARN-11957. Frequent NM Label Updates Cause Longer RM Failover Time

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4877,6 +4877,10 @@ public class YarnConfiguration extends Configuration {
   public static final String FS_STORE_FILE_REPLICATION = YARN_PREFIX
       + "fs-store.file.replication";
   public static final int DEFAULT_FS_STORE_FILE_REPLICATION = 0;
+  /** Enable mergeMirrorAndEditLog on init */
+  public static final String FS_NODE_LABELS_STORE_MERGE_ENABLED = NODE_LABELS_PREFIX
+      + "fs-store.merge-enabled";
+  public static final boolean DEFAULT_FS_NODE_LABELS_STORE_MERGE_ENABLED = false;
 
   /**
    * Node-attribute configurations.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4877,7 +4877,7 @@ public class YarnConfiguration extends Configuration {
   public static final String FS_STORE_FILE_REPLICATION = YARN_PREFIX
       + "fs-store.file.replication";
   public static final int DEFAULT_FS_STORE_FILE_REPLICATION = 0;
-  /** Enable mergeMirrorAndEditLog on init */
+  /** Enable mergeMirrorAndEditLog on init. */
   public static final String FS_NODE_LABELS_STORE_MERGE_ENABLED = NODE_LABELS_PREFIX
       + "fs-store.merge-enabled";
   public static final boolean DEFAULT_FS_NODE_LABELS_STORE_MERGE_ENABLED = false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/FileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/FileSystemNodeLabelsStore.java
@@ -70,6 +70,10 @@ public class FileSystemNodeLabelsStore
     initStore(conf, new Path(
         conf.get(YarnConfiguration.FS_NODE_LABELS_STORE_ROOT_DIR,
             getDefaultFSNodeLabelsRootDir())), schema, mgr);
+    if (conf.getBoolean(YarnConfiguration.FS_NODE_LABELS_STORE_MERGE_ENABLED,
+        YarnConfiguration.DEFAULT_FS_NODE_LABELS_STORE_MERGE_ENABLED)) {
+      mergeMirrorAndEditLog();
+    }
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
@@ -85,7 +85,7 @@ public abstract class AbstractFSNodeStore<M> {
     }
 
     void setNodeLabels(Map<NodeId, Set<String>> newNodeToLabels) {
-       this.nodeToLabels = newNodeToLabels;
+      this.nodeToLabels = newNodeToLabels;
     }
 
     Map<NodeId, Set<String>> getNodeLabels() {
@@ -281,9 +281,9 @@ public abstract class AbstractFSNodeStore<M> {
   /**
    * Parse edit log and apply operations to merge state.
    */
-  private void parseEditLogToState(Path editLogPath, NodeLabelMergeState state)
+  private void parseEditLogToState(Path editLogFilePath, NodeLabelMergeState state)
       throws IOException {
-    try (FSDataInputStream is = fs.open(editLogPath)) {
+    try (FSDataInputStream is = fs.open(editLogFilePath)) {
       while (true) {
         try {
           int opCode = is.readInt();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
@@ -17,6 +17,11 @@
  */
 package org.apache.hadoop.yarn.nodelabels.store;
 
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.NodeLabel;
+import org.apache.hadoop.yarn.nodelabels.store.op.AddClusterLabelOp;
+import org.apache.hadoop.yarn.nodelabels.store.op.NodeToLabelOp;
+import org.apache.hadoop.yarn.nodelabels.store.op.RemoveClusterLabelOp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -29,9 +34,20 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.yarn.nodelabels.store.op.FSNodeStoreLogOp;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.nodelabels.store.FSStoreOpHandler.StoreType;
+import org.apache.hadoop.yarn.proto.YarnServerResourceManagerServiceProtos;
+import org.apache.hadoop.yarn.server.api.protocolrecords.AddToClusterNodeLabelsRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.AddToClusterNodeLabelsRequestPBImpl;
+import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.ReplaceLabelsOnNodeRequestPBImpl;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Abstract class for File System based store.
@@ -40,6 +56,46 @@ import java.io.IOException;
  *           CommonNodeLabelManager.
  */
 public abstract class AbstractFSNodeStore<M> {
+
+  /**
+   * Lightweight state class for merging mirror and edit log.
+   * Used to collect final state without triggering manager events.
+   */
+  protected static class NodeLabelMergeState {
+    private Map<String, NodeLabel> labels = new HashMap<>();
+    private Map<NodeId, Set<String>> nodeToLabels = new HashMap<>();
+    private boolean centralizedConfig = true;
+
+    void addLabel(NodeLabel label) {
+      labels.put(label.getName(), label);
+    }
+
+    void removeLabel(String labelName) {
+      labels.remove(labelName);
+    }
+
+    void replaceNodeToLabels(Map<NodeId, Set<String>> newNodeToLabels) {
+      for (Map.Entry<NodeId, Set<String>> entry : newNodeToLabels.entrySet()) {
+        this.nodeToLabels.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    List<NodeLabel> getClusterNodeLabels() {
+      return new ArrayList<>(labels.values());
+    }
+
+    void setNodeLabels(Map<NodeId, Set<String>> newNodeToLabels) {
+       this.nodeToLabels = newNodeToLabels;
+    }
+
+    Map<NodeId, Set<String>> getNodeLabels() {
+      return nodeToLabels;
+    }
+
+    boolean isCentralizedConfiguration() {
+      return centralizedConfig;
+    }
+  }
 
   protected static final Logger LOG =
       LoggerFactory.getLogger(AbstractFSNodeStore.class);
@@ -153,6 +209,147 @@ public abstract class AbstractFSNodeStore<M> {
 
   protected StoreType getStoreType() {
     return storeType;
+  }
+
+  /**
+   * Merge mirror and edit log into a new mirror file.
+   * This reads from mirror (or mirror.old), then applies edit log operations,
+   * and writes the result back to mirror.
+   * No events are triggered during this process.
+   */
+  protected void mergeMirrorAndEditLog() throws IOException {
+    Path mirrorPath = new Path(fsWorkingPath, schema.mirrorName);
+    Path oldMirrorPath = new Path(fsWorkingPath, schema.mirrorName + ".old");
+    editLogPath = new Path(fsWorkingPath, schema.editLogName);
+
+    // Create merge state to collect final result
+    NodeLabelMergeState mergeState = new NodeLabelMergeState();
+
+    // Parse mirror file to get initial labels and node-to-labels
+    Path mirrorToRead = fs.exists(mirrorPath) ? mirrorPath :
+        fs.exists(oldMirrorPath) ? oldMirrorPath : null;
+    if (mirrorToRead != null) {
+      parseMirrorToState(mirrorToRead, mergeState);
+    }
+
+    // Parse edit log and apply operations to state
+    if (fs.exists(editLogPath)) {
+      parseEditLogToState(editLogPath, mergeState);
+    }
+
+    // Write new mirror using merge state
+    try (FSDataOutputStream os = fs.create(mirrorPath, true)) {
+      writeMirrorFromState(os, mergeState);
+    }
+
+    // Create new empty editlog file
+    editlogOs = fs.create(editLogPath, true);
+    editlogOs.close();
+    editlogOs = null;
+
+    LOG.info("Merged mirror and edit log to: " + mirrorPath);
+  }
+
+  /**
+   * Parse mirror file and populate merge state.
+   */
+  private void parseMirrorToState(Path mirrorPath, NodeLabelMergeState state)
+      throws IOException {
+    try (FSDataInputStream is = fs.open(mirrorPath)) {
+      // Parse cluster node labels
+      List<NodeLabel> labels = new AddToClusterNodeLabelsRequestPBImpl(
+          YarnServerResourceManagerServiceProtos
+              .AddToClusterNodeLabelsRequestProto
+              .parseDelimitedFrom(is)).getNodeLabels();
+      for (NodeLabel label : labels) {
+        state.addLabel(label);
+      }
+
+      // Parse node-to-labels if exists (check if more data available)
+      try {
+        Map<NodeId, Set<String>> nodeToLabels = new ReplaceLabelsOnNodeRequestPBImpl(
+            YarnServerResourceManagerServiceProtos
+                .ReplaceLabelsOnNodeRequestProto
+                .parseDelimitedFrom(is)).getNodeToLabels();
+        state.setNodeLabels(nodeToLabels);
+      } catch (EOFException e) {
+        // No node-to-labels section, that's ok
+      }
+    }
+  }
+
+  /**
+   * Parse edit log and apply operations to merge state.
+   */
+  private void parseEditLogToState(Path editLogPath, NodeLabelMergeState state)
+      throws IOException {
+    try (FSDataInputStream is = fs.open(editLogPath)) {
+      while (true) {
+        try {
+          int opCode = is.readInt();
+          if (opCode == AddClusterLabelOp.OPCODE) {
+            List<NodeLabel> labels = new AddToClusterNodeLabelsRequestPBImpl(
+                YarnServerResourceManagerServiceProtos
+                    .AddToClusterNodeLabelsRequestProto
+                    .parseDelimitedFrom(is)).getNodeLabels();
+            for (NodeLabel label : labels) {
+              state.addLabel(label);
+            }
+          } else if (opCode == RemoveClusterLabelOp.OPCODE) {
+            Set<String> labelsToRemove = new HashSet<>(
+                YarnServerResourceManagerServiceProtos
+                    .RemoveFromClusterNodeLabelsRequestProto
+                    .parseDelimitedFrom(is).getNodeLabelsList());
+            for (String labelName : labelsToRemove) {
+              state.removeLabel(labelName);
+            }
+          } else if (opCode == NodeToLabelOp.OPCODE) {
+            Map<NodeId, Set<String>> nodeToLabels = new ReplaceLabelsOnNodeRequestPBImpl(
+                YarnServerResourceManagerServiceProtos
+                    .ReplaceLabelsOnNodeRequestProto
+                    .parseDelimitedFrom(is)).getNodeToLabels();
+            state.replaceNodeToLabels(nodeToLabels);
+          }
+        } catch (EOFException e) {
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Write mirror file from merge state.
+   */
+  private void writeMirrorFromState(FSDataOutputStream os,
+      NodeLabelMergeState state) throws IOException {
+    // Write cluster node labels
+    ((AddToClusterNodeLabelsRequestPBImpl)
+        AddToClusterNodeLabelsRequest.newInstance(state.getClusterNodeLabels()))
+        .getProto().writeDelimitedTo(os);
+
+    // Write node-to-labels if centralized config, filtering out labels
+    // that no longer exist in the cluster
+    if (state.isCentralizedConfiguration()) {
+      Map<NodeId, Set<String>> filteredNodeToLabels = new HashMap<>();
+      Set<String> validLabels = new HashSet<>();
+      for (NodeLabel label : state.getClusterNodeLabels()) {
+        validLabels.add(label.getName());
+      }
+      for (Map.Entry<NodeId, Set<String>> entry : state.getNodeLabels().entrySet()) {
+        Set<String> filteredLabels = new HashSet<>();
+        for (String label : entry.getValue()) {
+          if (validLabels.contains(label)) {
+            filteredLabels.add(label);
+          }
+        }
+        if (!filteredLabels.isEmpty()) {
+          filteredNodeToLabels.put(entry.getKey(), filteredLabels);
+        }
+      }
+      ((ReplaceLabelsOnNodeRequestPBImpl)
+          ReplaceLabelsOnNodeRequest.newInstance(filteredNodeToLabels))
+          .getProto().writeDelimitedTo(os);
+    }
   }
 
   public Path getFsWorkingPath() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
@@ -405,6 +405,7 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
   @SuppressWarnings("unchecked")
   @Test
   public void testMergeMirrorAndEditLog() throws Exception {
+    initTestFileSystemNodeLabelsStore(FileSystemNodeLabelsStore.class.getCanonicalName());
     // Step 1: Add initial labels and node-to-labels mapping
     mgr.addToCluserNodeLabelsWithDefaultExclusivity(toSet("p1", "p2"));
     mgr.replaceLabelsOnNode(ImmutableMap.of(toNodeId("n1"), toSet("p1"),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdfs.server.namenode.SafeModeException;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -39,9 +40,7 @@ import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.InlineDispatcher;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
   MockNodeLabelManager mgr = null;
@@ -421,8 +420,8 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
     mgr.start();
 
     // Verify state after first restart
-    Assert.assertEquals(2, mgr.getClusterNodeLabelNames().size());
-    Assert.assertTrue(mgr.getClusterNodeLabelNames().containsAll(
+    assertEquals(2, mgr.getClusterNodeLabelNames().size());
+    assertTrue(mgr.getClusterNodeLabelNames().containsAll(
         Arrays.asList("p1", "p2")));
     assertMapContains(mgr.getNodeLabels(), ImmutableMap.of(
         toNodeId("n1"), toSet("p1"),
@@ -446,8 +445,8 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
 
     // Step 6: Verify final state after second restart
     // Expected: p1 (kept), p3 (added), p4 (added), p5 (added), p2 (removed)
-    Assert.assertEquals(4, mgr.getClusterNodeLabelNames().size());
-    Assert.assertTrue(mgr.getClusterNodeLabelNames().containsAll(
+    assertEquals(4, mgr.getClusterNodeLabelNames().size());
+    assertTrue(mgr.getClusterNodeLabelNames().containsAll(
         Arrays.asList("p1", "p3", "p4", "p5")));
 
     // Node-to-labels mapping should be correctly merged
@@ -456,7 +455,7 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
         toNodeId("n1"), toSet("p1"),
         toNodeId("n3"), toSet("p4"),
         toNodeId("n4"), toSet("p5")));
-    Assert.assertFalse("n2 should not have any labels after p2 removal",
-        mgr.getNodeLabels().containsKey(toNodeId("n2")));
+    assertFalse(mgr.getNodeLabels().containsKey(toNodeId("n2")),
+        "n2 should not have any labels after p2 removal");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
@@ -391,4 +391,72 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
         expectedNumOfCalls)).mkdirs(Mockito.any(Path
         .class));
   }
+
+  /**
+   * Test mergeMirrorAndEditLog correctly merges mirror and edit log.
+   *
+   * Test flow:
+   * 1. Add labels [p1, p2] and node-to-labels mapping
+   * 2. Stop manager to finalize current state to disk
+   * 3. Restart manager - this triggers mergeMirrorAndEditLog during init
+   * 4. Add more labels [p3, p4], remove label p2, and modify node-to-labels mapping
+   * 5. Stop and restart again
+   * 6. Verify final state has correct merged labels [p1, p3, p4, p5]
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testMergeMirrorAndEditLog() throws Exception {
+    // Step 1: Add initial labels and node-to-labels mapping
+    mgr.addToCluserNodeLabelsWithDefaultExclusivity(toSet("p1", "p2"));
+    mgr.replaceLabelsOnNode(ImmutableMap.of(toNodeId("n1"), toSet("p1"),
+        toNodeId("n2"), toSet("p2")));
+
+    // Step 2: Stop manager
+    mgr.stop();
+
+    // Step 3: Restart manager - triggers mergeMirrorAndEditLog
+    conf.setBoolean(YarnConfiguration.FS_NODE_LABELS_STORE_MERGE_ENABLED, true);
+    mgr = new MockNodeLabelManager();
+    mgr.init(conf);
+    mgr.start();
+
+    // Verify state after first restart
+    Assert.assertEquals(2, mgr.getClusterNodeLabelNames().size());
+    Assert.assertTrue(mgr.getClusterNodeLabelNames().containsAll(
+        Arrays.asList("p1", "p2")));
+    assertMapContains(mgr.getNodeLabels(), ImmutableMap.of(
+        toNodeId("n1"), toSet("p1"),
+        toNodeId("n2"), toSet("p2")));
+
+    // Step 4: Add more labels, remove label, and modify node-to-labels mapping
+    mgr.addToCluserNodeLabelsWithDefaultExclusivity(toSet("p3", "p4", "p5"));
+    mgr.removeFromClusterNodeLabels(toSet("p2"));
+    // Modify node-to-labels: n1 keeps p1, n3 added with p4, n4 added with p5
+    mgr.replaceLabelsOnNode(ImmutableMap.of(
+        toNodeId("n1"), toSet("p1"),
+        toNodeId("n3"), toSet("p4"),
+        toNodeId("n4"), toSet("p5")));
+
+    // Step 5: Stop and restart again
+    mgr.stop();
+    mgr = new MockNodeLabelManager();
+    conf.setBoolean(YarnConfiguration.FS_NODE_LABELS_STORE_MERGE_ENABLED, true);
+    mgr.init(conf);
+    mgr.start();
+
+    // Step 6: Verify final state after second restart
+    // Expected: p1 (kept), p3 (added), p4 (added), p5 (added), p2 (removed)
+    Assert.assertEquals(4, mgr.getClusterNodeLabelNames().size());
+    Assert.assertTrue(mgr.getClusterNodeLabelNames().containsAll(
+        Arrays.asList("p1", "p3", "p4", "p5")));
+
+    // Node-to-labels mapping should be correctly merged
+    // n1 has p1; n3 has p4; n4 has p5; n2 should be removed (p2 was removed)
+    assertMapContains(mgr.getNodeLabels(), ImmutableMap.of(
+        toNodeId("n1"), toSet("p1"),
+        toNodeId("n3"), toSet("p4"),
+        toNodeId("n4"), toSet("p5")));
+    Assert.assertFalse("n2 should not have any labels after p2 removal",
+        mgr.getNodeLabels().containsKey(toNodeId("n2")));
+  }
 }


### PR DESCRIPTION
### Description of PR
In our scenario, the labels of a batch of nodes are updated periodically. After the active RM had been running for a long time, an active-standby switchover was triggered, and the switchover took an unusually long time. By analyzing the logs and jstack information related to the standby RM's transition to active, we found that a core thread, "SchedulerEventDispatcher:Event Processor", had been continuously processing updateNodeLabelsAndQueueResource. The service logs also showed a large number of "REPLACE labels on nodes" messages.


