### PR TITLE
MAPREDUCE-7537. Add mapreduce.security.allowed-groups bypass for task…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TaskLevelSecurityEnforcer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.mapreduce.v2.app.security.authorize;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +36,9 @@ import org.apache.hadoop.security.UserGroupInformation;
  * a job is allowed to execute the mapper/reducer/task classes defined in the job
  * configuration. The check is performed inside the Application Master before
  * task containers are launched.</p>
- * <p>If the user is not on the allowed list and any job property within the configured
- * security property domain references a denied class/prefix, a
+ * <p>If the submitting user is neither on the allowed-users list nor a member of any
+ * configured allowed-group (exact group name match), and some job property in the configured
+ * security property domain references a denied class or prefix, a
  * {@link TaskLevelSecurityException} is thrown and the job is rejected.</p>
  * <p>This prevents unauthorized or unsafe custom code from running inside
  * cluster containers.</p>
@@ -57,7 +59,8 @@ public final class TaskLevelSecurityEnforcer {
    * <p>The method performs the following steps:</p>
    * <ol>
    *   <li>Check whether task-level security is enabled.</li>
-   *   <li>Allow the job immediately if the user is on the configured allowed-users list.</li>
+   *   <li>Allow the job immediately if the user is on the configured allowed-users list
+   *       or belongs to any configured allowed-groups (exact group name match).</li>
    *   <li>Retrieve the security property domain (list of job configuration keys to inspect).</li>
    *   <li>Retrieve the list of denied task class prefixes.</li>
    *   <li>For each domain property, check whether its value begins with any denied prefix.</li>
@@ -92,6 +95,19 @@ public final class TaskLevelSecurityEnforcer {
       return;
     }
 
+    String[] allowedGroupNames = conf.getTrimmedStrings(
+        MRConfig.SECURITY_ALLOWED_GROUPS,
+        MRConfig.DEFAULT_SECURITY_ALLOWED_GROUPS);
+    if (allowedGroupNames.length > 0) {
+      UserGroupInformation submitterUgi =
+          UserGroupInformation.createRemoteUser(currentUserName);
+      if (isUserInAllowedGroups(submitterUgi, allowedGroupNames)) {
+        LOG.debug("The {} is allowed to execute every task via allowed-groups",
+            currentUserName);
+        return;
+      }
+    }
+
     String[] propertyDomain = conf.getTrimmedStrings(
         MRConfig.SECURITY_PROPERTY_DOMAIN,
         MRConfig.DEFAULT_SECURITY_PROPERTY_DOMAIN
@@ -110,5 +126,19 @@ public final class TaskLevelSecurityEnforcer {
       }
     }
     LOG.debug("The {} is allowed to execute the submitted job", currentUser);
+  }
+
+  private static boolean isUserInAllowedGroups(UserGroupInformation ugi,
+      String[] allowedGroupNames) {
+    Set<String> resolvedGroupSet = ugi.getGroupsSet();
+    if (resolvedGroupSet.isEmpty()) {
+      return false;
+    }
+    for (String allowed : allowedGroupNames) {
+      if (resolvedGroupSet.contains(allowed)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/security/authorize/TestTaskLevelSecurityEnforcer.java
@@ -17,8 +17,11 @@
  */
 package org.apache.hadoop.mapreduce.v2.app.security.authorize;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -30,22 +33,41 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
 
+  private static final String DEFAULT_SUBMIT_USER = "mrjobuser";
+
+  private static JobConf jobConfForSubmitUser(String submitUser) {
+    JobConf conf = new JobConf();
+    conf.set(MRJobConfig.USER_NAME, submitUser);
+    return conf;
+  }
+
+  @BeforeEach
+  public void setUp() {
+    UserGroupInformation.reset();
+    UserGroupInformation.setConfiguration(new Configuration());
+  }
+
+  @AfterEach
+  public void tearDown() {
+    UserGroupInformation.reset();
+  }
+
   @Test
   public void testServiceDisabled() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser(DEFAULT_SUBMIT_USER);
     assertPass(conf);
   }
 
   @Test
   public void testServiceEnabled() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser(DEFAULT_SUBMIT_USER);
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     assertPass(conf);
   }
 
   @Test
   public void testDeniedPackage() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser(DEFAULT_SUBMIT_USER);
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
@@ -54,7 +76,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
 
   @Test
   public void testDeniedClass() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser(DEFAULT_SUBMIT_USER);
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS,
         "org.apache.hadoop.streaming",
@@ -66,7 +88,7 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
 
   @Test
   public void testIgnoreReducer() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser(DEFAULT_SUBMIT_USER);
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_PROPERTY_DOMAIN,
         MRJobConfig.MAP_CLASS_ATTR,
@@ -81,34 +103,31 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
 
   @Test
   public void testDeniedUser() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser("bob");
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
-    conf.set(MRJobConfig.USER_NAME, "bob");
     assertDenied(conf);
   }
 
   @Test
   public void testAllowedUser() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser("bob");
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice", "bob");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
-    conf.set(MRJobConfig.USER_NAME, "bob");
     assertPass(conf);
   }
 
   @Test
   public void testTurnOff() {
-    JobConf conf = new JobConf();
+    JobConf conf = jobConfForSubmitUser("bob");
     conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, false);
     conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
     conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
     conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
-    conf.set(MRJobConfig.USER_NAME, "bob");
     assertPass(conf);
   }
 
@@ -126,6 +145,54 @@ public class TestTaskLevelSecurityEnforcer extends AbstractHadoopTestBase {
 
     mapreduceConf.addResource(jobConf);
     assertDenied(mapreduceConf);
+  }
+
+  @Test
+  public void testAllowedGroup() {
+    UserGroupInformation.createUserForTesting("alice",
+        new String[] {"hadoop"});
+    JobConf conf = jobConfForSubmitUser("alice");
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_GROUPS, "hadoop");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    assertPass(conf);
+  }
+
+  @Test
+  public void testDeniedGroup() {
+    UserGroupInformation.createUserForTesting("bob",
+        new String[] {"other"});
+    JobConf conf = jobConfForSubmitUser("bob");
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_GROUPS, "hadoop");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    assertDenied(conf);
+  }
+
+  @Test
+  public void testAllowedGroupMultipleEntries() {
+    UserGroupInformation.createUserForTesting("alice",
+        new String[] {"data-team"});
+    JobConf conf = jobConfForSubmitUser("alice");
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_GROUPS, "hadoop", "data-team");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    assertPass(conf);
+  }
+
+  @Test
+  public void testAllowedUserOverridesGroups() {
+    UserGroupInformation.createUserForTesting("alice", new String[] {});
+    JobConf conf = jobConfForSubmitUser("alice");
+    conf.setBoolean(MRConfig.MAPREDUCE_TASK_SECURITY_ENABLED, true);
+    conf.setStrings(MRConfig.SECURITY_DENIED_TASKS, "org.apache.hadoop.streaming");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_USERS, "alice");
+    conf.setStrings(MRConfig.SECURITY_ALLOWED_GROUPS, "hadoop");
+    conf.set(MRJobConfig.MAP_CLASS_ATTR, "org.apache.hadoop.streaming.PipeMapper");
+    assertPass(conf);
   }
 
   private void assertPass(JobConf conf) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRConfig.java
@@ -222,5 +222,20 @@ public interface MRConfig {
    */
   String SECURITY_ALLOWED_USERS = "mapreduce.security.allowed-users";
   String[] DEFAULT_SECURITY_ALLOWED_USERS = {};
+
+  /**
+   * MapReduce Task-Level Security Enforcement: Allowed Groups
+   *
+   * Group names whose members may bypass the deny list in {@link #SECURITY_DENIED_TASKS}.
+   * Same idea as {@link #SECURITY_ALLOWED_USERS}, but the AM checks group membership after
+   * the user list. Groups come from the cluster group mapping for the submitter, not from
+   * the job configuration. Names must match that mapping exactly (spelling and case).
+   *
+   * Property type: list of group names
+   * Default: empty (no bypass by group)
+   * Example: hadoop,hue
+   */
+  String SECURITY_ALLOWED_GROUPS = "mapreduce.security.allowed-groups";
+  String[] DEFAULT_SECURITY_ALLOWED_GROUPS = {};
 }
-  
+

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -2322,4 +2322,16 @@
     </description>
   </property>
 
+  <property>
+    <name>mapreduce.security.allowed-groups</name>
+    <value></value>
+    <description>
+      A comma-separated list of allowed group names. If the submitting user belongs to one of
+      these groups, the deny-list (mapreduce.security.denied-tasks) is ignored for their tasks,
+      just like mapreduce.security.allowed-users. This list is evaluated after the allowed-users
+      list, and group membership is determined by an exact name match via the Hadoop groups
+      provider.
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
…-level security.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[MAPREDUCE-7523](https://issues.apache.org/jira/browse/MAPREDUCE-7523) introduced mapreduce.security.denied-tasks: a single, global list of disallowed class name prefixes applied to values of keys listed in mapreduce.security.property-domain. By default the policy is not per-user or per-group—the same rules apply to every submitter until an exception is configured. mapreduce.security.allowed-users already provides a per-user bypass of that deny list.

This work adds mapreduce.security.allowed-groups: a per-group bypass using the submitter’s resolved group names from the cluster’s Hadoop group mapping (UserGroupInformation.getGroupsSet() for that user).

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html