### PR TITLE
HDFS-17935. [ARR] Separate router async handlers for active and observer

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -90,7 +90,7 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final int DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT = 10;
   public static final String DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY =
       FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "observer.handler.count";
-  public static final int DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_DEFAULT = 20;
+  public static final int DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_DEFAULT = 0;
   public static final String DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE =
       FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "queue.size";
   public static final int DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT = 1000;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -82,9 +82,15 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final String DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY =
           FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "ns.handler.count";
   public static final String DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT = "";
+  // Example: ns1:count1,ns2:count2,ns3:count3
+  public static final String DFS_ROUTER_ASYNC_RPC_NS_OBSERVER_HANDLER_COUNT_KEY =
+      FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "ns.observer.handler.count";
   public static final String DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY =
           FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "handler.count";
   public static final int DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT = 10;
+  public static final String DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY =
+      FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "observer.handler.count";
+  public static final int DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_DEFAULT = 20;
   public static final String DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE =
       FEDERATION_ROUTER_ASYNC_RPC_PREFIX + "queue.size";
   public static final int DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT = 1000;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -301,6 +301,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   private final boolean enableAsync;
   private final Map<String, ThreadPoolExecutor> asyncRouterHandlerExecutors =
       new ConcurrentHashMap<>();
+  private boolean useSeparateAsyncRouterOBHandlerExecutors = false;
   private final Map<String, ThreadPoolExecutor> asyncRouterOBHandlerExecutors =
       new ConcurrentHashMap<>();
   private ThreadPoolExecutor routerDefaultAsyncHandlerExecutor;
@@ -543,7 +544,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   private void initAsyncHandlerThreadPools(Configuration configuration, Set<String> allConfiguredNS,
       boolean useObserver, String handlerCountKey, int handlerCountDefault,
       Map<String, Integer> nsAsyncHandlerCount, Map<String, ThreadPoolExecutor> executors) {
-    LOG.info("Initializing asynchronous handler thread pools");
     String namenodeTypeForLogging = useObserver ? "Observer Namenode" : "Active Namenode";
     int asyncQueueSize = configuration.getInt(DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE,
         DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT);
@@ -551,9 +551,18 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       throw new IllegalArgumentException("Async queue size must be at least 1");
     }
     int asyncHandlerCountDefault = configuration.getInt(handlerCountKey, handlerCountDefault);
-    if (asyncHandlerCountDefault < 1) {
-      throw new  IllegalArgumentException("Async handler count must be at least 1");
+    // Skip separate observer handlers and let them share with active if not configured
+    if (asyncHandlerCountDefault < 1 && nsAsyncHandlerCount.isEmpty() && useObserver) {
+      LOG.info("Async observer handlers are not configured, skipping...");
+      return;
+    } else {
+      useSeparateAsyncRouterOBHandlerExecutors = true;
     }
+
+    if (asyncHandlerCountDefault < 1) {
+      throw new IllegalArgumentException("Async handler count must be at least 1");
+    }
+    LOG.info("Initializing asynchronous handler thread pools");
     for (String nsId : allConfiguredNS) {
       int dedicatedHandlers = nsAsyncHandlerCount.getOrDefault(nsId, 0);
       if (dedicatedHandlers <= 0) {
@@ -636,7 +645,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
    * @return the corresponding thread pool
    */
   public ThreadPoolExecutor getAsyncExecutorForNamespace(String nsId, boolean useObserver) {
-    ThreadPoolExecutor executor = useObserver ?
+    ThreadPoolExecutor executor = useObserver && useSeparateAsyncRouterOBHandlerExecutors ?
             asyncRouterOBHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor) :
             asyncRouterHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor);
     if (rpcMonitor != null && executor != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -569,8 +569,8 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       executors.computeIfAbsent(nsId, id -> {
         LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
         return new ThreadPoolExecutor(finalDedicatedHandlers, finalDedicatedHandlers, 0L,
-            TimeUnit.MILLISECONDS, queue,
-            new AsyncThreadFactory("Router Async " + namenodeTypeForLogging + " Handler for " + nsId + " #"));
+            TimeUnit.MILLISECONDS, queue, new AsyncThreadFactory(
+            "Router Async " + namenodeTypeForLogging + " Handler for " + nsId + " #"));
       });
       LOG.info("Assigned {} async handlers with queue size {} to nsId {} for {}", dedicatedHandlers,
           asyncQueueSize, nsId, namenodeTypeForLogging);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -555,12 +555,13 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     if (asyncHandlerCountDefault < 1 && nsAsyncHandlerCount.isEmpty() && useObserver) {
       LOG.info("Async observer handlers are not configured, skipping...");
       return;
-    } else {
-      useSeparateAsyncRouterOBHandlerExecutors = true;
     }
 
     if (asyncHandlerCountDefault < 1) {
       throw new IllegalArgumentException("Async handler count must be at least 1");
+    }
+    if (useObserver) {
+      useSeparateAsyncRouterOBHandlerExecutors = true;
     }
     LOG.info("Initializing asynchronous handler thread pools");
     for (String nsId : allConfiguredNS) {
@@ -645,13 +646,21 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
    * @return the corresponding thread pool
    */
   public ThreadPoolExecutor getAsyncExecutorForNamespace(String nsId, boolean useObserver) {
-    ThreadPoolExecutor executor = useObserver && useSeparateAsyncRouterOBHandlerExecutors ?
-            asyncRouterOBHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor) :
-            asyncRouterHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor);
+    ThreadPoolExecutor executor = getAsyncExecutorForNamespaceInternal(nsId, useObserver);
     if (rpcMonitor != null && executor != null) {
       rpcMonitor.recordAsyncHandlerQueueSize(nsId, executor.getQueue().size());
     }
     return executor;
+  }
+
+  private ThreadPoolExecutor getAsyncExecutorForNamespaceInternal(String nsId, boolean useObserver) {
+    if (useObserver && useSeparateAsyncRouterOBHandlerExecutors) {
+      ThreadPoolExecutor observerExecutor = asyncRouterOBHandlerExecutors.get(nsId);
+      if (observerExecutor != null) {
+        return observerExecutor;
+      }
+    }
+    return asyncRouterHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -23,8 +23,10 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_NS_OBSERVER_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
@@ -299,6 +301,8 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   private final boolean enableAsync;
   private final Map<String, ThreadPoolExecutor> asyncRouterHandlerExecutors =
       new ConcurrentHashMap<>();
+  private final Map<String, ThreadPoolExecutor> asyncRouterOBHandlerExecutors =
+      new ConcurrentHashMap<>();
   private ThreadPoolExecutor routerDefaultAsyncHandlerExecutor;
   private ExecutorService routerAsyncResponderExecutor;
 
@@ -509,21 +513,44 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   public void initAsyncThreadPools(Configuration configuration) {
     Set<String> allConfiguredNS = FederationUtil.getAllConfiguredNS(configuration);
     allConfiguredNS.add(CONCURRENT_NS);
-    Map<String, Integer> nsAsyncActiveHandlerCount = parseNsAsyncHandlerCount(configuration);
-    initAsyncHandlerThreadPools(configuration, allConfiguredNS, nsAsyncActiveHandlerCount);
+    Map<String, Integer> nsAsyncActiveHandlerCount = parseNsAsyncHandlerCount(configuration,
+        DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY);
+    initAsyncHandlerThreadPools(configuration, allConfiguredNS, false,
+        DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT,
+        nsAsyncActiveHandlerCount, asyncRouterHandlerExecutors);
+
+    Map<String, Integer> nsAsyncObserverHandlerCount = parseNsAsyncHandlerCount(configuration,
+        DFS_ROUTER_ASYNC_RPC_NS_OBSERVER_HANDLER_COUNT_KEY);
+    initAsyncHandlerThreadPools(configuration, allConfiguredNS, true,
+        DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY,
+        DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_DEFAULT, nsAsyncObserverHandlerCount,
+        asyncRouterOBHandlerExecutors);
+
     initAsyncResponderThreadPools(configuration);
   }
 
-  private void initAsyncHandlerThreadPools(Configuration configuration,
-      Set<String> allConfiguredNS, Map<String, Integer> nsAsyncHandlerCount) {
+  /**
+   * Initializes async handler executors for each configured namespace.
+   *
+   * @param configuration        router configuration
+   * @param allConfiguredNS      set of all configured namespace IDs
+   * @param useObserver         true if these handlers serve observer namenodes
+   * @param handlerCountKey     key for the default handler count
+   * @param handlerCountDefault default handler count
+   * @param nsAsyncHandlerCount per-namespace handler counts
+   * @param executors           executor map to populate
+   */
+  private void initAsyncHandlerThreadPools(Configuration configuration, Set<String> allConfiguredNS,
+      boolean useObserver, String handlerCountKey, int handlerCountDefault,
+      Map<String, Integer> nsAsyncHandlerCount, Map<String, ThreadPoolExecutor> executors) {
     LOG.info("Initializing asynchronous handler thread pools");
+    String namenodeTypeForLogging = useObserver ? "Observer Namenode" : "Active Namenode";
     int asyncQueueSize = configuration.getInt(DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE,
         DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE_DEFAULT);
     if (asyncQueueSize < 1) {
       throw new IllegalArgumentException("Async queue size must be at least 1");
     }
-    int asyncHandlerCountDefault = configuration.getInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY,
-        DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_DEFAULT);
+    int asyncHandlerCountDefault = configuration.getInt(handlerCountKey, handlerCountDefault);
     if (asyncHandlerCountDefault < 1) {
       throw new  IllegalArgumentException("Async handler count must be at least 1");
     }
@@ -531,22 +558,22 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       int dedicatedHandlers = nsAsyncHandlerCount.getOrDefault(nsId, 0);
       if (dedicatedHandlers <= 0) {
         dedicatedHandlers = asyncHandlerCountDefault;
-        LOG.info("Use default async handler count {} for ns {} to init Executors.",
-            asyncHandlerCountDefault, nsId);
+        LOG.info("Use default async handler count {} for ns {} to init {} Executors.",
+            asyncHandlerCountDefault, nsId, namenodeTypeForLogging);
       } else {
-        LOG.info("Dedicated handlers {} for ns {} to init Executors", dedicatedHandlers, nsId);
+        LOG.info("Dedicated handlers {} for ns {} to init {} Executors", dedicatedHandlers, nsId,
+            namenodeTypeForLogging);
       }
 
       int finalDedicatedHandlers = dedicatedHandlers;
-      asyncRouterHandlerExecutors.computeIfAbsent(nsId,
-          id -> {
-            LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
-            return new ThreadPoolExecutor(finalDedicatedHandlers, finalDedicatedHandlers,
-                0L, TimeUnit.MILLISECONDS, queue,
-                new AsyncThreadFactory("Router Async Handler for " + nsId + " #"));
-          });
-      LOG.info("Assigned {} async handlers with queue size {} to nsId {}", dedicatedHandlers,
-          asyncQueueSize, nsId);
+      executors.computeIfAbsent(nsId, id -> {
+        LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(asyncQueueSize);
+        return new ThreadPoolExecutor(finalDedicatedHandlers, finalDedicatedHandlers, 0L,
+            TimeUnit.MILLISECONDS, queue,
+            new AsyncThreadFactory("Router Async " + namenodeTypeForLogging + " Handler for " + nsId + " #"));
+      });
+      LOG.info("Assigned {} async handlers with queue size {} to nsId {} for {}", dedicatedHandlers,
+          asyncQueueSize, nsId, namenodeTypeForLogging);
     }
 
     if (routerDefaultAsyncHandlerExecutor == null) {
@@ -571,23 +598,27 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     AsyncRpcProtocolPBUtil.setAsyncResponderExecutor(routerAsyncResponderExecutor);
   }
 
-  private Map<String, Integer> parseNsAsyncHandlerCount(Configuration config) {
-    String configNsHandler = config.get(DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY,
-        DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT);
+  /**
+   * Parses per-namespace async handler counts from an ns:count list.
+   * @param config router configuration
+   * @param key configuration key to read
+   * @return map of namespace id -> handler count
+   */
+  private Map<String, Integer> parseNsAsyncHandlerCount(Configuration config, String key) {
+    String configNsHandler =
+        config.get(key, RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_DEFAULT);
     Map<String, Integer> nsAsyncHandlerCount = new HashMap<>();
     if (StringUtils.isEmpty(configNsHandler)) {
       LOG.info("No per-namespace async handler counts configured ({}). "
-              + "Will use default handler count for all namespaces.",
-          DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY);
+          + "Will use default handler count for all namespaces.", key);
       return nsAsyncHandlerCount;
     }
     String[] nsHandlers = configNsHandler.split(",");
     for (String nsHandlerInfo : nsHandlers) {
       String[] nsHandlerItems = nsHandlerInfo.split(":");
-      if (nsHandlerItems.length != 2 || StringUtils.isBlank(nsHandlerItems[0]) ||
-          !StringUtils.isNumeric(nsHandlerItems[1])) {
-        LOG.error("The config key: {} is incorrect! The value is {}.",
-            DFS_ROUTER_ASYNC_RPC_NS_HANDLER_COUNT_KEY, nsHandlerInfo);
+      if (nsHandlerItems.length != 2 || StringUtils.isBlank(nsHandlerItems[0])
+          || !StringUtils.isNumeric(nsHandlerItems[1])) {
+        LOG.error("The config key: {} is incorrect! The value is {}.", key, nsHandlerInfo);
         continue;
       }
       nsAsyncHandlerCount.put(nsHandlerItems[0], Integer.parseInt(nsHandlerItems[1]));
@@ -601,11 +632,13 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
    * Requires async RPC pools to be initialized (async RPC enabled).
    *
    * @param nsId the namespace identifier
+   * @param useObserver if an observer namenode is used
    * @return the corresponding thread pool
    */
-  public ThreadPoolExecutor getAsyncExecutorForNamespace(String nsId) {
-    ThreadPoolExecutor executor =
-        asyncRouterHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor);
+  public ThreadPoolExecutor getAsyncExecutorForNamespace(String nsId, boolean useObserver) {
+    ThreadPoolExecutor executor = useObserver ?
+            asyncRouterOBHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor) :
+            asyncRouterHandlerExecutors.getOrDefault(nsId, routerDefaultAsyncHandlerExecutor);
     if (rpcMonitor != null && executor != null) {
       rpcMonitor.recordAsyncHandlerQueueSize(nsId, executor.getQueue().size());
     }
@@ -725,6 +758,10 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       executor.shutdownNow();
     }
     asyncRouterHandlerExecutors.clear();
+    for (ThreadPoolExecutor executor : asyncRouterOBHandlerExecutors.values()) {
+      executor.shutdownNow();
+    }
+    asyncRouterOBHandlerExecutors.clear();
     if (routerDefaultAsyncHandlerExecutor != null) {
       routerDefaultAsyncHandlerExecutor.shutdownNow();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -177,7 +177,7 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
     // transfer threadLocalContext to worker threads of executor.
     ThreadLocalContext threadLocalContext = new ThreadLocalContext();
     asyncComplete(null);
-    // Returns a CompletableFuture with RejectedExecutionException if nsExecutor is full.
+    // Returns a CompletableFuture with RejectedExecutionException if the executor is full.
     asyncApplyUseExecutor((AsyncApplyFunction<Object, Object>) o -> {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Async invoke method : {}, {}, {}, {}", method.getName(), useObserver, namenodes,
@@ -192,7 +192,7 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
         releasePermit(nsid, ugi, method, controller);
         return object;
       });
-    }, router.getRpcServer().getAsyncExecutorForNamespace(nsid));
+    }, router.getRpcServer().getAsyncExecutorForNamespace(nsid, useObserver));
 
     // Catch the RejectedExecutionException and convert it to StandbyException
     asyncCatch((ret, e) -> {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -67,6 +67,24 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.async.rpc.ns.observer.handler.count</name>
+    <value></value>
+    <description>
+      The number of asynchronous handlers for observer namenodes per nameservice, separated by commas,
+      internally separated by colons. The identifier of nameservice is in dfs.nameservices configuration entry.
+      Such as: ns1:count1,ns2:count2,ns3:count3.
+    </description>
+  </property>
+
+  <property>
+    <name>dfs.federation.router.async.rpc.observer.handler.count</name>
+    <value>20</value>
+    <description>
+      The number of async handlers for the router to handle RPC client requests by observer namenodes.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.async.rpc.queue.size</name>
     <value>1000</value>
     <description>
@@ -150,7 +168,7 @@
     <name>dfs.federation.router.async.rpc.handler.count</name>
     <value>10</value>
     <description>
-      The number of async handler for the router to handle RPC client requests.
+      The number of async handlers for the router to handle RPC client requests by active namenodes.
     </description>
   </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -78,9 +78,12 @@
 
   <property>
     <name>dfs.federation.router.async.rpc.observer.handler.count</name>
-    <value>20</value>
+    <value>0</value>
     <description>
       The number of async handlers for the router to handle RPC client requests by observer namenodes.
+      Disabled when set to 0 or negative, and dfs.federation.router.async.rpc.ns.observer.handler.count
+      is empty. When disabled, requests to observer namenodes will use the same handlers defined in
+      dfs.federation.router.async.rpc.handler.count.
     </description>
   </property>
 
@@ -168,7 +171,7 @@
     <name>dfs.federation.router.async.rpc.handler.count</name>
     <value>10</value>
     <description>
-      The number of async handlers for the router to handle RPC client requests by active namenodes.
+      The number of async handlers for the router to handle RPC client requests by namenodes.
     </description>
   </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -202,7 +202,7 @@ public class TestRouterAsyncHandlerQueueOverflow {
     GenericTestUtils.waitFor(() -> {
       try {
         // Ping getAsyncExecutorForNamespace for metrics recording
-        routerRpcServer.getAsyncExecutorForNamespace(ns0);
+        routerRpcServer.getAsyncExecutorForNamespace(ns0, true);
         assertGauge("AsyncHandlerQueueSize", size,
             getMetrics(NAMESERVICE_RPC_METRICS_PREFIX + ns0));
         return true;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -53,6 +53,7 @@ import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFA
 import static org.apache.hadoop.hdfs.server.federation.metrics.NameserviceRPCMetrics.NAMESERVICE_RPC_METRICS_PREFIX;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_MAX_ASYNCCALL_PERMIT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT;
@@ -95,6 +96,7 @@ public class TestRouterAsyncHandlerQueueOverflow {
 
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_QUEUE_SIZE, QUEUE_CAP);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 1);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY, 1);
     routerConf.set(DFS_ROUTER_MONITOR_NAMENODE,
         cluster.getNameservices().get(0) + "," + cluster.getNameservices().get(1));
@@ -114,20 +116,23 @@ public class TestRouterAsyncHandlerQueueOverflow {
     FSNamesystem spyNamesystem = NameNodeAdapterMockitoUtil.spyOnNamesystem(nn0.getNamenode());
     // Mock one slow operation. Any public interface from FSNamesystem will do.
     spyNamesystem.writeLock();
-    Mockito.when(spyNamesystem.getFilesBlockingDecom(anyLong(), anyString()))
-        .thenAnswer(invocationOnMock -> {
-          if (testLatch == null) {
+    try {
+      Mockito.when(spyNamesystem.getFilesBlockingDecom(anyLong(), anyString()))
+          .thenAnswer(invocationOnMock -> {
+            if (testLatch == null) {
+              return null;
+            }
+            String invokePath = invocationOnMock.getArgument(1);
+            if (invokePath.startsWith("/veryBigOperation")) {
+              testLatch.await();
+            } else {
+              return invocationOnMock.callRealMethod();
+            }
             return null;
-          }
-          String invokePath = invocationOnMock.getArgument(1);
-          if (invokePath.startsWith("/veryBigOperation")) {
-            testLatch.await();
-          } else {
-            return invocationOnMock.callRealMethod();
-          }
-          return null;
-        });
-    spyNamesystem.writeUnlock();
+          });
+    } finally {
+      spyNamesystem.writeUnlock();
+    }
 
     testLatch = new CountDownLatch(1);
     MiniRouterDFSCluster.RouterContext router = cluster.getRouterContext(ns0, NAMENODES[0]);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncHandlerQueueOverflow.java
@@ -165,7 +165,7 @@ public class TestRouterAsyncHandlerQueueOverflow {
           asyncRpcClient.getOrderedNamenodes(ns0, true);
       // Downstream namespace processing this huge request
       asyncRpcClient.invokeMethod(ugi, namenodes, true, protocol, method.getMethod(), params);
-      ThreadPoolExecutor nsExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0);
+      ThreadPoolExecutor nsExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, true);
       // Successfully sent this request downstream, but all subsequent ones will get stuck
       GenericTestUtils.waitFor(() -> nsExecutor.getQueue().isEmpty(), 50, 500);
       GenericTestUtils.waitFor(() -> nsExecutor.getCompletedTaskCount() == 1, 50, 500);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MockResolver;
@@ -41,6 +42,7 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
@@ -52,11 +54,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.fs.permission.FsAction.ALL;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
@@ -109,9 +113,13 @@ public class TestRouterAsyncRpcClient {
         .build();
 
     // Reduce the number of RPC clients threads to overload the Router easy
+    routerConf.setBoolean(DFS_ROUTER_ASYNC_RPC_ENABLE_KEY, true);
     routerConf.setInt(RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY, 1);
+    routerConf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
+    routerConf.set(RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE,
+        String.join(",", cluster.getNameservices()));
     // We decrease the DN cache times to make the test faster
     routerConf.setTimeDuration(
         RBFConfigKeys.DN_REPORT_CACHE_EXPIRE, 1, TimeUnit.SECONDS);
@@ -283,6 +291,37 @@ public class TestRouterAsyncRpcClient {
         "Cannot get a connection",
         () -> syncReturn(FileStatus.class));
     assertEquals(1, rpcMetrics.getProxyOpFailureCommunicate());
+  }
+
+  @Test
+  public void testInvokeMethodsSeparateExecutors() throws Exception {
+    ThreadPoolExecutor activeExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, false);
+    ThreadPoolExecutor observerExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, true);
+    DFSClient routerClient = router.getClient();
+
+    // Send a mkdirs, it should be proxied to active
+    long activeTaskCount = activeExecutor.getCompletedTaskCount();
+    routerClient.mkdirs("/testDir");
+    long finalActiveTaskCount1 = activeTaskCount;
+    GenericTestUtils.waitFor(
+        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount1 + 1, 50, 1000);
+    activeTaskCount = activeExecutor.getCompletedTaskCount();
+
+    // Set a getFileInfo, it should be proxied to observer and not active
+    long observerTaskCount = observerExecutor.getCompletedTaskCount();
+    routerClient.getFileInfo("/testDir");
+    long finalObserverTaskCount1 = observerTaskCount;
+    GenericTestUtils.waitFor(
+        () -> observerExecutor.getCompletedTaskCount() == finalObserverTaskCount1 + 1, 50, 1000);
+    assertEquals(activeTaskCount, activeExecutor.getCompletedTaskCount());
+    observerTaskCount = observerExecutor.getCompletedTaskCount();
+
+    // Send a createFile, it should be proxied twice (once for mkdirs, once for create) to active
+    routerClient.create(testFile, true).close();
+    long finalActiveTaskCount2 = activeTaskCount;
+    GenericTestUtils.waitFor(
+        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount2 + 2, 50, 1000);
+    assertEquals(observerTaskCount, observerExecutor.getCompletedTaskCount());
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
@@ -62,6 +62,7 @@ import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMEN
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -116,6 +117,7 @@ public class TestRouterAsyncRpcClient {
     routerConf.setBoolean(DFS_ROUTER_ASYNC_RPC_ENABLE_KEY, true);
     routerConf.setInt(RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 1);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY, 1);
     routerConf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
     routerConf.set(RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcClient.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MockResolver;
@@ -42,7 +41,6 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
@@ -54,13 +52,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.fs.permission.FsAction.ALL;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
@@ -114,14 +110,10 @@ public class TestRouterAsyncRpcClient {
         .build();
 
     // Reduce the number of RPC clients threads to overload the Router easy
-    routerConf.setBoolean(DFS_ROUTER_ASYNC_RPC_ENABLE_KEY, true);
     routerConf.setInt(RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY, 1);
     routerConf.setInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY, 1);
-    routerConf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
-    routerConf.set(RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE,
-        String.join(",", cluster.getNameservices()));
     // We decrease the DN cache times to make the test faster
     routerConf.setTimeDuration(
         RBFConfigKeys.DN_REPORT_CACHE_EXPIRE, 1, TimeUnit.SECONDS);
@@ -293,37 +285,6 @@ public class TestRouterAsyncRpcClient {
         "Cannot get a connection",
         () -> syncReturn(FileStatus.class));
     assertEquals(1, rpcMetrics.getProxyOpFailureCommunicate());
-  }
-
-  @Test
-  public void testInvokeMethodsSeparateExecutors() throws Exception {
-    ThreadPoolExecutor activeExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, false);
-    ThreadPoolExecutor observerExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, true);
-    DFSClient routerClient = router.getClient();
-
-    // Send a mkdirs, it should be proxied to active
-    long activeTaskCount = activeExecutor.getCompletedTaskCount();
-    routerClient.mkdirs("/testDir");
-    long finalActiveTaskCount1 = activeTaskCount;
-    GenericTestUtils.waitFor(
-        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount1 + 1, 50, 1000);
-    activeTaskCount = activeExecutor.getCompletedTaskCount();
-
-    // Set a getFileInfo, it should be proxied to observer and not active
-    long observerTaskCount = observerExecutor.getCompletedTaskCount();
-    routerClient.getFileInfo("/testDir");
-    long finalObserverTaskCount1 = observerTaskCount;
-    GenericTestUtils.waitFor(
-        () -> observerExecutor.getCompletedTaskCount() == finalObserverTaskCount1 + 1, 50, 1000);
-    assertEquals(activeTaskCount, activeExecutor.getCompletedTaskCount());
-    observerTaskCount = observerExecutor.getCompletedTaskCount();
-
-    // Send a createFile, it should be proxied twice (once for mkdirs, once for create) to active
-    routerClient.create(testFile, true).close();
-    long finalActiveTaskCount2 = activeTaskCount;
-    GenericTestUtils.waitFor(
-        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount2 + 2, 50, 1000);
-    assertEquals(observerTaskCount, observerExecutor.getCompletedTaskCount());
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncSeparateNamenodeExecutors.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncSeparateNamenodeExecutors.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router.async;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSClient;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.MockResolver;
+import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.test.GenericTestUtils;
+
+import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
+import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class TestRouterAsyncSeparateNamenodeExecutors {
+
+  private MiniRouterDFSCluster cluster;
+  private Configuration routerConf;
+  private String ns0;
+  private MiniRouterDFSCluster.RouterContext router;
+  private RouterRpcServer routerRpcServer;
+  private final String testFile = "/test.file";
+
+  private void setUpCluster(boolean useSeparateObserverExecutor) throws Exception {
+    cluster = new MiniRouterDFSCluster(true, 1, 3, DEFAULT_HEARTBEAT_INTERVAL_MS, 1000);
+    // Don't need DNs for this suite
+    cluster.setNumDatanodesPerNameservice(0);
+    cluster.startCluster();
+    if (cluster.isHighAvailability()) {
+      for (String ns : cluster.getNameservices()) {
+        cluster.switchToActive(ns, NAMENODES[0]);
+        cluster.switchToStandby(ns, NAMENODES[1]);
+        cluster.switchToObserver(ns, NAMENODES[2]);
+      }
+    }
+    // Start routers with only an RPC service
+    routerConf = new RouterConfigBuilder().metrics().rpc().build();
+
+    routerConf.setInt(DFS_ROUTER_CLIENT_THREADS_SIZE, 1);
+    routerConf.setBoolean(DFS_ROUTER_ASYNC_RPC_ENABLE_KEY, true);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_HANDLER_COUNT_KEY, 1);
+    routerConf.setInt(DFS_ROUTER_ASYNC_RPC_RESPONDER_COUNT_KEY, 1);
+    routerConf.setBoolean(DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
+    if (useSeparateObserverExecutor) {
+      routerConf.setInt(DFS_ROUTER_ASYNC_RPC_OBSERVER_HANDLER_COUNT_KEY, 1);
+    }
+    cluster.addRouterOverrides(routerConf);
+    cluster.startRouters();
+
+    cluster.registerNamenodes();
+    cluster.waitNamenodeRegistration();
+    cluster.waitActiveNamespaces();
+    ns0 = cluster.getNameservices().get(0);
+
+    router = cluster.getRandomRouter();
+    routerRpcServer = router.getRouterRpcServer();
+    routerRpcServer.initAsyncThreadPools(routerConf);
+    MockResolver resolver = (MockResolver) router.getRouter().getSubclusterResolver();
+    resolver.addLocation("/", ns0, "/");
+  }
+
+  @AfterEach
+  public void shutdownCluster() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testInvokeMethodsSeparateExecutors() throws Exception {
+    setUpCluster(true);
+
+    ThreadPoolExecutor activeExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, false);
+    ThreadPoolExecutor observerExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, true);
+    DFSClient routerClient = router.getClient();
+
+    // Send a mkdirs, it should be proxied to active
+    long activeTaskCount = activeExecutor.getCompletedTaskCount();
+    routerClient.mkdirs("/testDir");
+    long finalActiveTaskCount1 = activeTaskCount;
+    GenericTestUtils.waitFor(
+        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount1 + 1, 50, 1000);
+    activeTaskCount = activeExecutor.getCompletedTaskCount();
+
+    // Set a getFileInfo, it should be proxied to observer and not active
+    long observerTaskCount = observerExecutor.getCompletedTaskCount();
+    routerClient.getFileInfo("/testDir");
+    long finalObserverTaskCount1 = observerTaskCount;
+    GenericTestUtils.waitFor(
+        () -> observerExecutor.getCompletedTaskCount() == finalObserverTaskCount1 + 1, 50, 1000);
+    assertEquals(activeTaskCount, activeExecutor.getCompletedTaskCount());
+    observerTaskCount = observerExecutor.getCompletedTaskCount();
+
+    // Send a createFile, it should be proxied twice (once for mkdirs, once for create) to active
+    routerClient.create(testFile, true).close();
+    long finalActiveTaskCount2 = activeTaskCount;
+    GenericTestUtils.waitFor(
+        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount2 + 2, 50, 1000);
+    assertEquals(observerTaskCount, observerExecutor.getCompletedTaskCount());
+  }
+
+  @Test
+  public void testObserverUsesActiveExecutorWhenSeparateExecutorDisabled() throws Exception {
+    setUpCluster(false);
+
+    ThreadPoolExecutor activeExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, false);
+    ThreadPoolExecutor observerExecutor = routerRpcServer.getAsyncExecutorForNamespace(ns0, true);
+    ThreadPoolExecutor defaultExecutor =
+        routerRpcServer.getAsyncExecutorForNamespace("unknown", false);
+    assertNotSame(defaultExecutor, observerExecutor);
+    assertSame(activeExecutor, observerExecutor);
+
+    DFSClient routerClient = router.getClient();
+    long activeTaskCount = activeExecutor.getCompletedTaskCount();
+    // mkdirs goes to active
+    routerClient.mkdirs("/testDir");
+    long finalActiveTaskCount1 = activeTaskCount;
+    GenericTestUtils.waitFor(
+        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount1 + 1, 50, 1000);
+
+    // getFileInfo also goes to active
+    activeTaskCount = activeExecutor.getCompletedTaskCount();
+    routerClient.getFileInfo("/testDir");
+    long finalActiveTaskCount2 = activeTaskCount;
+    GenericTestUtils.waitFor(
+        () -> activeExecutor.getCompletedTaskCount() == finalActiveTaskCount2 + 1, 50, 1000);
+    assertSame(activeExecutor, observerExecutor);
+  }
+}


### PR DESCRIPTION
### Description of PR

Most router traffic are reads, and currently all traffic to a namespace is handled by one same executor, so high observer load can increase competition for active ops. It would be beneficial to split the handler pools into 2 separate sets, one for active, one for observer.

Added a simple unit test (LLM-gen for skeleton then rewrote) to count how many calls are proxied through which executor. Contains content generated by Codex/ChatGPT-5.5.

### How was this patch tested?

UT. Have been running on production environment for months.

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html