### PR TITLE
YARN-11964: Clamp negative available resources in AllocateResponse to zero

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DefaultAMSProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DefaultAMSProcessor.java
@@ -331,9 +331,9 @@ final class DefaultAMSProcessor implements ApplicationMasterServiceProcessor {
 
     response.setCompletedContainersStatuses(appAttempt
         .pullJustFinishedContainers());
-    response.setAvailableResources(
-        Resources.componentwiseMax(allocation.getResourceLimit(),
-            Resources.none()));
+    Resource resourceLimit = allocation.getResourceLimit();
+    response.setAvailableResources(resourceLimit == null ? null :
+        Resources.componentwiseMax(resourceLimit, Resources.none()));
 
     QueueMetrics queueMetrics =
         this.rmContext.getScheduler().getRootQueueMetrics();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DefaultAMSProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DefaultAMSProcessor.java
@@ -331,7 +331,9 @@ final class DefaultAMSProcessor implements ApplicationMasterServiceProcessor {
 
     response.setCompletedContainersStatuses(appAttempt
         .pullJustFinishedContainers());
-    response.setAvailableResources(allocation.getResourceLimit());
+    response.setAvailableResources(
+        Resources.componentwiseMax(allocation.getResourceLimit(),
+            Resources.none()));
 
     QueueMetrics queueMetrics =
         this.rmContext.getScheduler().getRootQueueMetrics();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestDefaultAMSProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestDefaultAMSProcessor.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager;
+
+import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Allocation;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ContainerUpdates;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
+import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.SchedulingRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link DefaultAMSProcessor}.
+ */
+public class TestDefaultAMSProcessor {
+
+  /**
+   * Simulates transient YARN RM over-allocation by returning a negative
+   * resource limit from the scheduler.
+   */
+  public static class NegativeHeadroomScheduler extends FifoScheduler {
+    @Override
+    public Allocation allocate(ApplicationAttemptId applicationAttemptId,
+        List<ResourceRequest> ask,
+        List<SchedulingRequest> schedulingRequests,
+        List<ContainerId> release,
+        List<String> blacklistAdditions,
+        List<String> blacklistRemovals,
+        ContainerUpdates updateRequests) {
+      Allocation allocation = super.allocate(applicationAttemptId, ask,
+          schedulingRequests, release, blacklistAdditions,
+          blacklistRemovals, updateRequests);
+      allocation.setResourceLimit(Resource.newInstance(-1024, -4));
+      return allocation;
+    }
+  }
+
+  @Test
+  @Timeout(60)
+  public void testAvailableResourcesClampedToNonNegative() throws Exception {
+    YarnConfiguration conf = new YarnConfiguration();
+    conf.setClass(YarnConfiguration.RM_SCHEDULER,
+        NegativeHeadroomScheduler.class, ResourceScheduler.class);
+
+    MockRM rm = new MockRM(conf);
+    rm.start();
+    MockNM nm = rm.registerNode("127.0.0.1:1234", 8 * 1024, 8);
+
+    RMApp app = MockRMAppSubmitter.submitWithMemory(1024, rm);
+    MockAM am = MockRM.launchAndRegisterAM(app, rm, nm);
+
+    AllocateResponse response = am.doHeartbeat();
+    Resource available = response.getAvailableResources();
+
+    assertTrue(available.getMemorySize() >= 0,
+        "Available memory must be non-negative, but was: "
+            + available.getMemorySize());
+    assertTrue(available.getVirtualCores() >= 0,
+        "Available vCores must be non-negative, but was: "
+            + available.getVirtualCores());
+
+    rm.stop();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestDefaultAMSProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestDefaultAMSProcessor.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -63,6 +64,27 @@ public class TestDefaultAMSProcessor {
     }
   }
 
+  /**
+   * Simulates a scheduler that does not compute a resource limit,
+   * returning null from {@link Allocation#getResourceLimit()}.
+   */
+  public static class NullHeadroomScheduler extends FifoScheduler {
+    @Override
+    public Allocation allocate(ApplicationAttemptId applicationAttemptId,
+        List<ResourceRequest> ask,
+        List<SchedulingRequest> schedulingRequests,
+        List<ContainerId> release,
+        List<String> blacklistAdditions,
+        List<String> blacklistRemovals,
+        ContainerUpdates updateRequests) {
+      Allocation allocation = super.allocate(applicationAttemptId, ask,
+          schedulingRequests, release, blacklistAdditions,
+          blacklistRemovals, updateRequests);
+      allocation.setResourceLimit(null);
+      return allocation;
+    }
+  }
+
   @Test
   @Timeout(60)
   public void testAvailableResourcesClampedToNonNegative() throws Exception {
@@ -86,6 +108,29 @@ public class TestDefaultAMSProcessor {
     assertTrue(available.getVirtualCores() >= 0,
         "Available vCores must be non-negative, but was: "
             + available.getVirtualCores());
+
+    rm.stop();
+  }
+
+  @Test
+  @Timeout(60)
+  public void testNullResourceLimitDoesNotThrow() throws Exception {
+    YarnConfiguration conf = new YarnConfiguration();
+    conf.setClass(YarnConfiguration.RM_SCHEDULER,
+        NullHeadroomScheduler.class, ResourceScheduler.class);
+
+    MockRM rm = new MockRM(conf);
+    rm.start();
+    MockNM nm = rm.registerNode("127.0.0.1:1234", 8 * 1024, 8);
+
+    RMApp app = MockRMAppSubmitter.submitWithMemory(1024, rm);
+    MockAM am = MockRM.launchAndRegisterAM(app, rm, nm);
+
+    AllocateResponse response = am.doHeartbeat();
+
+    assertNull(response.getAvailableResources(),
+        "Available resources must remain null when the scheduler "
+            + "returns a null resource limit");
 
     rm.stop();
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

YARN RM can transiently report negative available resources (e.g. cluster_capacity - allocated goes negative due to overload or node failures). `DefaultAMSProcessor` now applies `Resources.componentwiseMax` with `Resources.none()` before setting available resources in `AllocateResponse`, ensuring the AM always receives a non-negative value.

This is a re-implementation of YARN-11964 (reverted in 9c865dd01fb). The previous fix applied the clamp inside `Resource.castToIntSafely()`, which was too broad and caused a regression in `TestRLESparseResourceAllocation`. This fix applies the clamp at the correct layer — in `DefaultAMSProcessor` where the `AllocateResponse` is built.

Contains content generated by Claude (Anthropic)

### How was this patch tested?

- Added `TestDefaultAMSProcessor#testAvailableResourcesClampedToNonNegative` which uses a custom scheduler that returns a negative resource limit and verifies the `AllocateResponse` always contains non-negative available resources.
- Existing tests pass: `TestApplicationMasterServiceCapacity`, `TestApplicationMasterServiceFair`, `TestApplicationMasterServiceInterceptor`, `TestRLESparseResourceAllocation`.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

- [x] The PR includes the phrase "Contains content generated by Claude (Anthropic)"
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html