### PR TITLE
HADOOP-19900. EC write can fail with ArrayIndexOutOfBoundsException due to CoderUtil emptyChunk resize race

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/CoderUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/CoderUtil.java
@@ -42,15 +42,25 @@ public final class CoderUtil {
    * @return empty chunk of zero bytes
    */
   static byte[] getEmptyChunk(int leastLength) {
-    if (emptyChunk.length >= leastLength) {
-      return emptyChunk; // In most time
+    byte[] chunk = emptyChunk;
+    if (chunk.length >= leastLength) {
+      return chunk; // In most time
     }
 
     synchronized (CoderUtil.class) {
-      emptyChunk = new byte[leastLength];
+      /*
+       * Recheck under the lock: another caller may already have grown the
+       * cache while this caller waited. A larger cached chunk is valid for a
+       * smaller request, so only allocate when the cache is still too small.
+       */
+      chunk = emptyChunk;
+      if (chunk.length < leastLength) {
+        chunk = new byte[leastLength];
+        emptyChunk = chunk;
+      }
     }
 
-    return emptyChunk;
+    return chunk;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestCoderUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestCoderUtil.java
@@ -19,19 +19,41 @@
 package org.apache.hadoop.io.erasurecode.rawcoder;
 
 import org.apache.hadoop.HadoopIllegalArgumentException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test of the utility of raw erasure coder.
  */
 public class TestCoderUtil {
+  private static final int INITIAL_EMPTY_CHUNK_LENGTH = 4096;
+  private static final int SMALL_CHUNK_SIZE = INITIAL_EMPTY_CHUNK_LENGTH + 1;
+  private static final int LARGE_CHUNK_SIZE = SMALL_CHUNK_SIZE * 2;
+
   private final int numInputs = 9;
   private final int chunkSize = 1024;
+
+  @BeforeEach
+  public void resetEmptyChunk() throws Exception {
+    Field emptyChunk = CoderUtil.class.getDeclaredField("emptyChunk");
+    emptyChunk.setAccessible(true);
+    synchronized (CoderUtil.class) {
+      emptyChunk.set(null, new byte[INITIAL_EMPTY_CHUNK_LENGTH]);
+    }
+  }
 
   @Test
   public void testGetEmptyChunk() {
@@ -55,6 +77,36 @@ public class TestCoderUtil {
     CoderUtil.resetBuffer(inputs, 0, numInputs);
     for (int i = 0; i < numInputs; i++) {
       assertEquals(0, inputs[i]);
+    }
+  }
+
+  @Test
+  public void testGetEmptyChunkDoesNotShrinkWhenCacheGrowsConcurrently()
+      throws Exception {
+    AtomicReference<Thread> workerThread = new AtomicReference<>();
+    ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+      Thread thread = new Thread(r, "get-empty-chunk-small");
+      workerThread.set(thread);
+      return thread;
+    });
+
+    try {
+      Future<byte[]> smallChunk;
+      synchronized (CoderUtil.class) {
+        smallChunk = executor.submit(() -> CoderUtil.getEmptyChunk(
+            SMALL_CHUNK_SIZE));
+        waitUntilBlocked(workerThread);
+        assertTrue(CoderUtil.getEmptyChunk(LARGE_CHUNK_SIZE).length
+            >= LARGE_CHUNK_SIZE);
+      }
+
+      assertTrue(smallChunk.get(10, TimeUnit.SECONDS).length
+          >= LARGE_CHUNK_SIZE,
+          "concurrent caller should return the larger chunk already cached");
+      assertTrue(CoderUtil.getEmptyChunk(LARGE_CHUNK_SIZE).length
+          >= LARGE_CHUNK_SIZE, "empty chunk cache should not shrink");
+    } finally {
+      executor.shutdownNow();
     }
   }
 
@@ -123,5 +175,21 @@ public class TestCoderUtil {
       byte[][] inputs = new byte[numInputs][];
       CoderUtil.findFirstValidInput(inputs);
     });
+  }
+
+  private static void waitUntilBlocked(AtomicReference<Thread> threadRef)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (System.nanoTime() < deadline) {
+      Thread thread = threadRef.get();
+      if (thread != null && thread.getState() == Thread.State.BLOCKED) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+
+    Thread thread = threadRef.get();
+    fail("small getEmptyChunk caller did not block on CoderUtil.class; state="
+        + (thread == null ? "not started" : thread.getState()));
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-19900

Contains content generated by Claude Code (Opus 4.7)

### Description of PR

Fix a race in `CoderUtil.getEmptyChunk()` that can cause EC writes to fail with `ArrayIndexOutOfBoundsException` during parity encoding.

This can be hit when multiple EC key output streams in the same client JVM use the Java raw EC encoder concurrently with different encode/reset lengths. Each `ECKeyOutputStream` has its own encoder, but all Java encoders share the static `CoderUtil.emptyChunk` cache. *If native ISA-L is unavailable or not selected*, the Java `RSRawEncoder` clears parity output buffers through `CoderUtil.resetOutputBuffers()`. Under concurrent close/flush paths, especially with partial final stripes of different sizes, one stream can grow the shared zero buffer for a larger encode while another smaller encode races and shrinks it, causing the larger encode’s later `System.arraycopy()` to throw `ArrayIndexOutOfBoundsException`.

For more details, see https://github.com/apache/ozone/pull/10324

### How was this patch tested?

- Added Claude-generated repro test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html