### PR TITLE
HDFS-17934. RBF: Add router web address to router web UI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ import javax.management.StandardMBean;
 
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
 import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
@@ -91,6 +93,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.metrics2.util.Metrics2Util;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.VersionInfo;
@@ -344,11 +347,7 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
     if (routerStore == null) {
       return "{}";
     }
-    int guessedWebPort = router.getConfig().getSocketAddr(
-        RBFConfigKeys.DFS_ROUTER_HTTP_BIND_HOST_KEY,
-        RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_KEY,
-        RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_DEFAULT,
-        RBFConfigKeys.DFS_ROUTER_HTTP_PORT_DEFAULT).getPort();
+    Configuration conf = router.getConfig();
     try {
       // Get all the routers in order
       GetRouterRegistrationsRequest request =
@@ -367,8 +366,7 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
         long dateModified = record.getDateModified();
         long lastHeartbeat = getSecondsSince(dateModified);
         innerInfo.put("lastHeartbeat", lastHeartbeat);
-        innerInfo.put("routerWebAddress",
-            guessRouterWebAddress(record.getAdminAddress(), guessedWebPort));
+        innerInfo.put("routerWebAddress", getRouterWebAddress(conf, record.getAdminAddress()));
 
         StateStoreVersion stateStoreVersion = record.getStateStoreVersion();
         if (stateStoreVersion == null) {
@@ -387,17 +385,35 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
     return JSON.toString(info);
   }
 
-  private static String guessRouterWebAddress(String adminAddress, int webPort) {
+  private static String getRouterWebAddress(Configuration conf, String adminAddress) {
     try {
       if (isNullOrEmpty(adminAddress)) {
         return "";
       }
-      String host = adminAddress.split(":")[0];
-      return "http://" + host + ":" + webPort;
+      String scheme = DFSUtil.getHttpClientScheme(conf);
+      int webPort = getRouterWebAddressPort(conf, scheme);
+      InetSocketAddress adminSocketAddress = NetUtils.createSocketAddr(adminAddress.trim());
+      return new URI(scheme, null, adminSocketAddress.getHostString(), webPort, null, null,
+          null).toString();
     } catch (Exception e) {
       LOG.error("Cannot get router web address", e);
       return "";
     }
+  }
+
+  private static int getRouterWebAddressPort(Configuration conf, String scheme) {
+    if ("http".equals(scheme)) {
+      return conf.getSocketAddr(
+          RBFConfigKeys.DFS_ROUTER_HTTP_BIND_HOST_KEY,
+          RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_KEY,
+          RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_DEFAULT,
+          RBFConfigKeys.DFS_ROUTER_HTTP_PORT_DEFAULT).getPort();
+    }
+    return conf.getSocketAddr(
+        RBFConfigKeys.DFS_ROUTER_HTTPS_BIND_HOST_KEY,
+        RBFConfigKeys.DFS_ROUTER_HTTPS_ADDRESS_KEY,
+        RBFConfigKeys.DFS_ROUTER_HTTPS_ADDRESS_DEFAULT,
+        RBFConfigKeys.DFS_ROUTER_HTTPS_PORT_DEFAULT).getPort();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.federation.metrics;
 
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
 import static org.apache.hadoop.metrics2.impl.MsInfo.ProcessName;
+import static org.apache.hadoop.thirdparty.com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.hadoop.util.Time.now;
 
 import java.io.IOException;
@@ -343,6 +344,11 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
     if (routerStore == null) {
       return "{}";
     }
+    int guessedWebPort = router.getConfig().getSocketAddr(
+        RBFConfigKeys.DFS_ROUTER_HTTP_BIND_HOST_KEY,
+        RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_KEY,
+        RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_DEFAULT,
+        RBFConfigKeys.DFS_ROUTER_HTTP_PORT_DEFAULT).getPort();
     try {
       // Get all the routers in order
       GetRouterRegistrationsRequest request =
@@ -361,6 +367,8 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
         long dateModified = record.getDateModified();
         long lastHeartbeat = getSecondsSince(dateModified);
         innerInfo.put("lastHeartbeat", lastHeartbeat);
+        innerInfo.put("routerWebAddress",
+            guessRouterWebAddress(record.getAdminAddress(), guessedWebPort));
 
         StateStoreVersion stateStoreVersion = record.getStateStoreVersion();
         if (stateStoreVersion == null) {
@@ -377,6 +385,19 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
       return "{}";
     }
     return JSON.toString(info);
+  }
+
+  private static String guessRouterWebAddress(String adminAddress, int webPort) {
+    try {
+      if (isNullOrEmpty(adminAddress)) {
+        return "";
+      }
+      String host = adminAddress.split(":")[0];
+      return "http://" + host + ":" + webPort;
+    } catch (Exception e) {
+      LOG.error("Cannot get router web address", e);
+      return "";
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
@@ -303,7 +303,13 @@
     {#Routers}
     <tr>
       <td class="federationhealth-router-icon federationhealth-router-{iconState}" title="{title}"></td>
-      <td>{address}</td>
+      <td>
+        {?routerWebAddress}
+        <a href='{routerWebAddress}'>{address}</a>
+        {:else}
+        {address}
+        {/routerWebAddress}
+      </td>
       <td>{status}</td>
       <td>{lastHeartbeat} sec ago</td>
       <td>{lastMembershipUpdate}</td>


### PR DESCRIPTION
### Description of PR

In router web interface, there are clickable URLs for namenodes and datanodes, but none for routers.

This patch uses a hacky method to guess the web URL from configuration and admin address, which works for cluster that runs the same port for all routers, instead of 100% accurately getting it using some other method that requires more intrusive changes to what's stored in the router state store. I think it's a fair compromise for a small improvement that works for most deployments.

### How was this patch tested?

Local deployment and test deployment with a few nodes.

<img width="1812" height="268" alt="image" src="https://github.com/user-attachments/assets/18391c42-d402-4631-b940-2507d40e9c68" />

No unit tests since it's a minor front end change.