### PR TITLE
HDFS-17930. [ARR] Router shutdown should not shut routerAsyncResponderExecutor down

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -724,9 +724,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     if (routerDefaultAsyncHandlerExecutor != null) {
       routerDefaultAsyncHandlerExecutor.shutdownNow();
     }
-    if (routerAsyncResponderExecutor != null) {
-      routerAsyncResponderExecutor.shutdownNow();
-    }
     super.serviceStop();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -169,7 +169,7 @@ public class TestRouterAsyncHandlerQueueOverflow {
     // Queue full, rejected
     asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
     assertEquals(2, nsExecutor.getQueue().size());
-    String expectedMsg = "Namespace '" + ns0 + "' is overloaded (queue size: " + QUEUE_CAP + ")";
+    String expectedMsg = "Namespace '" + ns0 + "' async handler is busy.";
     LambdaTestUtils.intercept(StandbyException.class, expectedMsg,
         () -> syncReturn(FileStatus.class));
     // Unstuck the namenode so we can terminate this test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -104,21 +104,27 @@ public class TestRouterAsyncHandlerQueueOverflow {
     cluster.waitNamenodeRegistration();
     cluster.waitActiveNamespaces();
 
-    testLatch = new CountDownLatch(1);
     ns0 = cluster.getNameservices().get(0);
     MiniRouterDFSCluster.NamenodeContext nn0 = cluster.getNamenode(ns0, null);
     FSNamesystem spyNamesystem = NameNodeAdapterMockitoUtil.spyOnNamesystem(nn0.getNamenode());
     // Mock one slow operation. Any public interface from FSNamesystem will do.
-    Mockito.doAnswer(invocationOnMock -> {
-      String invokePath = invocationOnMock.getArgument(1);
-      if (invokePath.startsWith("/veryBigOperation")) {
-        testLatch.await();
-      } else {
-        return invocationOnMock.callRealMethod();
-      }
-      return null;
-    }).when(spyNamesystem).getFilesBlockingDecom(anyLong(), anyString());
+    spyNamesystem.writeLock();
+    Mockito.when(spyNamesystem.getFilesBlockingDecom(anyLong(), anyString()))
+        .thenAnswer(invocationOnMock -> {
+          if (testLatch == null) {
+            return null;
+          }
+          String invokePath = invocationOnMock.getArgument(1);
+          if (invokePath.startsWith("/veryBigOperation")) {
+            testLatch.await();
+          } else {
+            return invocationOnMock.callRealMethod();
+          }
+          return null;
+        });
+    spyNamesystem.writeUnlock();
 
+    testLatch = new CountDownLatch(1);
     MiniRouterDFSCluster.RouterContext router = cluster.getRandomRouter();
     routerRpcServer = router.getRouterRpcServer();
     routerRpcServer.initAsyncThreadPools(routerConf);


### PR DESCRIPTION
### Description of PR

During ARR init, AsyncRpcProtocolPBUtil stores the async responder executor as a static ref. Nuking `routerAsyncResponderExecutor` during shutdown will point the static ref to a terminated executor, poisoning later test runs.

Fix: Do not shut down `routerAsyncResponderExecutor` in `RouterRpcServer#serviceStop()`. The responder threads are daemon so they won't block JVM during actual router shutdown.