### PR TITLE
HADOOP-19899. Fix sleep time in RetryInvocationHandler

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java
@@ -132,7 +132,7 @@ public class RetryInvocationHandler<T> implements RpcInvocationHandler {
           callId, retryInfo, waitTime);
       if (waitTime != null && waitTime > 0) {
         try {
-          Thread.sleep(retryInfo.delay);
+          Thread.sleep(waitTime);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sleep period in `RetryInvocationHandler` should be `waitTime`, not `delay`.

1. `RetryInfo.retryTime` is calculated when it is created:
    https://github.com/apache/hadoop/blob/71d216d8c80e7e2682471a2b9819c36a1558033d/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java#L252-L253
2. `waitTime` is calculated before `sleep` as:
    https://github.com/apache/hadoop/blob/71d216d8c80e7e2682471a2b9819c36a1558033d/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java#L84-L85
3. but then original `RetryInfo.delay` is used for actual sleep time:
    https://github.com/apache/hadoop/blob/71d216d8c80e7e2682471a2b9819c36a1558033d/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryInvocationHandler.java#L130-L135

https://issues.apache.org/jira/browse/HADOOP-19899

## How was this patch tested?

https://github.com/adoroszlai/hadoop/actions/runs/26225351328