### PR TITLE
HADOOP-19908. ZStandardDecompressor should reset compressedDirectBuf correctly

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zstd/ZStandardCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zstd/ZStandardCompressor.java
@@ -301,7 +301,7 @@ public class ZStandardCompressor implements Compressor {
     finished = false;
     bytesRead = 0;
     bytesWritten = 0;
-    uncompressedDirectBuf.rewind();
+    uncompressedDirectBuf.clear();
     uncompressedDirectBufOff = 0;
     uncompressedDirectBufLen = 0;
     keepUncompressedBuf = false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zstd/ZStandardDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zstd/ZStandardDecompressor.java
@@ -92,7 +92,7 @@ public class ZStandardDecompressor implements Decompressor {
       bytesInCompressedBuffer = directBufferSize;
     }
 
-    compressedDirectBuf.rewind();
+    compressedDirectBuf.clear();
     compressedDirectBuf.put(
         userBuf, userBufOff, bytesInCompressedBuffer);
 
@@ -225,6 +225,8 @@ public class ZStandardDecompressor implements Decompressor {
     finished = false;
     compressedDirectBufOff = 0;
     bytesInCompressedBuffer = 0;
+    compressedDirectBuf.limit(directBufferSize);
+    compressedDirectBuf.position(0);
     uncompressedDirectBuf.limit(directBufferSize);
     uncompressedDirectBuf.position(directBufferSize);
     userBufOff = 0;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zstd/ZStandardDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zstd/ZStandardDecompressor.java
@@ -188,6 +188,9 @@ public class ZStandardDecompressor implements Decompressor {
       }
 
       // Restore limit so setInputFromSavedData() can rewind+put on next call.
+      // There is possible that `decompressDirectByteBufferStream` throws exception
+      // on decompressing corrupt data, code won't reach here, the caller must
+      // call `reset` to clear the state before resuing this decompressor.
       compressedDirectBuf.limit(directBufferSize);
     } else {
       n = 0;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/zstd/TestZStandardCompressorDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/zstd/TestZStandardCompressorDecompressor.java
@@ -15,6 +15,7 @@
  */
 package org.apache.hadoop.io.compress.zstd;
 
+import com.github.luben.zstd.ZstdException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestZStandardCompressorDecompressor {
   private final static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
@@ -598,7 +600,8 @@ public class TestZStandardCompressorDecompressor {
     decompressor.setInput(corrupted, 0, corrupted.length);
     try {
       decompressor.decompress(out, 0, out.length);
-    } catch (Exception e) {
+      fail("decompress should throw exception on corrupted data");
+    } catch (ZstdException e) {
       // Expected: corrupted data causes an exception.
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/zstd/TestZStandardCompressorDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/zstd/TestZStandardCompressorDecompressor.java
@@ -557,6 +557,64 @@ public class TestZStandardCompressorDecompressor {
     assertEquals(0, result);
   }
 
+  /**
+   * Verify that {@code setInput()} does not throw {@code BufferOverflowException}
+   * after a previous {@code decompress()} call threw an exception.
+   *
+   * <p>When {@code decompress()} processes compressed data, it sets
+   * {@code compressedDirectBuf.limit(bytesInCompressedBuffer)} — a value that
+   * may be smaller than {@code directBufferSize}. If {@code decompressDirectByteBufferStream}
+   * throws (e.g. on corrupted input), the limit is never restored. A subsequent
+   * {@code reset()} also does not restore {@code compressedDirectBuf.limit}.
+   * So the next {@code setInput()} call will hit {@code BufferOverflowException}
+   * because {@code setInputFromSavedData()} tries to {@code put()} more bytes
+   * than the current limit allows.</p>
+   *
+   * <p>This scenario occurs in practice when reading multiple zstd-compressed
+   * files from a directory: a corrupted file causes an exception mid-decompress,
+   * the decompressor is returned to the pool and reset, but the limit stays
+   * small. The next file's {@code setInput()} then fails.</p>
+   */
+  @Test
+  public void testSetInputAfterDecompressThrowsOnCorruptedData() throws Exception {
+    byte[] rawData = generate(400);
+    int bufSize = IO_FILE_BUFFER_SIZE_DEFAULT;
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (CompressionOutputStream cos = new CompressorStream(baos,
+        new ZStandardCompressor(), bufSize)) {
+      cos.write(rawData);
+    }
+    byte[] compressed = baos.toByteArray();
+
+    // Corrupt the compressed data by dropping the first 10 bytes.
+    byte[] corrupted = new byte[compressed.length - 10];
+    System.arraycopy(compressed, 10, corrupted, 0, corrupted.length);
+
+    ZStandardDecompressor decompressor = new ZStandardDecompressor(bufSize);
+    byte[] out = new byte[bufSize];
+
+    // Feed corrupted data — decompress() sets limit to corrupted.length, then throws.
+    decompressor.setInput(corrupted, 0, corrupted.length);
+    try {
+      decompressor.decompress(out, 0, out.length);
+    } catch (Exception e) {
+      // Expected: corrupted data causes an exception.
+    }
+
+    // Reset the decompressor (as the codec pool would).
+    decompressor.reset();
+
+    // Feed valid data — this must NOT throw BufferOverflowException.
+    decompressor.setInput(compressed, 0, compressed.length);
+    int n = decompressor.decompress(out, 0, out.length);
+    assertTrue(n >= 0, "decompress should return >= 0 after reset");
+
+    while (!decompressor.finished()) {
+      decompressor.decompress(out, 0, out.length);
+    }
+  }
+
   // workers > 0 should produce data that round-trips correctly through the
   // decompressor, matching the bytes produced with the default workers=0.
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Long-standing issue, but only causes real problems after HADOOP-19855, because the previous Hadoop native `inflateBytesDirect` operates on raw memory, ignoring `ByteBuffer`'s limit, while the zstd-jni's method uses pure Java code to access `ByteBuffer`'s, so `put()` may throw `BufferOverflowException` if it gets from Codec pool, and the previous round throws exception and `reset` does not clean the state.

Side note: the issue was identified in Spark during testing while reading corrupted zstd files.

### How was this patch tested?

An UT is added, without this change, it fails with `BufferOverflowException` and passes now. 

```
./mvnw -pl :hadoop-common -am test -Dtest=TestZStandardCompressorDecompressor
```

before
```
[INFO] Running org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor
[ERROR] Tests run: 25, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.812 s <<< FAILURE! -- in org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor
[ERROR] org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor.testSetInputAfterDecompressThrowsOnCorruptedData -- Time elapsed: 0.003 s <<< ERROR!
java.nio.BufferOverflowException
        at java.base/java.nio.ByteBuffer.put(ByteBuffer.java:1179)
        at org.apache.hadoop.io.compress.zstd.ZStandardDecompressor.setInputFromSavedData(ZStandardDecompressor.java:96)
        at org.apache.hadoop.io.compress.zstd.ZStandardDecompressor.setInput(ZStandardDecompressor.java:82)
        at org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor.testSetInputAfterDecompressThrowsOnCorruptedData(TestZStandardCompressorDecompressor.java:609)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```
after
```
[INFO] Running org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.919 s -- in org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by XiaoMi Mimo V2.5 Pro