### PR TITLE
HADOOP-19905. Implement HttpServer2 thread pool metrics

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -1448,11 +1448,18 @@ public final class HttpServer2 implements FilterContainer {
           // Create metrics source for each HttpServer2 instance.
           // Use port number to make the metrics source name unique.
           int port = -1;
+          int acceptorThreads = 0;
+          int selectorThreads = 0;
           for (ServerConnector connector : listeners) {
-            port = connector.getLocalPort();
-            break;
+            if (port == -1) {
+              port = connector.getLocalPort();
+            }
+            acceptorThreads += connector.getAcceptors();
+            selectorThreads += connector.getSelectorManager().getSelectorCount();
           }
-          metrics = HttpServer2Metrics.create(statsHandler, port);
+          metrics = HttpServer2Metrics.create(statsHandler, port,
+              (QueuedThreadPool) webServer.getThreadPool(),
+              acceptorThreads, selectorThreads);
         }
       } catch (IOException ex) {
         LOG.info("HttpServer.start() threw a non Bind IOException", ex);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2Metrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2Metrics.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.http;
 
 import org.eclipse.jetty.server.handler.StatisticsHandler;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -37,6 +38,9 @@ public class HttpServer2Metrics {
 
   private final StatisticsHandler handler;
   private final int port;
+  private final QueuedThreadPool threadPool;
+  private final int acceptorThreads;
+  private final int selectorThreads;
 
   @Metric("number of requested that have been asynchronously dispatched")
   public int asyncDispatches() {
@@ -142,15 +146,65 @@ public class HttpServer2Metrics {
   public long statsOnMs() {
     return handler.getStatsOnMs();
   }
-
-  HttpServer2Metrics(StatisticsHandler handler, int port) {
-    this.handler = handler;
-    this.port = port;
+  @Metric("maximum number of threads in the pool")
+  public int maxThreads() {
+    return threadPool.getMaxThreads();
+  }
+  @Metric("number of idle threads in the pool")
+  public int idleThreads() {
+    return threadPool.getIdleThreads();
+  }
+  @Metric("number of busy threads in the pool")
+  public int busyThreads() {
+    return threadPool.getBusyThreads();
+  }
+  @Metric("number of threads in the pool")
+  public int threads() {
+    return threadPool.getThreads();
+  }
+  @Metric("minimum number of threads in the pool")
+  public int minThreads() {
+    return threadPool.getMinThreads();
+  }
+  @Metric("size of the job queue")
+  public int queueSize() {
+    return threadPool.getQueueSize();
+  }
+  @Metric("number of acceptor threads across all connectors")
+  public int acceptorThreads() {
+    return acceptorThreads;
+  }
+  @Metric("number of selector threads across all connectors")
+  public int selectorThreads() {
+    return selectorThreads;
+  }
+  @Metric("maximum number of worker threads in the pool")
+  public int maxWorkerThreads() {
+    return threadPool.getMaxThreads() - acceptorThreads - selectorThreads;
+  }
+  @Metric("number of busy worker threads in the pool")
+  public int busyWorkerThreads() {
+    return threadPool.getBusyThreads() - acceptorThreads - selectorThreads;
+  }
+  @Metric("number of worker threads in the pool")
+  public int workerThreads() {
+    return threadPool.getThreads() - acceptorThreads - selectorThreads;
   }
 
-  static HttpServer2Metrics create(StatisticsHandler handler, int port) {
+  HttpServer2Metrics(StatisticsHandler handler, int port,
+      QueuedThreadPool threadPool, int acceptorThreads, int selectorThreads) {
+    this.handler = handler;
+    this.port = port;
+    this.threadPool = threadPool;
+    this.acceptorThreads = acceptorThreads;
+    this.selectorThreads = selectorThreads;
+  }
+
+  static HttpServer2Metrics create(StatisticsHandler handler, int port,
+      QueuedThreadPool threadPool, int acceptorThreads, int selectorThreads) {
     final MetricsSystem ms = DefaultMetricsSystem.instance();
-    final HttpServer2Metrics metrics = new HttpServer2Metrics(handler, port);
+    final HttpServer2Metrics metrics = new HttpServer2Metrics(handler, port,
+        threadPool, acceptorThreads, selectorThreads);
     // Remove the old metrics from metrics system to avoid duplicate error
     // when HttpServer2 is started twice.
     metrics.remove();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
@@ -289,6 +289,38 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     assertThat(after).isGreaterThan(before);
   }
 
+  @Test
+  public void testHttpServer2ThreadPoolMetrics() throws Exception {
+    final int maxThreads = 32;
+    final int acceptorCount = 2;
+    final int selectorCount = 4;
+    final Configuration conf = new Configuration();
+    conf.setInt(HttpServer2.HTTP_MAX_THREADS_KEY, maxThreads);
+    conf.setInt(HttpServer2.HTTP_ACCEPTOR_COUNT_KEY, acceptorCount);
+    conf.setInt(HttpServer2.HTTP_SELECTOR_COUNT_KEY, selectorCount);
+    conf.setBoolean(
+        CommonConfigurationKeysPublic.HADOOP_HTTP_METRICS_ENABLED, true);
+    final HttpServer2 testServer = createTestServer(conf);
+    try {
+      testServer.start();
+      final HttpServer2Metrics metrics = testServer.getMetrics();
+
+      assertThat(metrics.maxThreads()).isEqualTo(maxThreads);
+      assertThat(metrics.acceptorThreads()).isEqualTo(acceptorCount);
+      assertThat(metrics.selectorThreads()).isEqualTo(selectorCount);
+
+      // Worker gauges are defined as the pool counts minus acceptors+selectors.
+      assertThat(metrics.maxWorkerThreads())
+          .isEqualTo(maxThreads - acceptorCount - selectorCount);
+      assertThat(metrics.workerThreads())
+          .isEqualTo(metrics.threads() - acceptorCount - selectorCount);
+      assertThat(metrics.busyWorkerThreads())
+          .isEqualTo(metrics.busyThreads() - acceptorCount - selectorCount);
+    } finally {
+      testServer.stop();
+    }
+  }
+
   /**
    * Jetty StatisticsHandler must be inserted via Server#insertHandler
    * instead of Server#setHandler. The server fails to start if


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19905

HttpServer2Metrics (HADOOP-17133) exposes only StatisticsHandler
counters. It says nothing about the Jetty thread pool, so
administrators have no metric-level visibility into thread pool
saturation.
This patch adds gauges to HttpServer2Metrics:
* Pool: maxThreads, minThreads, threads, idleThreads, busyThreads, queueSize
* Per role (summed over connectors): acceptorThreads, selectorThreads
* Worker only (pool count minus acceptors and selectors):
  maxWorkerThreads, workerThreads, busyWorkerThreads
The worker-only gauges are exposed separately because acceptor and
selector threads sit in blocking accept()/select() loops and never go
idle

### How was this patch tested?

unit test and it has been running in production for over a year.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html