### PR TITLE
HDFS-17877. DatanodeID.updateRegInfo() does not update hostNameBytes …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeID.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeID.java
@@ -302,6 +302,7 @@ public class DatanodeID implements Comparable<DatanodeID> {
     setIpAndXferPort(nodeReg.getIpAddr(), nodeReg.getIpAddrBytes(),
         nodeReg.getXferPort());
     hostName = nodeReg.getHostName();
+    hostNameBytes = nodeReg.getHostNameBytes();
     peerHostName = nodeReg.getPeerHostName();
     infoPort = nodeReg.getInfoPort();
     infoSecurePort = nodeReg.getInfoSecurePort();

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/protocol/TestDatanodeID.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/protocol/TestDatanodeID.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestDatanodeID {
+
+  @Test
+  public void testUpdateRegInfoUpdatesHostNameBytes() {
+    DatanodeID original = new DatanodeID("1.2.3.4", "host1-dc2",
+        "uuid-1", 9866, 9864, 9865, 9867);
+
+    DatanodeID updated = new DatanodeID("1.2.3.4", "host1-dc2.example.com",
+        "uuid-1", 9866, 9864, 9865, 9867);
+
+    original.updateRegInfo(updated);
+    assertEquals("host1-dc2.example.com", original.getHostName());
+    assertEquals("host1-dc2.example.com",
+        original.getHostNameBytes().toStringUtf8());
+  }
+}


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

DataNodeID.updateRegInfo() updates hostName but misses hostNameBytes.

Since PBHelperClient.convert(DatanodeID) uses getHostNameBytes() for protobuf
serialization, clients end up receiving the stale hostname from before the
re-registration.

This becomes a real problem when a DataNode first registers with a PQDN and
later re-registers with a FQDN. With dfs.client.use.datanode.hostname=true,
the client tries to connect using the old PQDN and fails with
UnknownHostException.

The fix is to add hostNameBytes = nodeReg.getHostNameBytes() in updateRegInfo(),
same as how setIpAndXferPort() already handles ipAddr/ipAddrBytes together

In my environment, I use configurations as follows:

```
dfs.client.use.datanode.hostname=true
hadoop.security.token.service.use_ip=false
```

I got an UnknownHostException while reproducing this issue.
(hostname, IP address, and username are anonymized for privacy)

- `datanode001` should be `datanode001.example.com` as FQDN, not PQDN.
- I stopped the DataNode for approximately 10 minutes and 30 seconds (2 × dfs.namenode.heartbeat.recheck-interval + 10 × dfs.heartbeat.interval), so that it would be recognized as dead by the NameNode. After that, I restarted the DataNode, and also restarted both the active and standby NameNodes. After these steps, the issue was resolved.

```
$ HADOOP_ROOT_LOGGER=DEBUG,console yarn logs -applicationId application_1763013060073_51480 > application_1763013060073_51480.txt

26/01/29 18:42:09 DEBUG ipc.Client: IPC Client (307400933) connection to namenode001.example.com/10.1.1.2:9020 from eubnara@EXAMPLE.COM sending #138 org.apache.hadoop.hdfs.protocol.ClientProtocol.getFileInfo
26/01/29 18:42:09 DEBUG ipc.Client: IPC Client (307400933) connection to namenode001.example.com/10.1.1.2:9020 from eubnara@EXAMPLE.COM got value #138
26/01/29 18:42:09 DEBUG ipc.ProtobufRpcEngine2: Call: getFileInfo took 1ms
26/01/29 18:42:09 DEBUG hdfs.DFSClient: Connecting to datanode datanode001:9011
26/01/29 18:42:09 DEBUG impl.BlockReaderFactory: Block read failed. Getting remote block reader using TCP
java.io.IOException: Unresolved host: datanode001:9011
        at org.apache.hadoop.hdfs.DFSUtilClient.isLocalAddress(DFSUtilClient.java:640)
        at org.apache.hadoop.hdfs.shortcircuit.DomainSocketFactory.getPathInfo(DomainSocketFactory.java:152)
        at org.apache.hadoop.hdfs.client.impl.BlockReaderFactory.getBlockReaderLocal(BlockReaderFactory.java:472)
        at org.apache.hadoop.hdfs.client.impl.BlockReaderFactory.build(BlockReaderFactory.java:360)
        at org.apache.hadoop.hdfs.DFSInputStream.getBlockReader(DFSInputStream.java:755)
        at org.apache.hadoop.hdfs.DFSInputStream.blockSeekTo(DFSInputStream.java:685)
        at org.apache.hadoop.hdfs.DFSInputStream.readWithStrategy(DFSInputStream.java:884)
        at org.apache.hadoop.hdfs.DFSInputStream.read(DFSInputStream.java:957)
        at java.io.DataInputStream.readFully(DataInputStream.java:195)
        at java.io.DataInputStream.readLong(DataInputStream.java:416)
        at org.apache.hadoop.io.file.tfile.BCFile$Reader.<init>(BCFile.java:626)
        at org.apache.hadoop.io.file.tfile.TFile$Reader.<init>(TFile.java:804)
        at org.apache.hadoop.yarn.logaggregation.AggregatedLogFormat$LogReader.<init>(AggregatedLogFormat.java:581)
        at org.apache.hadoop.yarn.logaggregation.filecontroller.tfile.LogAggregationTFileController.readAggregatedLogs(LogAggregationTFileController.java:196)
        at org.apache.hadoop.yarn.logaggregation.LogCLIHelpers.dumpAllContainersLogs(LogCLIHelpers.java:244)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.fetchApplicationLogs(LogsCLI.java:1185)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.runCommand(LogsCLI.java:374)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.run(LogsCLI.java:139)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.main(LogsCLI.java:403)
26/01/29 18:42:09 WARN impl.BlockReaderFactory: I/O error constructing remote block reader.
java.net.UnknownHostException: datanode001:9011
        at org.apache.hadoop.net.NetUtils.connect(NetUtils.java:591)
        at org.apache.hadoop.hdfs.DFSClient.newConnectedPeer(DFSClient.java:3033)
        at org.apache.hadoop.hdfs.client.impl.BlockReaderFactory.nextTcpPeer(BlockReaderFactory.java:829)
        at org.apache.hadoop.hdfs.client.impl.BlockReaderFactory.getRemoteBlockReaderFromTcp(BlockReaderFactory.java:754)
        at org.apache.hadoop.hdfs.client.impl.BlockReaderFactory.build(BlockReaderFactory.java:381)
        at org.apache.hadoop.hdfs.DFSInputStream.getBlockReader(DFSInputStream.java:755)
        at org.apache.hadoop.hdfs.DFSInputStream.blockSeekTo(DFSInputStream.java:685)
        at org.apache.hadoop.hdfs.DFSInputStream.readWithStrategy(DFSInputStream.java:884)
        at org.apache.hadoop.hdfs.DFSInputStream.read(DFSInputStream.java:957)
        at java.io.DataInputStream.readFully(DataInputStream.java:195)
        at java.io.DataInputStream.readLong(DataInputStream.java:416)
        at org.apache.hadoop.io.file.tfile.BCFile$Reader.<init>(BCFile.java:626)
        at org.apache.hadoop.io.file.tfile.TFile$Reader.<init>(TFile.java:804)
        at org.apache.hadoop.yarn.logaggregation.AggregatedLogFormat$LogReader.<init>(AggregatedLogFormat.java:581)
        at org.apache.hadoop.yarn.logaggregation.filecontroller.tfile.LogAggregationTFileController.readAggregatedLogs(LogAggregationTFileController.java:196)
        at org.apache.hadoop.yarn.logaggregation.LogCLIHelpers.dumpAllContainersLogs(LogCLIHelpers.java:244)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.fetchApplicationLogs(LogsCLI.java:1185)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.runCommand(LogsCLI.java:374)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.run(LogsCLI.java:139)
        at org.apache.hadoop.yarn.client.cli.LogsCLI.main(LogsCLI.java:403)
```


### How was this patch tested?

- manual test on the private cluster
- add an unit test


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html