### PR TITLE
HADOOP-19891: update cloud connector testing requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,11 @@
 
 ### For code changes:
 
-- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
-- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
+- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
+- [ ] Object storage: Have the integration tests been executed and the endpoint
+      declared according to the connector-specific documentation? *Note: Automated CI
+      testing doesn't cover all cases so manual testing with cloud storage is still
+      required.*
 - [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
 - [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -25,15 +25,16 @@ convention `Test*.java`.  Integration tests follow the naming convention
 
 ## <a name="policy"></a> Policy for submitting patches which affect the `hadoop-aws` module.
 
-The Apache Jenkins infrastructure does not run any S3 integration tests,
-due to the need to keep credentials secure.
+The Apache Jenkins infrastructure runs a limited set of S3 integration tests
+with mock implementations of S3. Actual S3 testing is currently limited by
+infrastructure costs and the need to keep credentials secure.
 
 ### The submitter of any patch is required to run all the integration tests and declare which S3 region/implementation they used.
 
 This is important: **patches which do not include this declaration will be ignored**
 
 This policy has proven to be the only mechanism to guarantee full regression
-testing of code changes. Why the declaration of region? Two reasons
+testing of code changes. Why the declaration of region? Two reasons:
 
 1. It helps us identify regressions which only surface against specific endpoints
 or third-party implementations of the S3 protocol.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Now that we have some S3A integration testing in CI, update PR template and
hadoop-aws testing doc. The changes clarify that manual testing is still
required.

### How was this patch tested?

Documentation only: viewed rendered markdown.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [na] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [na] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [na] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
