### PR TITLE
HADOOP-19914. Replace JLine static `Log` reference with SLF4J `Logger` instance

### DIFF
--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/src/test/java/org/apache/hadoop/tools/dynamometer/workloadgenerator/TestWorkloadGenerator.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/src/test/java/org/apache/hadoop/tools/dynamometer/workloadgenerator/TestWorkloadGenerator.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.authorize.ImpersonationProvider;
-import org.jline.utils.Log;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -154,7 +153,7 @@ public class TestWorkloadGenerator {
         "part-r-00000"))) {
       String auditOutput = IOUtils.toString(auditOutputFile,
           StandardCharsets.UTF_8);
-      Log.info(auditOutput);
+      LOG.info(auditOutput);
       assertTrue(auditOutput.matches(
           ".*(hdfs,WRITE,[A-Z]+,[13]+,[0-9]+\\n){3}.*"));
       // Matches three lines of the format "hdfs,WRITE,name,count,time"


### PR DESCRIPTION
The class declare a SLF4J `Logger LOG` field, but sometimes the JLine `Log` static class is referenced instead.

It makes no sense to swap logging implementations mid-class, _my assumption_ is that it's an error by referencing the class instead of the field.