### PR TITLE
HADOOP-19917. Add cause to exception in AbfsClient if SASTokenProvider failed

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1180,7 +1180,7 @@ public abstract class AbfsClient implements Closeable {
       } catch (Exception ex) {
         throw new SASTokenProviderException(String.format(
             "Failed to acquire a SAS token for %s on %s due to %s", operation, path,
-            ex.toString()));
+            ex.toString()), ex);
       }
     }
     return sasToken;


### PR DESCRIPTION
### Description of PR

Currently in the org.apache.hadoop.fs.azurebfs.services.AbfsClient if the 
sasTokenProvider throws an exception, than the root cause wont be visible in the logs.
The SasTokenProvider can be a third party entity (for example Ranger implementation) so debugging can be challenging in these situation.

### How was this patch tested?

CI will run the UTs, no other test happened.


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html