### PR TITLE
HDFS-17920. Eliminate possible infinite loop from testShutdown()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDiskError.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDiskError.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -53,6 +54,7 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.DataChecksum;
+import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,10 +120,10 @@ public class TestDiskError {
 
       // create files and make sure that first datanode will be down
       DataNode dn = cluster.getDataNodes().get(dnIndex);
-      long deadline = System.currentTimeMillis() + 60000;
+      long deadline = Time.monotonicNow() + 60000;
       for (int i=0; dn.isDatanodeUp(); i++) {
-        if (System.currentTimeMillis() > deadline) {
-            org.junit.jupiter.api.Assertions.fail("DataNode stayed UP for 60s despite Disk Errors.");
+        if (Time.monotonicNow() > deadline) {
+            fail("DataNode stayed UP for 60s despite Disk Errors.");
         }
         Path fileName = new Path("/test.txt"+i);
         DFSTestUtil.createFile(fs, fileName, 1024, (short)2, 1L);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDiskError.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDiskError.java
@@ -118,11 +118,16 @@ public class TestDiskError {
 
       // create files and make sure that first datanode will be down
       DataNode dn = cluster.getDataNodes().get(dnIndex);
+      long deadline = System.currentTimeMillis() + 60000;
       for (int i=0; dn.isDatanodeUp(); i++) {
+        if (System.currentTimeMillis() > deadline) {
+            org.junit.jupiter.api.Assertions.fail("DataNode stayed UP for 60s despite Disk Errors.");
+        }
         Path fileName = new Path("/test.txt"+i);
         DFSTestUtil.createFile(fs, fileName, 1024, (short)2, 1L);
         DFSTestUtil.waitReplication(fs, fileName, (short)2);
         fs.delete(fileName, true);
+        Thread.sleep(200);
       }
     } finally {
       // restore its old permission


### PR DESCRIPTION
### Description of PR
The test TestDiskError.testShutdown can enter an infinite loop if dn.isDatanodeUp() fails to evaluate to true. Because there is no explicit timeout configured for this loop, it runs indefinitely. Inside the loop, the file creation, replication, and deletion operations execute incredibly fast. If the loop runs uninterrupted, it generates a massive volume of log entries in a short period. Consequently, if the exit condition is never met, the test will continuously write to the logs until the host storage runs completely out of space, which is ultimately what crashes the test execution.