### PR TITLE
HADOOP-19911. Fix flaky TestBalancerLongRunningTasks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
@@ -110,6 +110,7 @@ public class TestBalancerLongRunningTasks {
       cluster.shutdown();
       cluster = null;
     }
+    DefaultMetricsSystem.shutdown();
   }
 
   private ClientProtocol client;
@@ -823,17 +824,20 @@ public class TestBalancerLongRunningTasks {
 
       // Throw an error when we double-initialize BalancerMetrics
       DefaultMetricsSystem.setMiniClusterMode(false);
-      MetricsSystem instance = DefaultMetricsSystem.instance();
-      // Avoid the impact of cluster metric, remove cluster JvmMetrics
-      instance.unregisterSource("JvmMetrics");
+      try {
+        MetricsSystem instance = DefaultMetricsSystem.instance();
+        // Avoid the impact of cluster metric, remove cluster JvmMetrics
+        instance.unregisterSource("JvmMetrics");
 
-      final BalancerParameters balancerParameters = Balancer.Cli.parse(new String[] {
-          "-policy", BalancingPolicy.Node.INSTANCE.getName(),
-          "-threshold", "10",
-      });
-      int r = Balancer.run(namenodes, nsIds, balancerParameters, conf);
-      assertEquals(ExitStatus.SUCCESS.getExitCode(), r);
-      DefaultMetricsSystem.setMiniClusterMode(true);
+        final BalancerParameters balancerParameters = Balancer.Cli.parse(new String[] {
+            "-policy", BalancingPolicy.Node.INSTANCE.getName(),
+            "-threshold", "10",
+        });
+        int r = Balancer.run(namenodes, nsIds, balancerParameters, conf);
+        assertEquals(ExitStatus.SUCCESS.getExitCode(), r);
+      } finally {
+        DefaultMetricsSystem.setMiniClusterMode(true);
+      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
@@ -106,11 +106,14 @@ public class TestBalancerLongRunningTasks {
 
   @AfterEach
   public void shutdown() throws Exception {
-    if (cluster != null) {
-      cluster.shutdown();
+    try {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    } finally {
       cluster = null;
+      DefaultMetricsSystem.shutdown();
     }
-    DefaultMetricsSystem.shutdown();
   }
 
   private ClientProtocol client;
@@ -823,6 +826,7 @@ public class TestBalancerLongRunningTasks {
       assertEquals(1, namenodes.size());
 
       // Throw an error when we double-initialize BalancerMetrics
+      boolean oldValue = DefaultMetricsSystem.inMiniClusterMode();
       DefaultMetricsSystem.setMiniClusterMode(false);
       try {
         MetricsSystem instance = DefaultMetricsSystem.instance();
@@ -836,7 +840,7 @@ public class TestBalancerLongRunningTasks {
         int r = Balancer.run(namenodes, nsIds, balancerParameters, conf);
         assertEquals(ExitStatus.SUCCESS.getExitCode(), r);
       } finally {
-        DefaultMetricsSystem.setMiniClusterMode(true);
+        DefaultMetricsSystem.setMiniClusterMode(oldValue);
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Fix flaky tests like https://github.com/kokonguyen191/hadoop/actions/runs/26836456695/job/79134194743
```
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:  org.apache.hadoop.hdfs.server.balancer.TestBalancerLongRunningTasks.testBalancerMetricsDuplicate
Error:    Run 1: TestBalancerLongRunningTasks.testBalancerMetricsDuplicate:835 expected: <0> but was: <-3>
Error:    Run 2: TestBalancerLongRunningTasks.testBalancerMetricsDuplicate:797 » Metrics Metrics source RetryCache.NameNodeRetryCache already exists!
Error:    Run 3: TestBalancerLongRunningTasks.testBalancerMetricsDuplicate:797 » Metrics Metrics source RetryCache.NameNodeRetryCache already exists!
...
[INFO] 
Error:  Tests run: 1219, Failures: 0, Errors: 6, Skipped: 0
```

Two changes in `TestBalancerLongRunningTasks`:

1. `@AfterEach shutdown()` — Added `DefaultMetricsSystem.shutdown()` to reset the metrics singleton after each test, preventing stale `RetryCache.NameNodeRetryCache` registrations from carrying over between tests in the same JVM.

2. `testBalancerMetricsDuplicate()` — Wrapped the `setMiniClusterMode(false)` block in `try-finally` so `setMiniClusterMode(<prior-state>)` is always restored. Previously, if the assertion on line 836 failed, the restoration was skipped, poisoning all subsequent test retries.

### How was this patch tested?

Pass GHA.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19911)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Assisted-by: OpenCode (Mimo-V2.5-Pro)