### PR TITLE
HDFS-17922 rename2 in the router asynchronous RPC is missing an async path

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncClientProtocol.java
@@ -288,6 +288,7 @@ public class RouterAsyncClientProtocol extends RouterClientProtocol {
     RemoteParam dstParam = getRenameDestinations(locs, dstLocations);
     if (locs.isEmpty()) {
       rbfRename.routerFedRename(src, dst, srcLocations, dstLocations);
+      asyncComplete(null);
       return;
     }
     RemoteMethod method = new RemoteMethod("rename2",

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRenameBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRenameBase.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.server.federation.fairness.RouterAsyncRpcFairnessPolicyController;
+import org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessPolicyController;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MockResolver;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
@@ -64,6 +66,10 @@ public class TestRouterFederationRenameBase {
   private static MiniRouterDFSCluster cluster;
 
   public static void globalSetUp() throws Exception {
+    globalSetUp(false);
+  }
+
+  public static void globalSetUp(boolean enableAsyncRpc) throws Exception {
     Configuration namenodeConf = new Configuration();
     namenodeConf.setBoolean(DFSConfigKeys.HADOOP_CALLER_CONTEXT_ENABLED_KEY,
         true);
@@ -98,6 +104,14 @@ public class TestRouterFederationRenameBase {
     routerConf.setBoolean(DFS_PERMISSIONS_ENABLED_KEY, true);
     routerConf.set(CommonConfigurationKeys.HADOOP_SECURITY_GROUP_MAPPING,
         TestRouterFederationRename.MockGroupsMapping.class.getName());
+    if (enableAsyncRpc) {
+      routerConf.setBoolean(RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY, true);
+      routerConf.setClass(
+          RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
+          RouterAsyncRpcFairnessPolicyController.class,
+          RouterRpcFairnessPolicyController.class);
+      routerConf.setInt(RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 2);
+    }
     cluster.addRouterOverrides(routerConf);
     cluster.startRouters();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncFederationRename.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncFederationRename.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router.async;
+
+import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verifyFileExists;
+import static org.apache.hadoop.test.GenericTestUtils.getMethodName;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSClient;
+import org.apache.hadoop.hdfs.protocol.ClientProtocol;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
+import org.apache.hadoop.hdfs.server.federation.router.TestRouterFederationRenameBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests router federation rename with async RPC enabled.
+ */
+public class TestRouterAsyncFederationRename
+    extends TestRouterFederationRenameBase {
+
+  private RouterContext router;
+  private FileSystem routerFS;
+  private MiniRouterDFSCluster cluster;
+
+  @BeforeAll
+  public static void before() throws Exception {
+    globalSetUp(true);
+  }
+
+  @AfterAll
+  public static void after() {
+    tearDown();
+  }
+
+  @BeforeEach
+  public void testSetup() throws Exception {
+    setup();
+    router = getRouterContext();
+    routerFS = getRouterFileSystem();
+    cluster = getCluster();
+  }
+
+  @Test
+  @Timeout(value = 60)
+  public void testAsyncRbfRename2() throws Exception {
+    List<String> nss = cluster.getNameservices();
+    String ns0 = nss.get(0);
+    String ns1 = nss.get(1);
+
+    String dir = cluster.getFederatedTestDirectoryForNS(ns0) + "/"
+        + getMethodName();
+    String renamedDir = cluster.getFederatedTestDirectoryForNS(ns1) + "/"
+        + getMethodName();
+
+    createDir(routerFS, dir);
+    try {
+      DFSClient client = router.getClient();
+      ClientProtocol clientProtocol = client.getNamenode();
+      clientProtocol.rename2(dir, renamedDir);
+
+      assertFalse(verifyFileExists(routerFS, dir));
+      assertTrue(verifyFileExists(routerFS, renamedDir + "/file"));
+    } finally {
+      FileContext fileContext = router.getFileContext();
+      fileContext.delete(new Path(dir), true);
+      fileContext.delete(new Path(renamedDir), true);
+    }
+  }
+}


### PR DESCRIPTION
### Description of PR

JIRA: [HDFS-17922](https://issues.apache.org/jira/browse/HDFS-17922)

In RouterAsyncClientProtocol:rename2, there is a path that returns synchronously if we have empty locations `if (locs.isEmpty)`.
```
@Override
  public void rename2(
      final String src, final String dst,
      final Options.Rename... options) throws IOException {
    ...
    if (locs.isEmpty()) {
      rbfRename.routerFedRename(src, dst, srcLocations, dstLocations);
      // Missing async handling
      return;
    }
    ...
    asyncApply((AsyncApplyFunction<Boolean, Boolean>) isMultiDestDirectory -> {
      if (isMultiDestDirectory) {
        ...
        rpcClient.invokeConcurrent(locs, method);
      } else {
        rpcClient.invokeSequential(locs, method, null, null);
      }
    });
  }
```
There are other paths that behave similarly, such as msync()
```
@Override
  public void msync() throws IOException {
    rpcServer.checkOperation(NameNode.OperationCategory.READ, true);
    ...
    if (namespacesEligibleForObserverReads.isEmpty()) {
      asyncCompleteWith(CompletableFuture.completedFuture(null));
      return;
    }
    rpcClient.invokeConcurrent(namespacesEligibleForObserverReads, method);
  } 
```

We propose to add a patch to add `asyncComplete(null);` before the return.

### How was this patch tested?
```
mvn -am -pl hadoop-hdfs-project/hadoop-hdfs-rbf -Dtest=TestRouterAsyncFederationRename test
```