### PR TITLE
HDFS-17931. Add early return in PendingDataNodeMessages.removeQueuedBlock when queue is empty

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3525,8 +3525,8 @@ public class BlockManager implements BlockStatsMXBean {
    * standby node. @see PendingDataNodeMessages.
    */
   private void removeQueuedBlock(DatanodeStorageInfo storageInfo, Block block) {
-    LOG.debug("Removing queued block {} from datanode {} from pending queue.",
-        block, storageInfo.getDatanodeDescriptor());
+    LOG.debug("Removing queued block {} from datanode {} from pending queue (size = {}).",
+        block, storageInfo.getDatanodeDescriptor(), pendingDNMessages.count());
     pendingDNMessages.removeQueuedBlock(storageInfo, block);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -109,7 +109,7 @@ class PendingDataNodeMessages {
   }
 
   void removeQueuedBlock(DatanodeStorageInfo storageInfo, Block block) {
-    if (storageInfo == null || block == null) {
+    if (count == 0 || storageInfo == null || block == null) {
       return;
     }
     Block blk = new Block(block);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -109,7 +109,7 @@ class PendingDataNodeMessages {
   }
 
   void removeQueuedBlock(DatanodeStorageInfo storageInfo, Block block) {
-    if (count == 0 || storageInfo == null || block == null) {
+    if (count <= 0 || storageInfo == null || block == null) {
       return;
     }
     Block blk = new Block(block);


### PR DESCRIPTION
### Description of PR

removeQueuedBlock() is called for every block in a block report. When the pending queue is empty (count == 0), the method still unconditionally allocates a new Block() and does a HashMap.get() before returning null. On large DataNodes this is millions of unnecessary allocations per report.

This is especially costly under ZGC, where these operations trigger load/write barriers even on the no-op path. In practice, on a ZGC Observer NameNode, count is almost always 0 because ZGC's sub-millisecond pauses keep EditLogTailer current, so isGenStampInFuture() rarely triggers.

Fix: add a count == 0 early return before the new Block() allocation.

### How was this patch tested?

This is a minor change, a new metrics will be needed to show the difference, which is not worthy. It can be added later if needed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html