### PR TITLE
YARN-11964: Resource.castToIntSafely() should clamp negative values to 0

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/Resource.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/Resource.java
@@ -513,13 +513,17 @@ public abstract class Resource implements Comparable<Resource> {
   }
 
   /**
-   * Convert long to int for a resource value safely. This method assumes
-   * resource value is positive.
+   * Convert long to int for a resource value safely. Negative values are
+   * clamped to 0; values exceeding Integer.MAX_VALUE are clamped to
+   * Integer.MAX_VALUE.
    *
    * @param value long resource value
    * @return int resource value
    */
   protected static int castToIntSafely(long value) {
+    if (value < 0) {
+      return 0;
+    }
     if (value > Integer.MAX_VALUE) {
       return Integer.MAX_VALUE;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/records/TestResource.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/records/TestResource.java
@@ -43,6 +43,11 @@ class TestResource {
         Resource.castToIntSafely(Long.MAX_VALUE),
         "Cast to Integer.MAX_VALUE if the long is greater than "
             + "Integer.MAX_VALUE");
+
+    assertEquals(0, Resource.castToIntSafely(-1),
+        "Cast to 0 if the long is negative");
+    assertEquals(0, Resource.castToIntSafely(Long.MIN_VALUE),
+        "Cast to 0 if the long is negative");
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Resource.castToIntSafely() only guarded against positive overflow (clamping values > Integer.MAX_VALUE to Integer.MAX_VALUE), but passed negative values through unchanged. The method's Javadoc stated "This method assumes resource value is positive", however YARN RM can transiently return negative available resources (e.g. due to overload or node failures), violating this assumption.

This patch adds a guard that clamps values below 0 to 0, consistent with the existing upper-bound clamping behavior.

### How was this patch tested?
Existing unit tests in TestResource pass.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by Claude (Anthropic)"
- [x] My use of AI contributions follows the ASF legal policy
