### PR TITLE
HDFS-17926. Automatically create home directory for users

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1882,6 +1882,15 @@ public class FSDirectory implements Closeable {
     }
   }
 
+  FSPermissionChecker getPermissionChecker(UserGroupInformation caller)
+      throws AccessControlException {
+    try {
+      return getPermissionChecker(fsOwnerShortUserName, supergroup, caller);
+    } catch (IOException e) {
+      throw new AccessControlException(e);
+    }
+  }
+
   @VisibleForTesting
   FSPermissionChecker getPermissionChecker(String fsOwner, String superGroup,
       UserGroupInformation ugi) throws AccessControlException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2185,10 +2185,15 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   void setOwner(String src, String username, String group)
       throws IOException {
+    setOwner(src, username, group, NameNode.getRemoteUser());
+  }
+
+  void setOwner(String src, String username, String group, UserGroupInformation caller)
+      throws IOException {
     final String operationName = "setOwner";
     FileStatus auditStat = null;
     checkOperation(OperationCategory.WRITE);
-    final FSPermissionChecker pc = getPermissionChecker();
+    final FSPermissionChecker pc = getPermissionChecker(caller);
     FSPermissionChecker.setOperationType(operationName);
     try {
       writeLock(RwLockMode.FS);
@@ -3453,6 +3458,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return dir.getPermissionChecker();
   }
 
+  FSPermissionChecker getPermissionChecker(UserGroupInformation caller)
+      throws AccessControlException {
+    return dir.getPermissionChecker(caller);
+  }
+
   /**
    * Remove leases and inodes related to a given path
    * @param removedUCFiles INodes whose leases need to be released
@@ -3562,10 +3572,15 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   boolean mkdirs(String src, PermissionStatus permissions,
       boolean createParent) throws IOException {
+    return mkdirs(src, permissions, createParent, NameNode.getRemoteUser());
+  }
+
+  boolean mkdirs(String src, PermissionStatus permissions,
+      boolean createParent, UserGroupInformation caller) throws IOException {
     final String operationName = "mkdirs";
     FileStatus auditStat = null;
     checkOperation(OperationCategory.WRITE);
-    final FSPermissionChecker pc = getPermissionChecker();
+    final FSPermissionChecker pc = getPermissionChecker(caller);
     FSPermissionChecker.setOperationType(operationName);
     try {
       writeLock(RwLockMode.FS);
@@ -3668,6 +3683,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   void setQuota(String src, long nsQuota, long ssQuota, StorageType type)
       throws IOException {
+    setQuota(src, nsQuota, ssQuota, type, NameNode.getRemoteUser());
+  }
+
+  void setQuota(String src, long nsQuota, long ssQuota, StorageType type,
+      UserGroupInformation caller) throws IOException {
     if (type != null) {
       requireEffectiveLayoutVersionForFeature(Feature.QUOTA_BY_STORAGE_TYPE);
     }
@@ -3676,10 +3696,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     }
     checkOperation(OperationCategory.WRITE);
     final String operationName = getQuotaCommand(nsQuota, ssQuota);
-    final FSPermissionChecker pc = getPermissionChecker();
+    final FSPermissionChecker pc = getPermissionChecker(caller);
     FSPermissionChecker.setOperationType(operationName);
     if(!allowOwnerSetQuota) {
-      checkSuperuserPrivilege(operationName, src);
+      checkSuperuserPrivilege(pc, operationName, src);
     }
     try {
       // Need to compute the curren space usage
@@ -9160,9 +9180,16 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   void checkSuperuserPrivilege(String operationName, String path)
       throws IOException {
     if (isPermissionEnabled) {
+      FSPermissionChecker pc = getPermissionChecker();
+      checkSuperuserPrivilege(pc, operationName, path);
+    }
+  }
+
+  void checkSuperuserPrivilege(FSPermissionChecker pc, String operationName, String path)
+      throws IOException {
+    if (isPermissionEnabled) {
       try {
         FSPermissionChecker.setOperationType(operationName);
-        FSPermissionChecker pc = getPermissionChecker();
         pc.checkSuperuserPrivilege(path);
       } catch(AccessControlException ace){
         logAuditEvent(false, operationName, path);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/HomeDirectoryAutoCreator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/HomeDirectoryAutoCreator.java
@@ -1,0 +1,470 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.permission.PermissionStatus;
+import org.apache.hadoop.hdfs.DFSUtilClient;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.ipc.StandbyException;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableQuantiles;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class HomeDirectoryAutoCreator extends Configured {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(HomeDirectoryAutoCreator.class.getName());
+
+  public static final String QUOTA_DONT_SET = "none";
+
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED = "dfs.namenode.auto.create.user.home.enabled";
+  public static final boolean DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED_DEFAULT = false;
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION = "dfs.namenode.auto.create.user.home.permission";
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION_DEFAULT = "0700";
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_GROUP = "dfs.namenode.auto.create.user.home.group";
+
+  // [group:]nameQuota:spaceQuota,group:nameQuota:spaceQuota,
+  // nameQuota example: 1000000
+  // spaceQuota example: 100T, 100G, 100M
+  // e.g. "100000:10G,services:1000000:100T"
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_QUOTA =  "dfs.namenode.auto.create.user.home.quota";
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_MAX_SIZE =  "dfs.namenode.auto.create.user.home.cacheMaxSize";
+  public static final long  DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_MAX_SIZE_DEFAULT = 1000L;
+  public static final String  DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_TTL =  "dfs.namenode.auto.create.user.home.cacheTTL";
+  public static final long  DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_TTL_DEFAULT = 0;
+
+  private Cache<String, Boolean> cache;
+
+  private NameNode nn;
+  private FSNamesystem namesystem;
+  private boolean enabled;
+  private FsPermission permission;
+  private volatile Map<String,QuotaValue> quotaMap;
+
+  private String defaultGroup;
+  private UserGroupInformation nameNodeUser;
+  private long cacheMaxSize;
+  private long cacheTTLms;
+
+  private HomeDirMetrics metrics;
+
+  public HomeDirectoryAutoCreator(Configuration conf, NameNode namenode) throws IOException {
+    super(conf);
+    this.nn = namenode;
+    this.namesystem = namenode.getNamesystem();
+    this.nameNodeUser = UserGroupInformation.getLoginUser();
+    this.enabled = conf.getBoolean(DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED,
+        DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED_DEFAULT);
+
+    if (enabled) {
+      permission = getHomeDirPermission(conf);
+      quotaMap = QuotaValue.parseQuota(conf.get(DFS_NAMENODE_AUTO_CREATE_USER_HOME_QUOTA));
+
+      defaultGroup = conf.get(DFS_NAMENODE_AUTO_CREATE_USER_HOME_GROUP);
+      cacheMaxSize = conf.getLong(DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_MAX_SIZE,
+          DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_MAX_SIZE_DEFAULT);
+      cacheTTLms = conf.getTimeDuration(DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_TTL,
+          DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_TTL_DEFAULT, TimeUnit.MILLISECONDS);
+      CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder().maximumSize(cacheMaxSize);
+      if (cacheTTLms > 0) {
+        builder.expireAfterWrite(cacheTTLms, TimeUnit.MILLISECONDS);
+      }
+      cache = builder.build();
+      nn.getReconfigurableProperties().add(DFS_NAMENODE_AUTO_CREATE_USER_HOME_QUOTA);
+      this.metrics = HomeDirMetrics.create(HomeDirectoryAutoCreator.class.getSimpleName(), this);
+    }
+    if (enabled) {
+      LOG.info("Auto creation enabled (cacheMaxSize={}, cacheTTLms={}ms)",
+          cacheMaxSize, cacheTTLms);
+    } else {
+      LOG.info("Auto creation for user home directory is disabled");
+    }
+  }
+
+  public Cache<String,Boolean> getCache() {
+    return cache;
+  }
+  public long getCacheMaxSize() {
+    return cacheMaxSize;
+  }
+  public long getCacheTTLms() {
+    return cacheTTLms;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+  private String getGroup(UserGroupInformation ugi) throws IOException {
+    String group = this.defaultGroup;
+    if (org.apache.commons.lang3.StringUtils.isBlank(group)) {
+      try {
+        group = ugi.getPrimaryGroupName();
+      } catch (IOException e) {
+        metrics.failedGetPrimaryGroup.incr();
+        throw e;
+      }
+    }
+    return group;
+  }
+
+  @VisibleForTesting
+  protected FsPermission getHomeDirPermission(Configuration conf) {
+    short octal;
+    String octalString = conf.get(DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION,
+        DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION_DEFAULT);
+    try {
+      octal = Short.parseShort(octalString, 8);
+    } catch (NumberFormatException e) {
+      LOG.warn("Unable to parse user home permission, using default value: {}", e.toString());
+      octal = Short.parseShort(DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION_DEFAULT, 8);
+    }
+    return new FsPermission(octal);
+  }
+
+  public String reconfigUserHomeQuota(final String newVal) {
+    if (!enabled) {
+      return newVal;
+    }
+    Map<String, QuotaValue> newQuotaMap = QuotaValue.parseQuota(newVal);
+    if (newVal != null && !newVal.isEmpty() && newQuotaMap.isEmpty()) {
+      throw new IllegalArgumentException(newVal + " is not valid");
+    }
+    quotaMap = newQuotaMap;
+    LOG.info("RECONFIGURE* changed home directory quota to {}", newVal);
+    return newVal;
+  }
+
+  @VisibleForTesting
+  public static String toNameQuotaString(long quota) {
+    if (quota == HdfsConstants.QUOTA_DONT_SET) {
+      return QuotaValue.QUOTA_DONT_SET;
+    }
+    DecimalFormat df = new DecimalFormat("#,###");
+    return df.format(quota);
+  }
+
+  @VisibleForTesting
+  public static String toSpaceQuotaString(long quota) {
+    if (quota == HdfsConstants.QUOTA_DONT_SET) {
+      return QuotaValue.QUOTA_DONT_SET;
+    }
+    return StringUtils.byteDesc(quota);
+  }
+
+  /*
+   * @return array size is always 2.
+   * index 0 is nameQuota, index 1 is spaceQuota
+   */
+  private long[] getQuotas(String group) {
+    long nameQuota = HdfsConstants.QUOTA_DONT_SET;
+    long spaceQuota = HdfsConstants.QUOTA_DONT_SET;
+    if (quotaMap != null && quotaMap.size() > 0) {
+      QuotaValue quotaValue = quotaMap.get(group);
+      if (quotaValue == null) {
+        quotaValue = quotaMap.get(QuotaValue.DEFAULT_GROUP_KEY);
+      }
+
+      if (quotaValue != null) {
+        nameQuota = quotaValue.getNameQuota();
+        spaceQuota = quotaValue.getSpaceQuota();
+      }
+    }
+    long[] quotas = new long[2];
+    quotas[0] = nameQuota;
+    quotas[1] = spaceQuota;
+    return quotas;
+  }
+
+  private void setupHomeDirectory(String homeDir, UserGroupInformation ugi) throws IOException {
+    String user = ugi.getShortUserName();
+    String group = getGroup(ugi);
+
+    // best-effort initial setup
+    PermissionStatus permStatus = new PermissionStatus(user, group, permission);
+    namesystem.mkdirs(homeDir, permStatus, true, nameNodeUser);
+
+    long[] quotas = getQuotas(group);
+    long nameQuota = quotas[0];
+    long spaceQuota = quotas[1];
+    if (nameQuota != HdfsConstants.QUOTA_DONT_SET || spaceQuota != HdfsConstants.QUOTA_DONT_SET) {
+      namesystem.setQuota(homeDir, nameQuota, spaceQuota, null, nameNodeUser);
+    }
+    namesystem.setOwner(homeDir, user, group, nameNodeUser);
+    LOG.info("Created home directory {} as owner={}:{} nameQuota={} spaceQuota={}",
+        homeDir, user, group, toNameQuotaString(nameQuota), toSpaceQuotaString(spaceQuota));
+  }
+
+  private boolean existsDirectory(String dir) {
+    try {
+      return namesystem.getFSDirectory().getINode(dir, FSDirectory.DirOp.READ) != null;
+    } catch (IOException e) {
+      LOG.debug("existsDirectory failed for {}", dir, e);
+      return false;
+    }
+  }
+
+  public void ensureHomeDirectory(UserGroupInformation ugi) throws StandbyException {
+    if (!enabled){
+      return;
+    }
+    long start = Time.monotonicNowNanos();
+    namesystem.checkOperation(NameNode.OperationCategory.READ);
+    String user = ugi.getShortUserName();
+    try {
+      if (cache.getIfPresent(user) != null) {
+        metrics.cacheHit.incr();
+        return;
+      }
+      metrics.cacheMiss.incr();
+    } finally {
+      long elapsedNanos = Time.monotonicNowNanos() - start;
+      metrics.cacheContainsNanosQuantiles.add(elapsedNanos);
+      if (LOG.isDebugEnabled()) {
+        double elapsedMs = elapsedNanos / 1_000_000.0;
+        LOG.debug("cache contains(user={}) elapsed={}ms", user, String.format("%.6f", elapsedMs));
+      }
+    }
+
+    String homeDir = DFSUtilClient.getHomeDirectory(getConf(), ugi);
+    boolean cacheable = true;
+    try {
+      try {
+        if (existsDirectory(homeDir)) {
+          return;
+        }
+      } finally {
+        long elapsedNanos = Time.monotonicNowNanos() - start;
+        metrics.checkHomeDirNanosQuantiles.add(elapsedNanos);
+        if (LOG.isDebugEnabled()) {
+          double elapsedMs = elapsedNanos / 1_000_000.0;
+          LOG.debug("checked home directory. elapsed={}ms homeDir={} ugi={} cacheSize={}",
+              String.format("%.6f", elapsedMs), homeDir, ugi, cache.size());
+        }
+      }
+
+      namesystem.checkOperation(NameNode.OperationCategory.WRITE);
+      // multiple requests for single user can enter this logic
+      // mkdir always succeeds even if already exists dir, except for permissions, etc issues.
+      // so it does not require lock.
+      setupHomeDirectory(homeDir, ugi);
+      metrics.creatingHomeDirs.incr();
+    } catch (StandbyException e) {
+      cacheable = false;
+      throw e;
+    } catch (IOException e) {
+      final String formatter = "Failed creating home directory." +
+          " Will not attempt to create home directory in future. {}: {}";
+      String errStr = e.toString();
+      if (errStr != null && errStr.contains("There is no primary group")) {
+        LOG.warn(formatter, homeDir, errStr);
+      } else {
+        LOG.error(formatter, homeDir, errStr, e);
+      }
+      metrics.failedCreatingHomeDirs.incr();
+    } finally {
+      if (cacheable) {
+        cache.put(user, Boolean.TRUE);
+      }
+    }
+  }
+
+  public static class QuotaValue {
+    public static final Logger LOG =
+        LoggerFactory.getLogger(QuotaValue.class.getName());
+
+    public static final String QUOTA_DONT_SET = "none";
+    public static final String DEFAULT_GROUP_KEY = "";
+
+    private String group;
+    private long nameQuota;
+    private long spaceQuota;
+
+    public QuotaValue(String group, String strNameQuota, String strSpaceQuota) {
+      this.group = group;
+      setNameQuota(strNameQuota);
+      setSpaceQuota(strSpaceQuota);
+    }
+
+    public String getGroup() {
+      return group;
+    }
+
+    public long getNameQuota() {
+      return nameQuota;
+    }
+
+    public long getSpaceQuota() {
+      return spaceQuota;
+    }
+
+    public void setGroup(String group) {
+      this.group = group;
+    }
+
+    public void setSpaceQuota(String strQuota) {
+      if (QUOTA_DONT_SET.equalsIgnoreCase(strQuota)) {
+        this.spaceQuota = HdfsConstants.QUOTA_DONT_SET;
+      } else {
+        try {
+          long quota = StringUtils.TraditionalBinaryPrefix.string2long(strQuota);
+          if (quota < 0) {
+            quota = 0L;
+          }
+          this.spaceQuota = quota;
+        } catch (IllegalArgumentException e) {
+          this.spaceQuota = HdfsConstants.QUOTA_DONT_SET;
+        }
+      }
+    }
+
+    public void setNameQuota(String strQuota) {
+      if (QUOTA_DONT_SET.equalsIgnoreCase(strQuota)) {
+        this.nameQuota = HdfsConstants.QUOTA_DONT_SET;
+      } else {
+        try {
+          long quota = StringUtils.TraditionalBinaryPrefix.string2long(strQuota);
+          if (quota <= 0) {
+            // for mkdir home, min quota is 1
+            quota = 1;
+          }
+          this.nameQuota = quota;
+        } catch (IllegalArgumentException e) {
+          this.nameQuota = HdfsConstants.QUOTA_DONT_SET;
+        }
+      }
+    }
+
+    public static Map<String, QuotaValue> parseQuota(String confStr) {
+      LOG.info("parse quota string \"{}\"", confStr);
+
+      Map<String, QuotaValue> quotaMap = new ConcurrentHashMap<>();
+      if (confStr == null || confStr.isEmpty()) {
+        return quotaMap;
+      }
+
+      // [group:]nameQuota:spaceQuota,group:nameQuota:spaceQuota,
+      String[] sp = confStr.split(",");
+      for (String s : sp) {
+        String[] quotas = s.split(":");
+        if (quotas.length != 2 && quotas.length != 3) {
+          LOG.warn("ignored quota string: \"{}\"", s);
+          continue;
+        }
+
+        String group, nameQuota, spaceQuota;
+        if (quotas.length == 3) {
+          group = quotas[0];
+          nameQuota = quotas[1];
+          spaceQuota = quotas[2];
+        } else {
+          group = "";
+          nameQuota = quotas[0];
+          spaceQuota = quotas[1];
+        }
+
+        QuotaValue quotaValue = new QuotaValue(group, nameQuota, spaceQuota);
+        quotaMap.put(group, quotaValue);
+      }
+      LOG.info("quotaMap={}", quotaMap);
+      return quotaMap;
+    }
+  }
+
+  @Metrics(name="HomeDirectory", about="NameNode metrics", context="dfs")
+  public static class HomeDirMetrics {
+
+    private final String name;
+    private final Cache<String, Boolean> cache;
+    private final long cacheMaxSize;
+    private final long cacheTTLms;
+
+    final MetricsRegistry registry = new MetricsRegistry("namenode");
+    // metrics
+    @Metric("Number of creating home directories")
+    MutableCounterLong creatingHomeDirs;
+    @Metric("Number of failed creating home directories")
+    MutableCounterLong failedCreatingHomeDirs;
+    @Metric("Number of failed getting primary group")
+    MutableCounterLong failedGetPrimaryGroup;
+
+    @Metric("Number of user cache size")
+    public long cacheSize(){
+      if (cache == null) {
+        return 0;
+      }
+      return cache.size();
+    }
+    @Metric("Number of user cache max size")
+    public long cacheMaxSize() {
+      return cacheMaxSize;
+    }
+    @Metric("User cache TTL in milliseconds")
+    public long cacheTTLms() {
+      return cacheTTLms;
+    }
+    final MutableQuantiles cacheContainsNanosQuantiles;
+    final MutableQuantiles checkHomeDirNanosQuantiles;
+    @Metric("Number of cache hit")
+    MutableCounterLong cacheHit;
+    @Metric("Number of cache miss")
+    MutableCounterLong cacheMiss;
+
+    public HomeDirMetrics(String name, HomeDirectoryAutoCreator creator) {
+      this.name = name;
+      this.cache = creator.getCache();
+      this.cacheMaxSize = creator.getCacheMaxSize();
+      this.cacheTTLms = creator.getCacheTTLms();
+      cacheContainsNanosQuantiles = registry.newQuantiles("cacheContains60s",
+          "cache contains elapsed in ns", "ops", "latencyNanos", 60);
+      checkHomeDirNanosQuantiles = registry.newQuantiles("checkHomeDir60s",
+          "check home directory elapsed in ns", "ops", "latencyNanos", 60);
+    }
+
+    public void remove() {
+      DefaultMetricsSystem.removeSourceName(name);
+    }
+
+    public static HomeDirMetrics create(String name, HomeDirectoryAutoCreator creator) {
+      final MetricsSystem ms = DefaultMetricsSystem.instance();
+      final HomeDirMetrics metrics = new HomeDirMetrics(name, creator);
+      metrics.remove();
+      return ms.register(name, null,  metrics);
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -2357,6 +2357,8 @@ public class NameNode extends ReconfigurableBase implements
       return reconfCallerContextEnabled(newVal);
     } else if (property.equals(ipcClientRPCBackoffEnable)) {
       return reconfigureIPCBackoffEnabled(newVal);
+    } else if (property.equals(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_QUOTA)) {
+      return rpcServer.getHomeDirectoryAutoCreator().reconfigUserHomeQuota(newVal);
     } else if (property.equals(DFS_STORAGE_POLICY_SATISFIER_MODE_KEY)) {
       return reconfigureSPSModeEvent(newVal, property);
     } else if (property.equals(DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -272,6 +272,8 @@ public class NameNodeRpcServer implements NamenodeProtocols {
 
   private final String defaultECPolicyName;
 
+  private final HomeDirectoryAutoCreator homeDirectoryAutoCreator;
+
   // Users who can override the client info
   private final String[] ipProxyUsers;
 
@@ -555,6 +557,8 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     if (lifelineRpcServer != null) {
       lifelineRpcServer.setTracer(nn.tracer);
     }
+
+    homeDirectoryAutoCreator = new HomeDirectoryAutoCreator(conf, nn);
     int[] auxiliaryPorts =
         conf.getInts(DFS_NAMENODE_RPC_ADDRESS_AUXILIARY_KEY);
     if (auxiliaryPorts != null && auxiliaryPorts.length != 0) {
@@ -634,6 +638,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   @VisibleForTesting
   public InetSocketAddress getRpcAddress() {
     return clientRpcAddress;
+  }
+
+  public HomeDirectoryAutoCreator getHomeDirectoryAutoCreator() {
+    return homeDirectoryAutoCreator;
   }
 
   @VisibleForTesting
@@ -812,6 +820,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
       String storagePolicy)
       throws IOException {
     checkNNStartup();
+    ensureHomeDirectory();
     String clientMachine = getClientMachine();
     stateChangeLog.debug("*DIR* NameNode.create: file {} for {} at {}.",
         src, clientName, clientMachine);
@@ -1168,9 +1177,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public boolean mkdirs(String src, FsPermission masked, boolean createParent)
       throws IOException {
     checkNNStartup();
+    ensureHomeDirectory();
     stateChangeLog.debug("*DIR* NameNode.mkdirs: {}.", src);
     if (!checkPathLength(src)) {
-      throw new IOException("mkdirs: Pathname too long.  Limit " 
+      throw new IOException("mkdirs: Pathname too long.  Limit "
                             + MAX_PATH_LENGTH + " characters, " + MAX_PATH_DEPTH + " levels.");
     }
     return namesystem.mkdirs(src,
@@ -1195,6 +1205,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public DirectoryListing getListing(String src, byte[] startAfter,
       boolean needLocation) throws IOException {
     checkNNStartup();
+    ensureHomeDirectory();
     DirectoryListing files = namesystem.getListing(
         src, startAfter, needLocation);
     if (files != null) {
@@ -1228,6 +1239,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   @Override // ClientProtocol
   public HdfsFileStatus getFileInfo(String src) throws IOException {
     checkNNStartup();
+    ensureHomeDirectory();
     metrics.incrFileInfoOps();
     return namesystem.getFileInfo(src, true, false, false);
   }
@@ -1236,6 +1248,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public HdfsLocatedFileStatus getLocatedFileInfo(String src,
       boolean needBlockToken) throws IOException {
     checkNNStartup();
+    ensureHomeDirectory();
     if (needBlockToken) {
       metrics.incrGetBlockLocations();
     } else {
@@ -2366,6 +2379,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     } finally {
       RetryCache.setState(cacheEntry, success);
     }
+  }
+
+  private void ensureHomeDirectory() throws IOException {
+    homeDirectoryAutoCreator.ensureHomeDirectory(getRemoteUser());
   }
 
   private void checkNNStartup() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHomeDirectoryAutoCreator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHomeDirectoryAutoCreator.java
@@ -1,0 +1,635 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.namenode;
+
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HANDLER_COUNT_KEY;
+
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.LogManager;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.QuotaUsage;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.security.PrivilegedExceptionAction;
+import java.util.Map;
+
+public class TestHomeDirectoryAutoCreator {
+
+  public void callApiGetFileStatus(UserGroupInformation ugi, MiniDFSCluster cluster)
+      throws IOException, InterruptedException {
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        FileSystem fs = cluster.getFileSystem();
+        fs.getFileStatus(new Path("/"));
+        return null;
+      }
+    });
+  }
+
+  public void callApiListStatus(UserGroupInformation ugi, MiniDFSCluster cluster)
+      throws IOException, InterruptedException {
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        FileSystem fs = cluster.getFileSystem();
+        fs.listStatus(new Path("/"));
+        return null;
+      }
+    });
+  }
+
+  public void callApiMkdirs(UserGroupInformation ugi, MiniDFSCluster cluster, Path p)
+      throws IOException, InterruptedException {
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        FileSystem fs = cluster.getFileSystem();
+        fs.mkdirs(p);
+        return null;
+      }
+    });
+  }
+
+  public void callApiCreateFile(UserGroupInformation ugi, MiniDFSCluster cluster, Path p)
+      throws IOException, InterruptedException {
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        FileSystem fs = cluster.getFileSystem();
+        try (FSDataOutputStream out = fs.create(p)){
+          out.writeUTF("hello");
+        }
+        return null;
+      }
+    });
+  }
+
+
+  @Test
+  public void testDisableMakeHomeDir() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user/"));
+
+      assertFalse(dfs.exists(new Path("/user/foo")));
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+      assertFalse(dfs.exists(new Path("/user/foo")));
+
+      NameNodeRpcServer rpcServer = (NameNodeRpcServer) cluster.getNameNode().getRpcServer();
+      assertNull(rpcServer.getHomeDirectoryAutoCreator().getCache());
+
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testEnsureHomeDirForSuperUser() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+
+      // make superuser home during mkdirs()
+      dfs.mkdirs(new Path("/user"));
+      dfs.setPermission(new Path("/user"), new FsPermission(0755));
+
+      // superuser
+      UserGroupInformation superuser = UserGroupInformation.getLoginUser();
+      String superUserHome = "/user/" + superuser.getShortUserName();
+
+      // check exists superuser home as non-superuser
+      UserGroupInformation nonSuperUser =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"foo"});
+      MiniDFSCluster finalCluster = cluster;
+      nonSuperUser.doAs(new PrivilegedExceptionAction<Void>() {
+        @Override
+        public Void run() throws Exception {
+          FileSystem fs = finalCluster.getFileSystem();
+          assertTrue(fs.exists(new Path(superUserHome)));
+          return null;
+        }
+      });
+
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testEnsureHomeDir() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user"));
+      dfs.setPermission(new Path("/user"), new FsPermission(0755));
+
+      // check as superuser
+      assertFalse(dfs.exists(new Path("/user/foo")));
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+
+      Path home = new Path("/user/foo");
+      FileStatus status = dfs.getFileStatus(home);
+      assertNotNull(status);
+      if (status != null) {
+        assertEquals("hello", status.getGroup());
+        assertTrue(status.isDirectory());
+      }
+
+      QuotaUsage usage = dfs.getQuotaUsage(home);
+      assertEquals(-1, usage.getQuota());
+      assertEquals(-1, usage.getSpaceQuota());
+
+
+      // check api to make home
+      assertFalse(dfs.exists(new Path("/user/bar")));
+      fakeUgi = UserGroupInformation.createUserForTesting("bar", new String[]{"users"});
+      callApiListStatus(fakeUgi, cluster);
+      assertTrue(dfs.exists(new Path("/user/bar")));
+
+      assertFalse(dfs.exists(new Path("/user/baz")));
+      fakeUgi = UserGroupInformation.createUserForTesting("baz", new String[]{"users"});
+      callApiMkdirs(fakeUgi, cluster, new Path("/user/baz/dir"));
+      assertTrue(dfs.exists(new Path("/user/baz")));
+      assertTrue(dfs.exists(new Path("/user/baz/dir")));
+
+      FileStatus xs = dfs.getFileStatus(new Path("/user/baz"));
+      assertEquals(700, xs.getPermission().toOctal());
+      assertFalse(dfs.exists(new Path("/user/foobar")));
+      fakeUgi = UserGroupInformation.createUserForTesting("foobar", new String[]{"users"});
+      callApiCreateFile(fakeUgi, cluster, new Path("/user/foobar/file.txt"));
+      assertTrue(dfs.exists(new Path("/user/foobar")));
+      assertTrue(dfs.exists(new Path("/user/foobar/file.txt")));
+
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+
+  @Test
+  public void testEnsureHomeDirWithQuota() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    long spaceQuotaDefault = 0;
+    String strSpaceQuotaDefault = "0";
+    long nameQuotaDefault = 1;
+
+    String groupA = "services";
+    long spaceQuotaGroupA = 2L * 1024 * 1024 * 1024;
+    String strSpaceQuotaGroupA = "2G";
+    long nameQuotaGroupA = 500_000;
+
+    String groupB = "users";
+    long spaceQuotaGroupB = 1L * 1024 * 1024;
+    String strSpaceQuotaGroupB = "1M";
+    long nameQuotaGroupB = 100_000;
+
+    String confQuota = String.format("%s:%s,%s:%s:%s,%s:%s:%s",
+        nameQuotaDefault, strSpaceQuotaDefault,
+        groupA, nameQuotaGroupA, strSpaceQuotaGroupA,
+        groupB, nameQuotaGroupB, strSpaceQuotaGroupB);
+
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_QUOTA, confQuota);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user/"));
+
+      assertFalse(dfs.exists(new Path("/user/foo")));
+      assertFalse(dfs.exists(new Path("/user/bar")));
+      assertFalse(dfs.exists(new Path("/user/baz")));
+      UserGroupInformation foo =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"services"});
+      UserGroupInformation bar =
+          UserGroupInformation.createUserForTesting("bar", new String[]{"users"});
+      UserGroupInformation baz =
+          UserGroupInformation.createUserForTesting("baz", new String[]{"test-users"});
+
+      callApiGetFileStatus(foo, cluster);
+      callApiGetFileStatus(bar, cluster);
+      callApiGetFileStatus(baz, cluster);
+
+
+      // groupA: services
+      Path home = new Path("/user/foo");
+      FileStatus status = dfs.getFileStatus(home);
+      assertNotNull(status);
+      if (status != null) {
+        assertEquals("services", status.getGroup());
+        assertTrue(status.isDirectory());
+
+        QuotaUsage usage = dfs.getQuotaUsage(home);
+        assertEquals(nameQuotaGroupA, usage.getQuota());
+        assertEquals(spaceQuotaGroupA, usage.getSpaceQuota());
+      }
+
+      // groupB: users
+      home = new Path("/user/bar");
+      status = dfs.getFileStatus(home);
+      assertNotNull(status);
+      if (status != null) {
+        assertEquals("users", status.getGroup());
+        assertTrue(status.isDirectory());
+
+        QuotaUsage usage = dfs.getQuotaUsage(home);
+        assertEquals(nameQuotaGroupB, usage.getQuota());
+        assertEquals(spaceQuotaGroupB, usage.getSpaceQuota());
+      }
+
+
+      // default
+      home = new Path("/user/baz");
+      status = dfs.getFileStatus(home);
+      assertNotNull(status);
+      if (status != null) {
+        assertEquals("test-users", status.getGroup());
+        assertTrue(status.isDirectory());
+
+        QuotaUsage usage = dfs.getQuotaUsage(home);
+        assertEquals(nameQuotaDefault, usage.getQuota());
+        assertEquals(spaceQuotaDefault, usage.getSpaceQuota());
+      }
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testEnsureHomeDirWithDefaultGroupAndQuota()
+      throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    long spaceQuota = 3L * 1024 * 1024 * 1024;
+    String strSpaceQuota = "3G";
+    long nameQuota = 1_000_000;
+    String strNameQuota = String.valueOf(nameQuota);
+    String defaultGroup = "world";
+
+    String confQuota = String.format("%s:%s", strNameQuota, strSpaceQuota);
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_QUOTA, confQuota);
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_GROUP, defaultGroup);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user/"));
+
+      assertFalse(dfs.exists(new Path("/user/foo")));
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+
+      Path home = new Path("/user/foo");
+      FileStatus status = dfs.getFileStatus(home);
+      assertNotNull(status);
+      if (status != null) {
+        assertEquals(defaultGroup, status.getGroup());
+        assertTrue(status.isDirectory());
+      }
+
+      QuotaUsage usage = dfs.getQuotaUsage(home);
+      assertEquals(nameQuota, usage.getQuota());
+      assertEquals(spaceQuota, usage.getSpaceQuota());
+
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testEnsureHomeDirWithPermission() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION, "0750");
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user/"));
+
+      assertFalse(dfs.exists(new Path("/user/foo")));
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+
+      Path home = new Path("/user/foo");
+      FileStatus status = dfs.getFileStatus(home);
+
+      assertEquals("rwxr-x---", status.getPermission().toString());
+      assertEquals(750, status.getPermission().toOctal());
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testFailedMakeHomeDirNoPrimaryGroup() throws IOException, InterruptedException {
+
+    PrintStream originalOut = System.out;
+    ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    MiniDFSCluster cluster = null;
+    try {
+      // for capture log output
+      System.setOut(new PrintStream(outContent));
+      LogManager.resetConfiguration();
+      BasicConfigurator.configure();
+
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user"));
+      dfs.setPermission(new Path("/user"), new FsPermission(0755));
+
+      // check as superuser
+      assertFalse(dfs.exists(new Path("/user/foo")));
+
+      // no primary group
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{});
+      callApiGetFileStatus(fakeUgi, cluster);
+      Path home = new Path("/user/foo");
+      assertFalse(dfs.exists(home));
+
+      // retry with primary group
+      fakeUgi = UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+      // already caching. do not retry create home dir
+      assertFalse(dfs.exists(home));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+      // rollback log4j conf
+      System.setOut(originalOut);
+      LogManager.resetConfiguration();
+      BasicConfigurator.configure();
+    }
+
+    String output = outContent.toString();
+    System.out.println(output);
+    assertTrue(output.contains("Failed creating home directory. " +
+        "Will not attempt to create home directory in future. " +
+        "/user/foo: java.io.IOException: There is no primary group for UGI foo"));
+  }
+
+  @Test
+  public void testCacheWithTTL() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_MAX_SIZE, "100");
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_TTL, "2s");
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user"));
+      dfs.setPermission(new Path("/user"), new FsPermission(0755));
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+
+      NameNodeRpcServer rpcServer = (NameNodeRpcServer) cluster.getNameNode().getRpcServer();
+      HomeDirectoryAutoCreator creator = rpcServer.getHomeDirectoryAutoCreator();
+      Cache<String, Boolean> cache = creator.getCache();
+
+      // superuser and foo
+      assertEquals(2, cache.size());
+      assertEquals(100, creator.getCacheMaxSize());
+      assertEquals(2 * 1000, creator.getCacheTTLms());
+      assertNotNull(cache.getIfPresent("foo"));
+      Thread.sleep(1000);
+      assertNotNull(cache.getIfPresent("foo"));
+      Thread.sleep(1000);
+      assertNull(cache.getIfPresent("foo"));
+
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testCacheDisableTTL() throws IOException, InterruptedException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_ENABLED, true);
+    conf.setInt(DFS_NAMENODE_HANDLER_COUNT_KEY, 1);
+
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_MAX_SIZE, "100");
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_CACHE_TTL, "0");
+
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).build();
+      cluster.waitActive();
+
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      dfs.mkdirs(new Path("/user"));
+      dfs.setPermission(new Path("/user"), new FsPermission(0755));
+      UserGroupInformation fakeUgi =
+          UserGroupInformation.createUserForTesting("foo", new String[]{"hello"});
+      callApiGetFileStatus(fakeUgi, cluster);
+
+      NameNodeRpcServer rpcServer = (NameNodeRpcServer) cluster.getNameNode().getRpcServer();
+      HomeDirectoryAutoCreator creator = rpcServer.getHomeDirectoryAutoCreator();
+      Cache<String, Boolean> cache = creator.getCache();
+
+      // superuser and foo
+      assertEquals(2, cache.size());
+      assertEquals(100, creator.getCacheMaxSize());
+      assertEquals(0, creator.getCacheTTLms());
+
+      assertNotNull(cache.getIfPresent("foo"));
+      Thread.sleep(2000);
+      assertNotNull(cache.getIfPresent("foo"));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+
+  @Test
+  public void testToSpaceQuotaString() throws IOException {
+
+    long quota = 3L * 1024 * 1024 * 1024;
+    String strQuota = HomeDirectoryAutoCreator.toSpaceQuotaString(quota);
+    assertEquals("3 GB", strQuota);
+
+    quota = 3L * 1024 * 1024 * 1024 * 1024;
+    strQuota = HomeDirectoryAutoCreator.toSpaceQuotaString(quota);
+    assertEquals("3 TB", strQuota);
+
+    quota = 3L * 1024 * 1024 * 1024 * 1024 * 1024;
+    strQuota = HomeDirectoryAutoCreator.toSpaceQuotaString(quota);
+    assertEquals("3 PB", strQuota);
+
+    quota = 0;
+    strQuota = HomeDirectoryAutoCreator.toSpaceQuotaString(quota);
+    assertEquals("0 B", strQuota);
+  }
+
+  @Test
+  public void testToNameQuotaString() throws IOException {
+    long quota = 1_000_000;
+    String strQuota = HomeDirectoryAutoCreator.toNameQuotaString(quota);
+    assertEquals("1,000,000", strQuota);
+
+    quota = 0;
+    strQuota = HomeDirectoryAutoCreator.toNameQuotaString(quota);
+    assertEquals("0", strQuota);
+  }
+
+  @Test
+  public void testParseQuota() {
+    Map<String, HomeDirectoryAutoCreator.QuotaValue> map =
+        HomeDirectoryAutoCreator.QuotaValue.parseQuota(
+            "1:0,hadoop:none:none,users:1000:1M,hdfs:NONE:NONE");
+    assertEquals(4, map.size());
+    HomeDirectoryAutoCreator.QuotaValue quota = map.get("");
+    assertEquals(1, quota.getNameQuota());
+    assertEquals(0, quota.getSpaceQuota());
+
+    quota = map.get("hadoop");
+    assertEquals(HdfsConstants.QUOTA_DONT_SET, quota.getNameQuota());
+    assertEquals(HdfsConstants.QUOTA_DONT_SET, quota.getSpaceQuota());
+
+    quota = map.get("hdfs");
+    assertEquals(HdfsConstants.QUOTA_DONT_SET, quota.getNameQuota());
+    assertEquals(HdfsConstants.QUOTA_DONT_SET, quota.getSpaceQuota());
+
+    quota = map.get("users");
+    assertEquals(1000, quota.getNameQuota());
+    assertEquals(1 * 1024 * 1024, quota.getSpaceQuota());
+
+    map = HomeDirectoryAutoCreator.QuotaValue.parseQuota(null);
+    assertNotNull(map);
+    assertEquals(0, map.size());
+  }
+
+  @Test
+  public void testGetHomeDirPermission() throws IOException {
+
+    Configuration conf = new Configuration(false);
+    NameNode nn = Mockito.mock(NameNode.class);
+    HomeDirectoryAutoCreator creator = new HomeDirectoryAutoCreator(conf, nn);
+    FsPermission permission = creator.getHomeDirPermission(conf);
+    assertEquals(700, permission.toOctal());
+
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION,
+        "777");
+    permission = creator.getHomeDirPermission(conf);
+    assertEquals(777, permission.toOctal());
+
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION,
+        "0755");
+    permission = creator.getHomeDirPermission(conf);
+    assertEquals(755, permission.toOctal());
+
+    conf.set(HomeDirectoryAutoCreator.DFS_NAMENODE_AUTO_CREATE_USER_HOME_PERMISSION,
+        "invalid_value");
+    permission = creator.getHomeDirPermission(conf);
+    assertEquals(700, permission.toOctal());
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
HDFS-17926

Currently, HDFS does not automatically create a user's home directory (e.g., `/user/<user>`). This requires administrators to manually create home directories, which adds operational overhead and can cause failures for user-facing tools (e.g., MapReduce job submission, Hive, Spark) that assume the home directory exists.

This JIRA tracks the development of automatic home directory creation so that when a user's home directory does not yet exist, HDFS creates it automatically with appropriate ownership (`<username>:<supergroup>`) and permissions (`drwx------`).

**Motivation**:
   - Reduces administrative burden for large multi-tenant clusters
   - Prevents job failures caused by missing home directories
   - Aligns with the behavior expected by higher-level ecosystem tools
 

**Behavior**
  
When dfs.namenode.auto.create.user.home.enabled=true, the NN intercepts
the following RPCs and creates the caller's /user/<short-name> if it does
not yet exist:
  
    create, mkdirs, getListing, getFileInfo, getLocatedFileInfo

`hdfs dfs -ls` and similar commands issue getFileInfo first, so a user's
home directory is created the first time they touch the cluster.

The directory is created with:
   - owner: caller's short username
   - group: caller's primary group (or a configured group if set)
   - permission: configured octal (default 0700)
   - quota: matched against group/user rules from the new quota config

Creation is performed by the NN superuser (not the requesting user)

Results (success and most failures) are cached by short username so that
subsequent RPCs of the same user incur only a HashMap lookup (~0.001ms)
instead of an NN getFileInfo round trip (~0.1ms). 

### How was this patch tested?

This feature was originally developed and added to an internal fork of Apache Hadoop 3.1.2, and has been running in production for over a year.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html