### PR TITLE
HDFS-16739. EC: Reconstruction failed when file has specified Storage…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ErasureCodingWork.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ErasureCodingWork.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdfs.util.StripedBlockUtil;
 import org.apache.hadoop.net.Node;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
@@ -74,7 +75,12 @@ class ErasureCodingWork extends BlockReconstructionWork {
     } else {
       LOG.warn("ErasureCodingWork could not need choose targets for {}", getBlock());
     }
-    setTargets(chosenTargets);
+    if (chosenTargets.length > getAdditionalReplRequired()) {
+      setTargets(Arrays.copyOfRange(chosenTargets, 0, getAdditionalReplRequired()));
+    } else {
+      setTargets(chosenTargets);
+    }
+
   }
 
   /**


### PR DESCRIPTION
…Policy

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
As mentioned in [HDFS-16739](https://issues.apache.org/jira/browse/HDFS-16739), in order to satisfy the storage policy, the length ofchosenTargets may be more than the actual number of blocks that need to be reconstructed. We truncated the chosenTargets array to ensure the reconstruction task could run properly.

### How was this patch tested?
It has been running in production for over a year.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html