### PR TITLE
HADOOP-19901: Release checksum buffers after vectored read verification in ChecksumFileSystem

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -496,6 +496,7 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
       sums.readVectored(checksumRanges, allocate, release);
       datas.readVectored(dataRanges, allocate, release);
       for(CombinedFileRange checksumRange: checksumRanges) {
+        List<CompletableFuture<ByteBuffer>> verifications = new ArrayList<>();
         for(FileRange dataRange: checksumRange.getUnderlying()) {
           // when we have both the ranges, validate the checksum
           CompletableFuture<ByteBuffer> result =
@@ -503,12 +504,18 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
                   (sumBuffer, dataBuffer) ->
                       checkBytes(sumBuffer, checksumRange.getOffset(),
                           dataBuffer, dataRange.getOffset(), bytesPerSum, file));
+          verifications.add(result);
           // Now, slice the read data range to the user's ranges
           for(FileRange original: ((CombinedFileRange) dataRange).getUnderlying()) {
             original.setData(result.thenApply(
                 (b) -> VectoredReadUtils.sliceTo(b, dataRange.getOffset(), original)));
           }
         }
+        // Release the checksum buffer once all verifications using it are complete.
+        // Without this, buffers allocated through the caller's allocator for checksum
+        // data are never released, since the caller has no reference to them.
+        CompletableFuture.allOf(verifications.toArray(new CompletableFuture[0]))
+            .thenRun(() -> release.accept(checksumRange.getData().join()));
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractVectoredRead.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractVectoredRead.java
@@ -18,10 +18,13 @@
 
 package org.apache.hadoop.fs.contract.localfs;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntFunction;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,6 +43,8 @@ import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.io.ElasticByteBufferPool;
+import org.apache.hadoop.io.WeakReferencedElasticByteBufferPool;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.validateVectoredReadResult;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
@@ -194,5 +199,69 @@ public class TestLocalFSContractVectoredRead extends AbstractContractVectoredRea
     AtomicLong bytes = new AtomicLong();
     FileSystem.getAllStatistics().forEach(st -> bytes.addAndGet(st.getBytesRead()));
     return bytes.get();
+  }
+
+  /**
+   * HADOOP-19901: Verify that checksum buffers allocated during vectored read
+   * are released back to the caller's pool after verification completes.
+   * <p>
+   * Before the fix, ChecksumFileSystem would allocate buffers for reading
+   * checksum data but never release them, causing a buffer leak when callers
+   * use a tracking/pooled allocator.
+   * <p>
+   * This test counts the number of times the release consumer is called by the
+   * system (not by the caller) during a vectored read through ChecksumFileSystem.
+   * With the fix, the system must release checksum buffers after verification,
+   * so the release count must be greater than zero before the caller releases
+   * its own data buffers.
+   */
+  @Test
+  public void testChecksumBuffersReleasedAfterVectoredRead() throws Exception {
+    Path testPath = path("checksum_buffer_release_test");
+    LocalFileSystem localFs = (LocalFileSystem) getFileSystem();
+    final int length = 8192;
+    final byte[] dataset = ContractTestUtils.dataset(length, 'a', 32);
+    try (FSDataOutputStream out = localFs.create(testPath, true)) {
+      out.write(dataset);
+    }
+
+    // Count allocations and system-initiated releases
+    AtomicLong allocations = new AtomicLong();
+    AtomicLong systemReleases = new AtomicLong();
+    ElasticByteBufferPool innerPool = new WeakReferencedElasticByteBufferPool();
+    IntFunction<ByteBuffer> allocate = size -> {
+      allocations.incrementAndGet();
+      return innerPool.getBuffer(false, size);
+    };
+
+    List<FileRange> ranges = new ArrayList<>();
+    ranges.add(FileRange.createFileRange(0, 1024));
+    ranges.add(FileRange.createFileRange(4096, 1024));
+
+    CompletableFuture<FSDataInputStream> fis = localFs.openFile(testPath).build();
+    try (FSDataInputStream in = fis.get()) {
+      in.readVectored(ranges, allocate, buffer -> {
+        systemReleases.incrementAndGet();
+        innerPool.putBuffer(buffer);
+      });
+      // Wait for all data to arrive
+      for (FileRange range : ranges) {
+        range.getData().get(5, TimeUnit.SECONDS);
+      }
+      // Validate the data is correct
+      validateVectoredReadResult(ranges, dataset, 0);
+    }
+    // Allow async thenRun release to complete
+    Thread.sleep(200);
+
+    // The system must have allocated buffers for both data and checksums.
+    // With our fix, the checksum buffers are released by the system after
+    // verification. Before the fix, systemReleases would be 0.
+    assertThat(allocations.get())
+        .describedAs("Total allocations (data + checksum buffers)")
+        .isGreaterThan(ranges.size());
+    assertThat(systemReleases.get())
+        .describedAs("System-initiated releases (should include checksum buffers)")
+        .isGreaterThan(0);
   }
 }


### PR DESCRIPTION
## Description

`ChecksumFileSystem.readVectored()` allocates buffers for both data ranges and checksum ranges through the caller's allocator (`IntFunction<ByteBuffer>`). After checksum verification completes, the checksum buffers were never released because:

1. The caller has no reference to checksum buffers (only data range results are visible)
2. The system did not call the `release` consumer on them

This causes buffer leaks when callers use a tracking or pooled allocator. This bug was discovered while working on Apache Parquet's `TrackingByteBufferAllocator`, which detected unreleased buffers accumulating during vectored reads through `ChecksumFileSystem`.

## Root Cause

In `ChecksumFileSystem.ChecksumFSInputChecker.readVectored()`, checksum ranges are read via `sums.readVectored(checksumRanges, allocate, release)`. The checksum buffers are used in `thenCombineAsync` calls for verification, but after verification completes, no code released them back to the caller's pool.

A single checksum range can cover multiple data ranges, so the checksum buffer is shared across multiple `thenCombineAsync` calls — it must only be released once, after ALL verifications using it are complete.

## Fix

After collecting all verification futures for a checksum range, use `CompletableFuture.allOf(verifications).thenRun(...)` to release the checksum buffer exactly once after all verifications complete:

```java
CompletableFuture.allOf(verifications.toArray(new CompletableFuture[0]))
    .thenRun(() -> release.accept(checksumRange.getData().join()));
```

This ensures:
- Exactly-once release (not once per data range that shares the checksum buffer)
- Release happens only after the buffer is no longer in use
- Works correctly with both the 2-arg API (no-op release) and the 3-arg API

## Testing

Added `testChecksumBuffersReleasedAfterVectoredRead()` to `TestLocalFSContractVectoredRead`:
- Uses a counting allocator/release pair to track buffer lifecycle
- Performs a vectored read through `LocalFileSystem` (which uses `ChecksumFileSystem`)
- Asserts that the system calls the release consumer at least once for internal buffers
- Confirmed the test **fails without the fix** (0 system-initiated releases) and **passes with it**

All 54 existing vectored read contract tests continue to pass.

## JIRA

https://issues.apache.org/jira/browse/HADOOP-19901