### PR TITLE
HADOOP-19890: s3a: fix isolated classloader test for jdk >=17

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -34,8 +35,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.s3a.impl.InstantiationIOException;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 /**
  * Checks that classloader isolation for loading extension classes is applied
@@ -47,9 +46,9 @@ public class ITestS3AFileSystemIsolatedClassloader extends AbstractS3ATestBase {
 
   private static String customClassName = "custom.class.name";
 
-  private static class CustomCredentialsProvider implements AwsCredentialsProvider {
+  public static class CustomCredentialsProvider implements AwsCredentialsProvider {
 
-    CustomCredentialsProvider() {
+    public CustomCredentialsProvider() {
     }
 
     @Override
@@ -60,18 +59,24 @@ public class ITestS3AFileSystemIsolatedClassloader extends AbstractS3ATestBase {
   }
 
   private static class CustomClassLoader extends ClassLoader {
-  }
+    private final ClassLoader parent;
 
-  private final ClassLoader customClassLoader = spy(new CustomClassLoader());
-  {
-    try {
-      doReturn(CustomCredentialsProvider.class)
-          .when(customClassLoader)
-          .loadClass(customClassName);
-    } catch (ClassNotFoundException ex) {
-      throw new RuntimeException(ex);
+    CustomClassLoader(ClassLoader parent) {
+      super(parent);
+      this.parent = parent;
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+      if (customClassName.equals(name)) {
+        return CustomCredentialsProvider.class;
+      }
+      return parent.loadClass(name);
     }
   }
+
+  private final ClassLoader customClassLoader =
+      new CustomClassLoader(ITestS3AFileSystemIsolatedClassloader.class.getClassLoader());
 
   private S3AFileSystem createNewTestFs(Configuration conf) throws IOException {
     S3AFileSystem fs = new S3AFileSystem();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemIsolatedClassloader.java
@@ -59,11 +59,9 @@ public class ITestS3AFileSystemIsolatedClassloader extends AbstractS3ATestBase {
   }
 
   private static class CustomClassLoader extends ClassLoader {
-    private final ClassLoader parent;
 
     CustomClassLoader(ClassLoader parent) {
       super(parent);
-      this.parent = parent;
     }
 
     @Override
@@ -71,7 +69,7 @@ public class ITestS3AFileSystemIsolatedClassloader extends AbstractS3ATestBase {
       if (customClassName.equals(name)) {
         return CustomCredentialsProvider.class;
       }
-      return parent.loadClass(name);
+      return super.loadClass(name);
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The S3A isolated classloader test appears to be broken with newer JDKs'
restrictions on reflection access. The test fails with
`java.lang.IllegalAccessException: Attempt to lookup caller-sensitive method
using restricted lookup object`

See HADOOP-19890 for full stack trace.

### How was this patch tested?

```
./mvnw -pl :hadoop-aws -am -Dtest=none -Dit.test=ITestS3AFileSystemIsolatedClassloader.java clean verify
```

with Java 17 and 21.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [na] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [na] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
