### PR TITLE
HADOOP-19904. HttpServer2 access log does not record the authenticated user

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HadoopJettyAuthentication.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HadoopJettyAuthentication.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.http;
+
+import java.security.Principal;
+import javax.security.auth.Subject;
+import javax.servlet.ServletRequest;
+
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.UserIdentity;
+
+/**
+ * Bridges Hadoop's filter-based authentication to Jetty's native
+ * {@link Authentication} state on the base {@link Request}.
+ *
+ * <p>Hadoop authenticates with servlet filters
+ * ({@link org.apache.hadoop.security.authentication.server.AuthenticationFilter}
+ * and friends). Those filters wrap the {@code HttpServletRequest} so
+ * downstream filters and servlets see the authenticated user via the
+ * standard servlet API. The wrapper, however, only flows through the filter
+ * chain — Jetty observers that run outside the chain
+ * ({@code RequestLogHandler}, {@code StatisticsHandler}, async dispatch,
+ * JMX) all see the base {@link Request}, where {@code getAuthentication()}
+ * stays as {@code NOT_CHECKED} forever. As a result, the {@code %u} token
+ * in Jetty's default access log is logged as {@code -}.
+ *
+ * <p>After {@link #attach}, Jetty's standard API resolves the user from the
+ * base Request, so RequestLog (and anything else that reads from the Jetty
+ * layer) sees it without any Hadoop-specific knowledge.
+ */
+public final class HadoopJettyAuthentication {
+
+  private static final String AUTH_METHOD = "HADOOP";
+
+  private HadoopJettyAuthentication() {
+  }
+
+  /**
+   * Attach {@code userName} to the base Jetty {@link Request} as the
+   * authenticated user. No-op if either argument is {@code null}, or if the
+   * underlying request is not a Jetty {@link Request} (e.g., during tests
+   * with mock requests).
+   */
+  public static void attach(ServletRequest request, String userName) {
+    if (request == null || userName == null) {
+      return;
+    }
+    Request baseRequest = Request.getBaseRequest(request);
+    if (baseRequest == null) {
+      return;
+    }
+    baseRequest.setAuthentication(buildAuthentication(userName));
+  }
+
+  /** Package-private for testing. */
+  static Authentication.User buildAuthentication(String userName) {
+    Principal principal = new HadoopPrincipal(userName);
+    Subject subject = new Subject();
+    subject.getPrincipals().add(principal);
+    subject.setReadOnly();
+
+    UserIdentity identity = new HadoopUserIdentity(subject, principal);
+    return new HadoopAuthenticatedUser(identity);
+  }
+
+  private static final class HadoopPrincipal implements Principal {
+    private final String name;
+
+    HadoopPrincipal(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private static final class HadoopUserIdentity implements UserIdentity {
+    private final Subject subject;
+    private final Principal principal;
+
+    HadoopUserIdentity(Subject subject, Principal principal) {
+      this.subject = subject;
+      this.principal = principal;
+    }
+
+    @Override
+    public Subject getSubject() {
+      return subject;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+      return principal;
+    }
+
+    @Override
+    public boolean isUserInRole(String role, Scope scope) {
+      return false;
+    }
+  }
+
+  private static final class HadoopAuthenticatedUser
+      implements Authentication.User {
+    private final UserIdentity identity;
+
+    HadoopAuthenticatedUser(UserIdentity identity) {
+      this.identity = identity;
+    }
+
+    @Override
+    public String getAuthMethod() {
+      return AUTH_METHOD;
+    }
+
+    @Override
+    public UserIdentity getUserIdentity() {
+      return identity;
+    }
+
+    @Override
+    public boolean isUserInRole(UserIdentity.Scope scope, String role) {
+      return false;
+    }
+
+    @Override
+    public void logout() {
+      // Programmatic logout is not supported by Hadoop filter-based auth.
+    }
+
+    @Override
+    public Authentication logout(ServletRequest request) {
+      return null;
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -828,6 +828,11 @@ public final class HttpServer2 implements FilterContainer {
         c.initFilter(this, conf);
       }
     }
+    // Install last so it sits inside any user-configured auth filter wrap
+    // and can read the resolved user via the standard servlet API.
+    addGlobalFilter("jetty-auth-bridge",
+        JettyAuthBridgeFilter.class.getName(),
+        java.util.Collections.<String, String>emptyMap());
 
     addDefaultServlets(conf);
     addPrometheusServlet(conf);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/JettyAuthBridgeFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/JettyAuthBridgeFilter.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.http;
+
+import java.io.IOException;
+import java.util.Enumeration;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Reads {@link HttpServletRequest#getRemoteUser()} on the request flowing
+ * through the filter chain and forwards the user to
+ * {@link HadoopJettyAuthentication#attach}. This pushes the user onto the
+ * base Jetty Request so that Jetty observers running outside the filter
+ * chain — {@code RequestLogHandler}, {@code StatisticsHandler}, async
+ * dispatch, JMX — can resolve it via the standard servlet / Jetty API
+ * instead of seeing {@code NOT_CHECKED}.
+ *
+ * <p>The bridge does not need to know about Hadoop authentication
+ * mechanisms. Both modes route the user identifier into
+ * {@code getRemoteUser()} via a request wrap before this filter runs:
+ * <ul>
+ *   <li>Secure mode: {@code AuthenticationFilter} validates the Kerberos
+ *       ticket / delegation token and wraps with the authenticated
+ *       principal.</li>
+ *   <li>Insecure mode: {@code PseudoAuthenticationHandler} reads the
+ *       {@code user.name} query parameter, and {@code AuthenticationFilter}
+ *       wraps with that user.</li>
+ * </ul>
+ *
+ * <p>When the request also carries a {@code doAs} query parameter
+ * different from the resolved user, the attached label uses the
+ * Kerberos-principal-style format {@code "<effective>/<real>"} — for
+ * example, {@code "alice/oozie"}. The {@code /} separator keeps the
+ * resulting {@code %u} token a single field for NCSA-style log parsers.
+ *
+ * <p>{@code doAs} authorization itself is performed later by the relevant
+ * servlet code; unauthorized attempts are still logged with the
+ * slash-label alongside the resulting 403, which is useful for audit.
+ *
+ * <p>{@link HttpServer2} installs this filter automatically <em>after</em>
+ * the user-configured authentication filters, so the wrap from upstream
+ * auth filters is visible by the time this one runs.
+ */
+public class JettyAuthBridgeFilter implements Filter {
+
+  /** Canonical Hadoop impersonation parameter; matched case-insensitively. */
+  private static final String DO_AS_PARAM = "doAs";
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response,
+      FilterChain chain) throws IOException, ServletException {
+    if (request instanceof HttpServletRequest) {
+      HttpServletRequest http = (HttpServletRequest) request;
+      String realUser = http.getRemoteUser();
+      if (realUser != null) {
+        String doAs = readDoAs(http);
+        String label = (doAs != null && !doAs.equals(realUser))
+            ? doAs + "/" + realUser
+            : realUser;
+        HadoopJettyAuthentication.attach(request, label);
+      }
+    }
+    chain.doFilter(request, response);
+  }
+
+  /** Case-insensitive {@code doAs} parameter lookup. */
+  private static String readDoAs(HttpServletRequest request) {
+    Enumeration<String> names = request.getParameterNames();
+    while (names.hasMoreElements()) {
+      String name = names.nextElement();
+      if (DO_AS_PARAM.equalsIgnoreCase(name)) {
+        String value = request.getParameter(name);
+        if (value != null && !value.isEmpty()) {
+          return value;
+        }
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void destroy() {
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/DelegationTokenAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/DelegationTokenAuthenticationHandler.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.http.HadoopJettyAuthentication;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
@@ -262,6 +263,19 @@ public abstract class DelegationTokenAuthenticationHandler
                   HttpServletResponse.SC_FORBIDDEN, ex);
               return false;
             }
+          }
+          if (requestUgi != null) {
+            // DT mgmt ops (GETDELEGATIONTOKEN/RENEW/CANCEL) write the
+            // response inline and skip filterChain.doFilter, so the
+            // global JettyAuthBridgeFilter never runs. Attach directly,
+            // matching the bridge's "effective/real" Kerberos
+            // principal-style format for proxy users.
+            String label = requestUgi.getShortUserName();
+            UserGroupInformation real = requestUgi.getRealUser();
+            if (real != null && !real.getShortUserName().equals(label)) {
+              label = label + "/" + real.getShortUserName();
+            }
+            HadoopJettyAuthentication.attach(request, label);
           }
           Map map = null;
           switch (dtOp) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHadoopJettyAuthentication.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHadoopJettyAuthentication.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.http;
+
+import java.security.Principal;
+import javax.security.auth.Subject;
+
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.UserIdentity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHadoopJettyAuthentication {
+
+  @Test
+  public void testBuildAuthenticationProducesUserWithPrincipalName() {
+    Authentication.User auth =
+        HadoopJettyAuthentication.buildAuthentication("alice");
+
+    assertNotNull(auth, "buildAuthentication should return a non-null User");
+    assertEquals("HADOOP", auth.getAuthMethod());
+
+    UserIdentity identity = auth.getUserIdentity();
+    assertNotNull(identity, "UserIdentity should not be null");
+
+    Principal principal = identity.getUserPrincipal();
+    assertNotNull(principal, "Principal should not be null");
+    assertEquals("alice", principal.getName());
+    assertEquals("alice", principal.toString(),
+        "Principal toString should mirror the name");
+  }
+
+  @Test
+  public void testBuildAuthenticationSubjectContainsPrincipal() {
+    Authentication.User auth =
+        HadoopJettyAuthentication.buildAuthentication("bob");
+
+    Subject subject = auth.getUserIdentity().getSubject();
+    assertNotNull(subject, "Subject should not be null");
+    assertTrue(subject.isReadOnly(),
+        "Subject should be read-only to prevent post-attach mutation");
+    assertEquals(1, subject.getPrincipals().size());
+    assertEquals("bob",
+        subject.getPrincipals().iterator().next().getName());
+  }
+
+  @Test
+  public void testBuildAuthenticationUserIsNotInAnyRole() {
+    // We do not propagate roles from Hadoop; the helper must not pretend
+    // the user has any.
+    Authentication.User auth =
+        HadoopJettyAuthentication.buildAuthentication("carol");
+
+    assertFalse(auth.isUserInRole(null, "admin"));
+    assertFalse(auth.getUserIdentity().isUserInRole("admin", null));
+  }
+
+  @Test
+  public void testLogoutIsNoOp() {
+    // Programmatic logout is not supported. Both overloads must be
+    // callable without throwing; an unexpected exception fails the test.
+    Authentication.User auth =
+        HadoopJettyAuthentication.buildAuthentication("dave");
+
+    auth.logout();
+    assertNull(auth.logout(null),
+        "logout(ServletRequest) returns null (no logout support)");
+  }
+
+  @Test
+  public void testAttachIsNullSafe() {
+    // attach() is called unconditionally by auth filters; null args and
+    // requests that are not Jetty Requests must be silently skipped.
+    HadoopJettyAuthentication.attach(null, "alice");
+    HadoopJettyAuthentication.attach(null, null);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer2RemoteUser.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer2RemoteUser.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.log4j.Level;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.WriterAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end check that {@link HttpServer2}'s auto-installed
+ * {@link JettyAuthBridgeFilter} forwards the user from a request wrapper
+ * (the pattern that {@code AuthenticationFilter} uses) onto the base Jetty
+ * Request, so the standard servlet / Jetty API resolves the user from
+ * outside the filter chain as well — most importantly,
+ * {@link org.eclipse.jetty.server.handler.RequestLogHandler}.
+ *
+ * <p>The test relies on {@code StaticUserWebFilter}, the default filter
+ * initializer in core-default.xml, to stand in for an authentication
+ * filter: its job is to wrap the request so {@code getRemoteUser()}
+ * returns a configured user. Because filter initializers run <em>before</em>
+ * the bridge filter, this models the production order
+ * AuthenticationFilter → JettyAuthBridgeFilter.
+ */
+public class TestHttpServer2RemoteUser extends HttpServerFunctionalTest {
+
+  private static final String USER = "foo";
+  /** HttpServer2 emits Jetty access logs to this slf4j logger. */
+  private static final String ACCESS_LOG_LOGGER = "http.requests.test";
+
+  private HttpServer2 server;
+  private StringWriter accessLog;
+  private WriterAppender accessLogAppender;
+  private Level previousLevel;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    attachAccessLogCapture();
+
+    Configuration conf = new Configuration();
+    // StaticUserWebFilter (the default filter initializer) wraps the
+    // request so getRemoteUser() returns this user. Bridge filter runs
+    // after the initializers, so it sees the wrap — exactly the order
+    // that real auth filters experience.
+    conf.set(CommonConfigurationKeys.HADOOP_HTTP_STATIC_USER, USER);
+    server = createTestServer(conf);
+    server.addServlet("whoami", "/whoami", WhoAmIServlet.class);
+    server.start();
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    detachAccessLogCapture();
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  /**
+   * Sanity check: the servlet, which sees the wrap installed by
+   * StaticUserWebFilter, gets the user via the standard servlet API.
+   */
+  @Test
+  public void testRemoteUserVisibleToServlet() throws Exception {
+    String body = httpGet("/whoami");
+    assertEquals(USER + "|" + USER, body.trim(),
+        "Wrapped request should expose the user via the standard servlet "
+            + "API to the downstream servlet");
+  }
+
+  /**
+   * The interesting case: Jetty's {@code RequestLogHandler} runs outside
+   * the filter chain and only sees the base {@link
+   * org.eclipse.jetty.server.Request}. Without the bridge, {@code %u}
+   * would be {@code -}. With the bridge, the user is logged.
+   */
+  @Test
+  public void testAccessLogContainsRemoteUser() throws Exception {
+    httpGet("/whoami");
+    String log = awaitAccessLogContaining("/whoami");
+    assertTrue(log.contains("/whoami"),
+        "Access log should mention the request path, was:\n" + log);
+    // EXTENDED_NCSA_FORMAT places %u between the dash for identd and
+    // the request timestamp: "<ip> - <user> [<ts>] ..."
+    assertTrue(log.contains(" - " + USER + " ["),
+        "Access log should record the user resolved through the bridge "
+            + "filter (expected ' - " + USER + " ['), was:\n" + log);
+  }
+
+  /**
+   * {@code ?doAs=...} should produce an "<effective>/<real>" label
+   * (Kerberos principal-style) so impersonation is explicit while
+   * staying a single, parser-friendly token.
+   */
+  @Test
+  public void testAccessLogProxyUserFormatting() throws Exception {
+    httpGet("/whoami?doAs=alice");
+    String log = awaitAccessLogContaining("/whoami?doAs=alice");
+    String expected = " - alice/" + USER + " [";
+    assertTrue(log.contains(expected),
+        "Access log should show '<doAs>/<auth>' label (expected '"
+            + expected + "'), was:\n" + log);
+  }
+
+  /**
+   * Hadoop accepts the doAs parameter case-insensitively
+   * (matching {@code DelegationTokenAuthenticationFilter.getDoAs}).
+   */
+  @Test
+  public void testAccessLogProxyUserFormattingCaseInsensitive() throws Exception {
+    httpGet("/whoami?doas=alice");
+    String log = awaitAccessLogContaining("/whoami?doas=alice");
+    assertTrue(log.contains(" - alice/" + USER + " ["),
+        "Lowercase 'doas' must also produce the slash-formatted label, "
+            + "was:\n" + log);
+  }
+
+  /**
+   * When doAs equals the authenticated user, no spurious "X/X".
+   */
+  @Test
+  public void testAccessLogDoesNotFormatWhenDoAsEqualsUser() throws Exception {
+    httpGet("/whoami?doAs=" + USER);
+    String log = awaitAccessLogContaining("/whoami?doAs=" + USER);
+    assertTrue(log.contains(" - " + USER + " ["),
+        "Access log should show plain user (no '/') when doAs equals "
+            + "auth user, was:\n" + log);
+    assertFalse(log.contains(USER + "/" + USER),
+        "Should not produce 'X/X' degenerate label, was:\n" + log);
+  }
+
+  private String awaitAccessLogContaining(String needle) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + 5000;
+    String log;
+    do {
+      log = accessLog.toString();
+      if (log.contains(needle)) {
+        return log;
+      }
+      Thread.sleep(50);
+    } while (System.currentTimeMillis() < deadline);
+    return log;
+  }
+
+  private String httpGet(String path) throws IOException {
+    URL url = new URL(
+        "http://localhost:" + server.getConnectorAddress(0).getPort() + path);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.connect();
+    assertEquals(HttpServletResponse.SC_OK, conn.getResponseCode());
+    try (BufferedReader r = new BufferedReader(
+        new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+      StringBuilder sb = new StringBuilder();
+      String line;
+      while ((line = r.readLine()) != null) {
+        sb.append(line);
+      }
+      return sb.toString();
+    }
+  }
+
+  private void attachAccessLogCapture() {
+    accessLog = new StringWriter();
+    accessLogAppender = new WriterAppender(new PatternLayout("%m%n"), accessLog);
+    accessLogAppender.setName("test-access-log-capture");
+    accessLogAppender.setImmediateFlush(true);
+
+    org.apache.log4j.Logger logger =
+        org.apache.log4j.Logger.getLogger(ACCESS_LOG_LOGGER);
+    previousLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    logger.addAppender(accessLogAppender);
+  }
+
+  private void detachAccessLogCapture() {
+    if (accessLogAppender == null) {
+      return;
+    }
+    org.apache.log4j.Logger logger =
+        org.apache.log4j.Logger.getLogger(ACCESS_LOG_LOGGER);
+    logger.removeAppender(accessLogAppender);
+    logger.setLevel(previousLevel);
+    accessLogAppender = null;
+    accessLog = null;
+  }
+
+  public static class WhoAmIServlet extends javax.servlet.http.HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+        throws IOException {
+      String remoteUser = req.getRemoteUser();
+      Principal principal = req.getUserPrincipal();
+      String principalName = (principal == null) ? "<null>" : principal.getName();
+      resp.setContentType("text/plain");
+      resp.getWriter().write(remoteUser + "|" + principalName);
+    }
+  }
+}


### PR DESCRIPTION
Contains content generated by Claude Opus 4.7

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19904

#### Problem
HttpServer2's access log always records `-` in the `%u` position even
for authenticated requests:
Affects every HttpServer2-backed daemon (NN/DN/RM/NM/HttpFS/KMS).
 
#### Root cause
`AuthenticationFilter` wraps `HttpServletRequest` so downstream
filters and servlets see the user via `getRemoteUser()`. The wrap
only flows through the filter chain. Jetty's `RequestLogHandler`
runs outside the chain on the base `Request`, whose
`getAuthentication()` stays as `NOT_CHECKED` forever.
 
Jetty's native auth path (`jetty-security` Authenticators) sets
`Request.setAuthentication(...)` directly, which is why standard
deployments don't have this issue. Hadoop avoids `jetty-security`
for container portability and pays this cost.
 
#### Fix
Install a small Servlet `Filter` (in hadoop-common) after the
auth filters that:
 
1. Reads `getRemoteUser()` from the wrapped request,
2. Calls `Request.setAuthentication(...)` on the base `Request`
with a minimal inline `Authentication.User` (no
`jetty-security` dependency).
 
`HttpServer2.initializeWebServer` installs it automatically after
`FilterInitializer`s; no configuration needed. Works for both
Kerberos and pseudo-auth — both feed the user through
`getRemoteUser()`.
 
#### Known gap
`DelegationTokenAuthenticationHandler.managementOperation` writes
its response inline and returns `false`, so `AuthenticationFilter`
skips `filterChain.doFilter`. The bridge filter doesn't run for
token mgmt requests; the handler attaches directly there.


### How was this patch tested?

Added unit tests and verified on an internal cluster

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html