### PR TITLE
YARN-11965. Support partition-aware resource metrics in RM cluster metrics REST API.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -1277,15 +1277,25 @@ public class QueueMetrics implements MetricsSource {
   }
 
   public int getAllocatedContainers(String partition) {
-    return getPartitionMetrics(partition).getAllocatedContainers();
+    QueueMetrics partitionMetrics = lookupPartitionMetrics(partition);
+    return partitionMetrics == null ? 0 : partitionMetrics.getAllocatedContainers();
   }
 
   public int getPendingContainers(String partition) {
-    return getPartitionMetrics(partition).getPendingContainers();
+    QueueMetrics partitionMetrics = lookupPartitionMetrics(partition);
+    return partitionMetrics == null ? 0 : partitionMetrics.getPendingContainers();
   }
 
   public int getReservedContainers(String partition) {
-    return getPartitionMetrics(partition).getReservedContainers();
+    QueueMetrics partitionMetrics = lookupPartitionMetrics(partition);
+    return partitionMetrics == null ? 0 : partitionMetrics.getReservedContainers();
+  }
+
+  private QueueMetrics lookupPartitionMetrics(String partition) {
+    if (partition == null || partition.equals(RMNodeLabelsManager.NO_LABEL)) {
+      partition = DEFAULT_PARTITION;
+    }
+    return getQueueMetrics().get(partition + METRIC_NAME_DELIMITER);
   }
   
   public int getActiveUsers() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -1275,6 +1275,18 @@ public class QueueMetrics implements MetricsSource {
   public int getReservedContainers() {
     return reservedContainers.value();
   }
+
+  public int getAllocatedContainers(String partition) {
+    return getPartitionMetrics(partition).getAllocatedContainers();
+  }
+
+  public int getPendingContainers(String partition) {
+    return getPartitionMetrics(partition).getPendingContainers();
+  }
+
+  public int getReservedContainers(String partition) {
+    return getPartitionMetrics(partition).getReservedContainers();
+  }
   
   public int getActiveUsers() {
     return activeUsers.value();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
@@ -155,12 +155,13 @@ public class ClusterMetricsInfo {
 
         Resource available = Resources.subtractFromNonNegative(
             totalClusterResourcesAcrossPartition.getResource(),
-            Resources.add(totalUsedResourcesAcrossPartition.getResource(),
-                totalReservedResourcesAcrossPartition.getResource()));
+            totalUsedResourcesAcrossPartition.getResource());
         this.totalMB = totalClusterResourcesAcrossPartition.getMemorySize();
         this.totalVirtualCores = totalClusterResourcesAcrossPartition.getvCores();
-        this.allocatedMB = totalUsedResourcesAcrossPartition.getMemorySize();
-        this.allocatedVirtualCores = totalUsedResourcesAcrossPartition.getvCores();
+        this.allocatedMB = totalUsedResourcesAcrossPartition.getMemorySize()
+            - totalReservedResourcesAcrossPartition.getMemorySize();
+        this.allocatedVirtualCores = totalUsedResourcesAcrossPartition.getvCores()
+            - totalReservedResourcesAcrossPartition.getvCores();
         this.reservedMB = totalReservedResourcesAcrossPartition.getMemorySize();
         this.reservedVirtualCores = totalReservedResourcesAcrossPartition.getvCores();
         this.availableMB = available.getMemorySize();
@@ -225,9 +226,10 @@ public class ClusterMetricsInfo {
           partitionName, cs.getClusterResource());
       Resource reserved = usage.getReserved(partitionName);
       Resource pending = usage.getPending(partitionName);
-      Resource allocated = usage.getUsed(partitionName);
+      Resource used = usage.getUsed(partitionName);
+      Resource allocated = Resources.subtract(used, reserved);
       Resource available = Resources.subtractFromNonNegative(
-          Resources.clone(total), Resources.add(allocated, reserved));
+          Resources.clone(total), used);
       partitionMetrics.add(new PartitionClusterMetricsInfo(
           partitionName, total, allocated, reserved, pending, available,
           metrics.getAllocatedContainers(partitionName),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
@@ -17,16 +17,26 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.webapp.dao;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.nodelabels.RMNodeLabel;
 import org.apache.hadoop.yarn.server.resourcemanager.ClusterMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
+import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceUsage;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.ParentQueue;
+import org.apache.hadoop.yarn.util.resource.Resources;
 
 @XmlRootElement(name = "clusterMetrics")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -83,6 +93,8 @@ public class ClusterMetricsInfo {
   // Total allocated containers across all partitions.
   private int totalAllocatedContainersAcrossPartition;
 
+  private List<PartitionClusterMetricsInfo> partitionClusterMetrics;
+
   private boolean crossPartitionMetricsAvailable = false;
 
   private int rmEventQueueSize;
@@ -138,6 +150,28 @@ public class ClusterMetricsInfo {
             cs.getRootQueue().getQueueResourceUsage().getAllReserved());
         totalAllocatedContainersAcrossPartition =
             ((ParentQueue) cs.getRootQueue()).getNumContainers();
+        partitionClusterMetrics = getPartitionClusterMetrics(cs, metrics,
+            cs.getRootQueue().getQueueResourceUsage());
+
+        Resource available = Resources.subtractFromNonNegative(
+            totalClusterResourcesAcrossPartition.getResource(),
+            Resources.add(totalUsedResourcesAcrossPartition.getResource(),
+                totalReservedResourcesAcrossPartition.getResource()));
+        this.totalMB = totalClusterResourcesAcrossPartition.getMemorySize();
+        this.totalVirtualCores = totalClusterResourcesAcrossPartition.getvCores();
+        this.allocatedMB = totalUsedResourcesAcrossPartition.getMemorySize();
+        this.allocatedVirtualCores = totalUsedResourcesAcrossPartition.getvCores();
+        this.reservedMB = totalReservedResourcesAcrossPartition.getMemorySize();
+        this.reservedVirtualCores = totalReservedResourcesAcrossPartition.getvCores();
+        this.availableMB = available.getMemorySize();
+        this.availableVirtualCores = available.getVirtualCores();
+        this.pendingMB = cs.getRootQueue().getQueueResourceUsage()
+            .getAllPending().getMemorySize();
+        this.pendingVirtualCores = cs.getRootQueue().getQueueResourceUsage()
+            .getAllPending().getVirtualCores();
+        this.containersAllocated = totalAllocatedContainersAcrossPartition;
+        this.containersPending = sumPendingContainers(partitionClusterMetrics);
+        this.containersReserved = sumReservedContainers(partitionClusterMetrics);
         crossPartitionMetricsAvailable = true;
       }
     } else {
@@ -170,6 +204,55 @@ public class ClusterMetricsInfo {
     this.rmEventQueueSize = clusterMetrics.getRmEventQueueSize();
     this.schedulerEventQueueSize = clusterMetrics.getSchedulerEventQueueSize();
     this.utilizedVirtualCores = clusterMetrics.getUtilizedVirtualCores();
+  }
+
+  private List<PartitionClusterMetricsInfo> getPartitionClusterMetrics(
+      CapacityScheduler cs, QueueMetrics metrics, ResourceUsage usage) {
+    List<PartitionClusterMetricsInfo> partitionMetrics = new ArrayList<>();
+    RMNodeLabelsManager labelManager = cs.getRMContext().getNodeLabelManager();
+    if (labelManager == null) {
+      return partitionMetrics;
+    }
+
+    Set<String> partitionNames = new LinkedHashSet<>();
+    partitionNames.add(RMNodeLabelsManager.NO_LABEL);
+    for (RMNodeLabel label : labelManager.pullRMNodeLabelsInfo()) {
+      partitionNames.add(label.getLabelName());
+    }
+
+    for (String partitionName : partitionNames) {
+      Resource total = labelManager.getResourceByLabel(
+          partitionName, cs.getClusterResource());
+      Resource reserved = usage.getReserved(partitionName);
+      Resource pending = usage.getPending(partitionName);
+      Resource allocated = usage.getUsed(partitionName);
+      Resource available = Resources.subtractFromNonNegative(
+          Resources.clone(total), Resources.add(allocated, reserved));
+      partitionMetrics.add(new PartitionClusterMetricsInfo(
+          partitionName, total, allocated, reserved, pending, available,
+          metrics.getAllocatedContainers(partitionName),
+          metrics.getReservedContainers(partitionName),
+          metrics.getPendingContainers(partitionName)));
+    }
+    return partitionMetrics;
+  }
+
+  private int sumPendingContainers(
+      List<PartitionClusterMetricsInfo> partitionMetrics) {
+    int sum = 0;
+    for (PartitionClusterMetricsInfo partitionMetric : partitionMetrics) {
+      sum += partitionMetric.getContainersPending();
+    }
+    return sum;
+  }
+
+  private int sumReservedContainers(
+      List<PartitionClusterMetricsInfo> partitionMetrics) {
+    int sum = 0;
+    for (PartitionClusterMetricsInfo partitionMetric : partitionMetrics) {
+      sum += partitionMetric.getContainersReserved();
+    }
+    return sum;
   }
 
   public int getAppsSubmitted() {
@@ -422,6 +505,10 @@ public class ClusterMetricsInfo {
 
   public boolean getCrossPartitionMetricsAvailable() {
     return crossPartitionMetricsAvailable;
+  }
+
+  public List<PartitionClusterMetricsInfo> getPartitionClusterMetrics() {
+    return partitionClusterMetrics;
   }
 
   public int getContainerAssignedPerSecond() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/PartitionClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/PartitionClusterMetricsInfo.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.resourcemanager.webapp.dao;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.hadoop.yarn.api.records.Resource;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class PartitionClusterMetricsInfo {
+
+  private String partitionName;
+
+  private long totalMB;
+  private long totalVirtualCores;
+
+  private long availableMB;
+  private long availableVirtualCores;
+
+  private long allocatedMB;
+  private long allocatedVirtualCores;
+
+  private long reservedMB;
+  private long reservedVirtualCores;
+
+  private long pendingMB;
+  private long pendingVirtualCores;
+
+  private int containersAllocated;
+  private int containersReserved;
+  private int containersPending;
+
+  public PartitionClusterMetricsInfo() {
+  }
+
+  public PartitionClusterMetricsInfo(String partitionName, Resource total,
+      Resource allocated, Resource reserved, Resource pending,
+      Resource available, int containersAllocated, int containersReserved,
+      int containersPending) {
+    this.partitionName = partitionName;
+    this.totalMB = total.getMemorySize();
+    this.totalVirtualCores = total.getVirtualCores();
+    this.allocatedMB = allocated.getMemorySize();
+    this.allocatedVirtualCores = allocated.getVirtualCores();
+    this.reservedMB = reserved.getMemorySize();
+    this.reservedVirtualCores = reserved.getVirtualCores();
+    this.pendingMB = pending.getMemorySize();
+    this.pendingVirtualCores = pending.getVirtualCores();
+    this.availableMB = available.getMemorySize();
+    this.availableVirtualCores = available.getVirtualCores();
+    this.containersAllocated = containersAllocated;
+    this.containersReserved = containersReserved;
+    this.containersPending = containersPending;
+  }
+
+  public String getPartitionName() {
+    return partitionName;
+  }
+
+  public long getTotalMB() {
+    return totalMB;
+  }
+
+  public long getTotalVirtualCores() {
+    return totalVirtualCores;
+  }
+
+  public long getAvailableMB() {
+    return availableMB;
+  }
+
+  public long getAvailableVirtualCores() {
+    return availableVirtualCores;
+  }
+
+  public long getAllocatedMB() {
+    return allocatedMB;
+  }
+
+  public long getAllocatedVirtualCores() {
+    return allocatedVirtualCores;
+  }
+
+  public long getReservedMB() {
+    return reservedMB;
+  }
+
+  public long getReservedVirtualCores() {
+    return reservedVirtualCores;
+  }
+
+  public long getPendingMB() {
+    return pendingMB;
+  }
+
+  public long getPendingVirtualCores() {
+    return pendingVirtualCores;
+  }
+
+  public int getContainersAllocated() {
+    return containersAllocated;
+  }
+
+  public int getContainersReserved() {
+    return containersReserved;
+  }
+
+  public int getContainersPending() {
+    return containersPending;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ClassSerialisationConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/jsonprovider/ClassSerialisationConfig.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeLabelsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeToLabelsEntryList;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeToLabelsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodesInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.PartitionClusterMetricsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.QueueAclInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.QueueAclsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.RMQueueAclInfo;
@@ -153,7 +154,8 @@ public class ClassSerialisationConfig {
           CapacitySchedulerQueueInfo.class, CapacitySchedulerQueueInfoList.class, ClusterInfo.class,
           ClusterMetricsInfo.class, ConfigVersionInfo.class, ContainerInfo.class,
           FairSchedulerQueueInfoList.class, FifoSchedulerInfo.class, NewReservation.class,
-          NodeInfo.class, NodesInfo.class, QueueAclInfo.class, QueueAclsInfo.class,
+          NodeInfo.class, NodesInfo.class, PartitionClusterMetricsInfo.class,
+          QueueAclInfo.class, QueueAclsInfo.class,
           RemoteExceptionData.class, ReservationDeleteRequestInfo.class,
           ReservationDeleteResponseInfo.class, ReservationSubmissionRequestInfo.class,
           ReservationUpdateRequestInfo.class, ReservationUpdateResponseInfo.class,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
@@ -340,6 +340,47 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testClusterMetricsWithPartitions(boolean pLegacyQueueMode)
+      throws Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
+    WebTarget r = targetWithJsonObject();
+    Response response = r.path("ws").path("v1").path("cluster")
+        .path("metrics").request(MediaType.APPLICATION_JSON).get(Response.class);
+    assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
+        response.getMediaType().toString());
+
+    JSONObject clusterMetrics = response.readEntity(JSONObject.class)
+        .getJSONObject("clusterMetrics");
+    assertEquals(2 * 1024 + 2 * 128 * 1024, clusterMetrics.getInt("totalMB"));
+    assertEquals(2 + 2 * 128, clusterMetrics.getInt("totalVirtualCores"));
+    assertEquals(2 * 1024 + 2 * 128 * 1024, clusterMetrics.getInt("availableMB"));
+    assertEquals(2 + 2 * 128, clusterMetrics.getInt("availableVirtualCores"));
+    assertEquals(0, clusterMetrics.getInt("allocatedMB"));
+    assertEquals(0, clusterMetrics.getInt("allocatedVirtualCores"));
+    assertEquals(0, clusterMetrics.getInt("reservedMB"));
+    assertEquals(0, clusterMetrics.getInt("reservedVirtualCores"));
+    assertEquals(0, clusterMetrics.getInt("pendingMB"));
+    assertEquals(0, clusterMetrics.getInt("pendingVirtualCores"));
+    assertTrue(clusterMetrics.getBoolean("crossPartitionMetricsAvailable"));
+
+    verifyResourceInfo(clusterMetrics.getJSONObject("totalClusterResourcesAcrossPartition"),
+        2 * 1024 + 2 * 128 * 1024, 2 + 2 * 128);
+    verifyResourceInfo(clusterMetrics.getJSONObject("totalUsedResourcesAcrossPartition"),
+        0, 0);
+    verifyResourceInfo(clusterMetrics.getJSONObject("totalReservedResourcesAcrossPartition"),
+        0, 0);
+    assertEquals(0, clusterMetrics.getInt("totalAllocatedContainersAcrossPartition"));
+
+    JSONArray partitionMetrics = clusterMetrics.getJSONArray("partitionClusterMetrics");
+    assertEquals(3, partitionMetrics.length());
+
+    verifyPartitionMetrics(partitionMetrics, DEFAULT_PARTITION, 128 * 1024, 128, 128 * 1024, 128);
+    verifyPartitionMetrics(partitionMetrics, LABEL_LX, 2 * 1024, 2, 2 * 1024, 2);
+    verifyPartitionMetrics(partitionMetrics, LABEL_LY, 128 * 1024, 128, 128 * 1024, 128);
+  }
+
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
   public void testPartitionInSchedulerActivities(boolean pLegacyQueueMode)
       throws Exception {
     initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
@@ -410,6 +451,47 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
         queueCObj.get(0).optString(FN_ACT_ALLOCATION_STATE));
     assertEquals(ActivityDiagnosticConstant.QUEUE_DO_NOT_NEED_MORE_RESOURCE,
         queueCObj.get(0).optString(FN_ACT_DIAGNOSTIC));
+  }
+
+  private void verifyResourceInfo(JSONObject resourceInfo, long memory,
+      int vCores) throws JSONException {
+    assertEquals(memory, resourceInfo.getLong("memory"));
+    assertEquals(vCores, resourceInfo.getInt("vCores"));
+  }
+
+  private void verifyPartitionMetrics(JSONArray partitionMetrics,
+      String partitionName, long totalMB, int totalVirtualCores,
+      long availableMB, int availableVirtualCores) throws JSONException {
+    JSONObject partitionMetric = getPartitionMetrics(
+        partitionMetrics, partitionName);
+    assertEquals(partitionName, partitionMetric.getString("partitionName"));
+    assertEquals(totalMB, partitionMetric.getLong("totalMB"));
+    assertEquals(totalVirtualCores,
+        partitionMetric.getInt("totalVirtualCores"));
+    assertEquals(availableMB, partitionMetric.getLong("availableMB"));
+    assertEquals(availableVirtualCores,
+        partitionMetric.getInt("availableVirtualCores"));
+    assertEquals(0, partitionMetric.getLong("allocatedMB"));
+    assertEquals(0, partitionMetric.getInt("allocatedVirtualCores"));
+    assertEquals(0, partitionMetric.getLong("reservedMB"));
+    assertEquals(0, partitionMetric.getInt("reservedVirtualCores"));
+    assertEquals(0, partitionMetric.getLong("pendingMB"));
+    assertEquals(0, partitionMetric.getInt("pendingVirtualCores"));
+    assertEquals(0, partitionMetric.getInt("containersAllocated"));
+    assertEquals(0, partitionMetric.getInt("containersReserved"));
+    assertEquals(0, partitionMetric.getInt("containersPending"));
+  }
+
+  private JSONObject getPartitionMetrics(JSONArray partitionMetrics,
+      String partitionName) throws JSONException {
+    for (int i = 0; i < partitionMetrics.length(); i++) {
+      JSONObject partitionMetric = partitionMetrics.getJSONObject(i);
+      if (partitionName.equals(partitionMetric.getString("partitionName"))) {
+        return partitionMetric;
+      }
+    }
+    fail("Missing partition metrics for " + partitionName);
+    return null;
   }
 
   private void verifySchedulerInfoXML(Document dom) throws Exception {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.util.XMLUtils;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.MockAM;
@@ -67,8 +68,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.MockRMAppSubmitter;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceUsage;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.activities.ActivityDiagnosticConstant;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.activities.ActivityState;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueuePath;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.jsonprovider.JsonProviderFeature;
@@ -374,9 +377,12 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     JSONArray partitionMetrics = clusterMetrics.getJSONArray("partitionClusterMetrics");
     assertEquals(3, partitionMetrics.length());
 
-    verifyPartitionMetrics(partitionMetrics, DEFAULT_PARTITION, 128 * 1024, 128, 128 * 1024, 128);
-    verifyPartitionMetrics(partitionMetrics, LABEL_LX, 2 * 1024, 2, 2 * 1024, 2);
-    verifyPartitionMetrics(partitionMetrics, LABEL_LY, 128 * 1024, 128, 128 * 1024, 128);
+    verifyPartitionMetrics(partitionMetrics, DEFAULT_PARTITION,
+        128 * 1024, 128, 0, 0, 0, 0, 128 * 1024, 128);
+    verifyPartitionMetrics(partitionMetrics, LABEL_LX,
+        2 * 1024, 2, 0, 0, 0, 0, 2 * 1024, 2);
+    verifyPartitionMetrics(partitionMetrics, LABEL_LY,
+        128 * 1024, 128, 0, 0, 0, 0, 128 * 1024, 128);
   }
 
   @MethodSource("getParameters")
@@ -434,11 +440,128 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     assertEquals(3, partitionMetricsXml.getLength());
 
     verifyPartitionMetricsXML(partitionMetricsXml, DEFAULT_PARTITION,
-        128 * 1024, 128, 128 * 1024, 128);
+        128 * 1024, 128, 0, 0, 0, 0, 128 * 1024, 128);
     verifyPartitionMetricsXML(partitionMetricsXml, LABEL_LX,
-        2 * 1024, 2, 2 * 1024, 2);
+        2 * 1024, 2, 0, 0, 0, 0, 2 * 1024, 2);
     verifyPartitionMetricsXML(partitionMetricsXml, LABEL_LY,
-        128 * 1024, 128, 128 * 1024, 128);
+        128 * 1024, 128, 0, 0, 0, 0, 128 * 1024, 128);
+  }
+
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testClusterMetricsWithPartitionsWithReserved(
+      boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
+    CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
+    ResourceUsage rootUsage = cs.getRootQueue().getQueueResourceUsage();
+    rootUsage.incUsed(LABEL_LX, Resource.newInstance(2 * 1024, 2));
+    rootUsage.incReserved(LABEL_LX, Resource.newInstance(1024, 1));
+    rootUsage.incUsed(LABEL_LY, Resource.newInstance(4 * 1024, 4));
+    rootUsage.incReserved(LABEL_LY, Resource.newInstance(1024, 1));
+
+    WebTarget r = targetWithJsonObject();
+    Response response = r.path("ws").path("v1").path("cluster")
+        .path("metrics").request(MediaType.APPLICATION_JSON).get(Response.class);
+    assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
+        response.getMediaType().toString());
+
+    JSONObject clusterMetrics = response.readEntity(JSONObject.class)
+        .getJSONObject("clusterMetrics");
+    assertEquals(2 * 1024 + 2 * 128 * 1024, clusterMetrics.getInt("totalMB"));
+    assertEquals(2 + 2 * 128, clusterMetrics.getInt("totalVirtualCores"));
+    assertEquals(4 * 1024, clusterMetrics.getInt("allocatedMB"));
+    assertEquals(4, clusterMetrics.getInt("allocatedVirtualCores"));
+    assertEquals(2 * 1024, clusterMetrics.getInt("reservedMB"));
+    assertEquals(2, clusterMetrics.getInt("reservedVirtualCores"));
+    assertEquals(2 * 1024 + 2 * 128 * 1024 - 6 * 1024,
+        clusterMetrics.getInt("availableMB"));
+    assertEquals(2 + 2 * 128 - 6, clusterMetrics.getInt("availableVirtualCores"));
+    assertTrue(clusterMetrics.getBoolean("crossPartitionMetricsAvailable"));
+
+    verifyResourceInfo(clusterMetrics.getJSONObject(
+        "totalUsedResourcesAcrossPartition"), 6 * 1024, 6);
+    verifyResourceInfo(clusterMetrics.getJSONObject(
+        "totalReservedResourcesAcrossPartition"), 2 * 1024, 2);
+    verifyResourceInfo(clusterMetrics.getJSONObject(
+        "totalClusterResourcesAcrossPartition"),
+        2 * 1024 + 2 * 128 * 1024, 2 + 2 * 128);
+
+    JSONArray partitionMetrics = clusterMetrics.getJSONArray(
+        "partitionClusterMetrics");
+    assertEquals(3, partitionMetrics.length());
+    verifyPartitionMetrics(partitionMetrics, DEFAULT_PARTITION,
+        128 * 1024, 128, 0, 0, 0, 0, 128 * 1024, 128);
+    verifyPartitionMetrics(partitionMetrics, LABEL_LX,
+        2 * 1024, 2, 1024, 1, 1024, 1, 0, 0);
+    verifyPartitionMetrics(partitionMetrics, LABEL_LY,
+        128 * 1024, 128, 3 * 1024, 3, 1024, 1, 124 * 1024, 124);
+  }
+
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testClusterMetricsWithPartitionsWithReservedXML(
+      boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
+    CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
+    ResourceUsage rootUsage = cs.getRootQueue().getQueueResourceUsage();
+    rootUsage.incUsed(LABEL_LX, Resource.newInstance(2 * 1024, 2));
+    rootUsage.incReserved(LABEL_LX, Resource.newInstance(1024, 1));
+    rootUsage.incUsed(LABEL_LY, Resource.newInstance(4 * 1024, 4));
+    rootUsage.incReserved(LABEL_LY, Resource.newInstance(1024, 1));
+
+    WebTarget r = target();
+    Response response = r.path("ws").path("v1").path("cluster")
+        .path("metrics").request(MediaType.APPLICATION_XML).get(Response.class);
+    assertEquals(MediaType.APPLICATION_XML_TYPE + ";" + JettyUtils.UTF_8,
+        response.getMediaType().toString());
+
+    String xml = response.readEntity(String.class);
+    DocumentBuilderFactory dbf = XMLUtils.newSecureDocumentBuilderFactory();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    InputSource is = new InputSource();
+    is.setCharacterStream(new StringReader(xml));
+    Document dom = db.parse(is);
+
+    NodeList nodes = dom.getElementsByTagName("clusterMetrics");
+    assertEquals(1, nodes.getLength());
+    Element clusterMetrics = (Element) nodes.item(0);
+
+    assertEquals(2 * 1024 + 2 * 128 * 1024,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "totalMB"));
+    assertEquals(2 + 2 * 128,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "totalVirtualCores"));
+    assertEquals(4 * 1024,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "allocatedMB"));
+    assertEquals(4,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "allocatedVirtualCores"));
+    assertEquals(2 * 1024,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "reservedMB"));
+    assertEquals(2,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "reservedVirtualCores"));
+    assertEquals(2 * 1024 + 2 * 128 * 1024 - 6 * 1024,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "availableMB"));
+    assertEquals(2 + 2 * 128 - 6,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "availableVirtualCores"));
+    assertTrue(WebServicesTestUtils.getXmlBoolean(
+        clusterMetrics, "crossPartitionMetricsAvailable"));
+
+    verifyResourceInfoXML(getSingleChild(clusterMetrics,
+            "totalClusterResourcesAcrossPartition"),
+        2 * 1024 + 2 * 128 * 1024, 2 + 2 * 128);
+    verifyResourceInfoXML(getSingleChild(clusterMetrics,
+            "totalUsedResourcesAcrossPartition"), 6 * 1024, 6);
+    verifyResourceInfoXML(getSingleChild(clusterMetrics,
+            "totalReservedResourcesAcrossPartition"), 2 * 1024, 2);
+
+    NodeList partitionMetricsXml = clusterMetrics
+        .getElementsByTagName("partitionClusterMetrics");
+    assertEquals(3, partitionMetricsXml.getLength());
+    verifyPartitionMetricsXML(partitionMetricsXml, DEFAULT_PARTITION,
+        128 * 1024, 128, 0, 0, 0, 0, 128 * 1024, 128);
+    verifyPartitionMetricsXML(partitionMetricsXml, LABEL_LX,
+        2 * 1024, 2, 1024, 1, 1024, 1, 0, 0);
+    verifyPartitionMetricsXML(partitionMetricsXml, LABEL_LY,
+        128 * 1024, 128, 3 * 1024, 3, 1024, 1, 124 * 1024, 124);
   }
 
   @MethodSource("getParameters")
@@ -523,6 +646,8 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
 
   private void verifyPartitionMetrics(JSONArray partitionMetrics,
       String partitionName, long totalMB, int totalVirtualCores,
+      long allocatedMB, int allocatedVirtualCores,
+      long reservedMB, int reservedVirtualCores,
       long availableMB, int availableVirtualCores) throws JSONException {
     JSONObject partitionMetric = getPartitionMetrics(
         partitionMetrics, partitionName);
@@ -530,13 +655,15 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     assertEquals(totalMB, partitionMetric.getLong("totalMB"));
     assertEquals(totalVirtualCores,
         partitionMetric.getInt("totalVirtualCores"));
+    assertEquals(allocatedMB, partitionMetric.getLong("allocatedMB"));
+    assertEquals(allocatedVirtualCores,
+        partitionMetric.getInt("allocatedVirtualCores"));
+    assertEquals(reservedMB, partitionMetric.getLong("reservedMB"));
+    assertEquals(reservedVirtualCores,
+        partitionMetric.getInt("reservedVirtualCores"));
     assertEquals(availableMB, partitionMetric.getLong("availableMB"));
     assertEquals(availableVirtualCores,
         partitionMetric.getInt("availableVirtualCores"));
-    assertEquals(0, partitionMetric.getLong("allocatedMB"));
-    assertEquals(0, partitionMetric.getInt("allocatedVirtualCores"));
-    assertEquals(0, partitionMetric.getLong("reservedMB"));
-    assertEquals(0, partitionMetric.getInt("reservedVirtualCores"));
     assertEquals(0, partitionMetric.getLong("pendingMB"));
     assertEquals(0, partitionMetric.getInt("pendingVirtualCores"));
     assertEquals(0, partitionMetric.getInt("containersAllocated"));
@@ -564,6 +691,8 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
 
   private void verifyPartitionMetricsXML(NodeList partitionMetrics,
       String partitionName, long totalMB, int totalVirtualCores,
+      long allocatedMB, int allocatedVirtualCores,
+      long reservedMB, int reservedVirtualCores,
       long availableMB, int availableVirtualCores) {
     Element partitionMetric = getPartitionMetricsXML(partitionMetrics, partitionName);
     assertEquals(partitionName,
@@ -572,18 +701,18 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
         WebServicesTestUtils.getXmlLong(partitionMetric, "totalMB"));
     assertEquals(totalVirtualCores,
         WebServicesTestUtils.getXmlLong(partitionMetric, "totalVirtualCores"));
+    assertEquals(allocatedMB,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "allocatedMB"));
+    assertEquals(allocatedVirtualCores, WebServicesTestUtils.getXmlLong(
+        partitionMetric, "allocatedVirtualCores"));
+    assertEquals(reservedMB,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "reservedMB"));
+    assertEquals(reservedVirtualCores, WebServicesTestUtils.getXmlLong(
+        partitionMetric, "reservedVirtualCores"));
     assertEquals(availableMB,
         WebServicesTestUtils.getXmlLong(partitionMetric, "availableMB"));
-    assertEquals(availableVirtualCores,
-        WebServicesTestUtils.getXmlLong(partitionMetric, "availableVirtualCores"));
-    assertEquals(0,
-        WebServicesTestUtils.getXmlLong(partitionMetric, "allocatedMB"));
-    assertEquals(0,
-        WebServicesTestUtils.getXmlLong(partitionMetric, "allocatedVirtualCores"));
-    assertEquals(0,
-        WebServicesTestUtils.getXmlLong(partitionMetric, "reservedMB"));
-    assertEquals(0,
-        WebServicesTestUtils.getXmlLong(partitionMetric, "reservedVirtualCores"));
+    assertEquals(availableVirtualCores, WebServicesTestUtils.getXmlLong(
+        partitionMetric, "availableVirtualCores"));
     assertEquals(0,
         WebServicesTestUtils.getXmlLong(partitionMetric, "pendingMB"));
     assertEquals(0,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
@@ -381,6 +381,68 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testClusterMetricsWithPartitionsXML(boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
+    WebTarget r = target();
+    Response response = r.path("ws").path("v1").path("cluster")
+        .path("metrics").request(MediaType.APPLICATION_XML).get(Response.class);
+    assertEquals(MediaType.APPLICATION_XML_TYPE + ";" + JettyUtils.UTF_8,
+        response.getMediaType().toString());
+
+    String xml = response.readEntity(String.class);
+    DocumentBuilderFactory dbf = XMLUtils.newSecureDocumentBuilderFactory();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    InputSource is = new InputSource();
+    is.setCharacterStream(new StringReader(xml));
+    Document dom = db.parse(is);
+
+    NodeList nodes = dom.getElementsByTagName("clusterMetrics");
+    assertEquals(1, nodes.getLength());
+    Element clusterMetrics = (Element) nodes.item(0);
+
+    assertEquals(2 * 1024 + 2 * 128 * 1024,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "totalMB"));
+    assertEquals(2 + 2 * 128,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "totalVirtualCores"));
+    assertEquals(2 * 1024 + 2 * 128 * 1024,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "availableMB"));
+    assertEquals(2 + 2 * 128,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "availableVirtualCores"));
+    assertEquals(0, WebServicesTestUtils.getXmlLong(clusterMetrics, "allocatedMB"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "allocatedVirtualCores"));
+    assertEquals(0, WebServicesTestUtils.getXmlLong(clusterMetrics, "reservedMB"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "reservedVirtualCores"));
+    assertEquals(0, WebServicesTestUtils.getXmlLong(clusterMetrics, "pendingMB"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(clusterMetrics, "pendingVirtualCores"));
+    assertTrue(WebServicesTestUtils.getXmlBoolean(
+        clusterMetrics, "crossPartitionMetricsAvailable"));
+
+    verifyResourceInfoXML(getSingleChild(clusterMetrics,
+            "totalClusterResourcesAcrossPartition"),
+        2 * 1024 + 2 * 128 * 1024, 2 + 2 * 128);
+    verifyResourceInfoXML(getSingleChild(clusterMetrics,
+            "totalUsedResourcesAcrossPartition"), 0, 0);
+    verifyResourceInfoXML(getSingleChild(clusterMetrics,
+            "totalReservedResourcesAcrossPartition"), 0, 0);
+    assertEquals(0, WebServicesTestUtils.getXmlInt(clusterMetrics,
+        "totalAllocatedContainersAcrossPartition"));
+
+    NodeList partitionMetricsXml = clusterMetrics.getElementsByTagName("partitionClusterMetrics");
+    assertEquals(3, partitionMetricsXml.getLength());
+
+    verifyPartitionMetricsXML(partitionMetricsXml, DEFAULT_PARTITION,
+        128 * 1024, 128, 128 * 1024, 128);
+    verifyPartitionMetricsXML(partitionMetricsXml, LABEL_LX,
+        2 * 1024, 2, 2 * 1024, 2);
+    verifyPartitionMetricsXML(partitionMetricsXml, LABEL_LY,
+        128 * 1024, 128, 128 * 1024, 128);
+  }
+
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
   public void testPartitionInSchedulerActivities(boolean pLegacyQueueMode)
       throws Exception {
     initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
@@ -492,6 +554,66 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     }
     fail("Missing partition metrics for " + partitionName);
     return null;
+  }
+
+  private void verifyResourceInfoXML(Element resourceInfo, long memory,
+      int vCores) {
+    assertEquals(memory, WebServicesTestUtils.getXmlLong(resourceInfo, "memory"));
+    assertEquals(vCores, WebServicesTestUtils.getXmlInt(resourceInfo, "vCores"));
+  }
+
+  private void verifyPartitionMetricsXML(NodeList partitionMetrics,
+      String partitionName, long totalMB, int totalVirtualCores,
+      long availableMB, int availableVirtualCores) {
+    Element partitionMetric = getPartitionMetricsXML(partitionMetrics, partitionName);
+    assertEquals(partitionName,
+        WebServicesTestUtils.getXmlString(partitionMetric, "partitionName"));
+    assertEquals(totalMB,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "totalMB"));
+    assertEquals(totalVirtualCores,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "totalVirtualCores"));
+    assertEquals(availableMB,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "availableMB"));
+    assertEquals(availableVirtualCores,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "availableVirtualCores"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "allocatedMB"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "allocatedVirtualCores"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "reservedMB"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "reservedVirtualCores"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "pendingMB"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlLong(partitionMetric, "pendingVirtualCores"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlInt(partitionMetric, "containersAllocated"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlInt(partitionMetric, "containersReserved"));
+    assertEquals(0,
+        WebServicesTestUtils.getXmlInt(partitionMetric, "containersPending"));
+  }
+
+  private Element getPartitionMetricsXML(NodeList partitionMetrics,
+      String partitionName) {
+    for (int i = 0; i < partitionMetrics.getLength(); i++) {
+      Element partitionMetric = (Element) partitionMetrics.item(i);
+      if (partitionName.equals(WebServicesTestUtils.getXmlString(
+          partitionMetric, "partitionName"))) {
+        return partitionMetric;
+      }
+    }
+    fail("Missing partition metrics for " + partitionName);
+    return null;
+  }
+
+  private Element getSingleChild(Element parent, String name) {
+    NodeList nodes = parent.getElementsByTagName(name);
+    assertEquals(1, nodes.getLength(),
+        "Expected exactly one <" + name + "> under <" + parent.getNodeName() + ">");
+    return (Element) nodes.item(0);
   }
 
   private void verifySchedulerInfoXML(Document dom) throws Exception {


### PR DESCRIPTION
### Description of PR

When node labels are enabled, different labels represent separate resource pools. However, the RM REST API `/ws/v1/cluster/metrics` currently exposes fields such as totalMB and totalVirtualCores based on the default partition only. As a result, resources from non-default partitions are not visible to external resource management systems, which may incorrectly determine that the cluster has no available capacity after new labels are added.

The API should expose cluster resource metrics across all partitions and provide partition-level metrics so clients can distinguish capacity and usage by node label.

### How was this patch tested?

unit test and test in cluster based on internal hadoop version.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html