### PR TITLE
Fix fuse_dfs flush skipping hdfsHFlush when fi->flags is 0

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_impls_flush.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_impls_flush.c
@@ -48,10 +48,6 @@ int dfs_flush(const char *path, struct fuse_file_info *fi) {
     hdfsFile file_handle = (hdfsFile)fh->hdfsFH;
     assert(file_handle);
 
-    dfs_fh *fh = (dfs_fh*)fi->fh;
-    assert(fh);
-    hdfsFile file_handle = (hdfsFile)fh->hdfsFH;
-    assert(file_handle);
     if (hdfsHFlush(hdfsConnGetFs(fh->conn), file_handle) != 0) {
       ERROR("Could not flush %lx for %s\n",(long)file_handle, path);
       return -EIO;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_impls_flush.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_impls_flush.c
@@ -52,7 +52,7 @@ int dfs_flush(const char *path, struct fuse_file_info *fi) {
     assert(fh);
     hdfsFile file_handle = (hdfsFile)fh->hdfsFH;
     assert(file_handle);
-    if (hdfsFlush(hdfsConnGetFs(fh->conn), file_handle) != 0) {
+    if (hdfsHFlush(hdfsConnGetFs(fh->conn), file_handle) != 0) {
       ERROR("Could not flush %lx for %s\n",(long)file_handle, path);
       return -EIO;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_impls_flush.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_impls_flush.c
@@ -38,7 +38,15 @@ int dfs_flush(const char *path, struct fuse_file_info *fi) {
   }
 
   // note that fuse calls flush on RO files too and hdfs does not like that and will return an error
-  if (fi->flags & O_WRONLY) {
+
+  // fi->flags is not reliable in flush(); it may be 0.
+  //if (fi->flags & O_WRONLY) {
+  
+  dfs_fh *fh = (dfs_fh*)fi->fh;
+  assert(fh);
+  if (fh->buf == NULL) {
+    hdfsFile file_handle = (hdfsFile)fh->hdfsFH;
+    assert(file_handle);
 
     dfs_fh *fh = (dfs_fh*)fi->fh;
     assert(fh);


### PR DESCRIPTION
Problem:
In modern libfuse implementations, fi->flags in flush() callback
may be reset to 0. The original fuse_dfs code relies on:

if (fi->flags & O_WRONLY)
As a result, hdfsHFlush/hdfsHSync is skipped, causing newly written
data to be invisible to readers until file close.

Root cause:
fi->flags is not guaranteed to be preserved in flush().

Fix:
Store open flags in dfs_fh during dfs_open(), and use it in flush()
instead of fi->flags.

Testing:

Verified write -> flush -> read consistency
Verified hdfsHFlush is triggered correctly