### PR TITLE
HADOOP-19920. Fix flaky test TestPrometheusMetricsSink

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.annotation.Metric.Type;
-import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
@@ -57,31 +56,27 @@ public class TestPrometheusMetricsSink {
       LoggerFactory.getLogger(TestPrometheusMetricsSink.class);
 
   /**
-   * A dedicated metrics system per test to keep the tests isolated from the
-   * JVM-global {@code DefaultMetricsSystem} singleton. Sharing the singleton
-   * across tests is flaky: if any test leaks registered sources (e.g. when an
-   * assertion fails before the inline cleanup runs), subsequent tests/reruns
-   * fail with errors such as "Metrics source TestMetrics already exists!".
+   * Shared {@code DefaultMetricsSystem} singleton, set up fresh per test.
+   * Each test does exactly one balanced {@code init}/{@code shutdown} so the
+   * system (and the JVM-global source-name registry it owns) is fully reset
+   * between tests. This keeps tests isolated even when an assertion fails
+   * before the test body finishes, avoiding flaky failures such as
+   * "Metrics source TestMetrics already exists!" on later tests or reruns.
    */
   private MetricsSystem metrics;
 
   @BeforeEach
   public void setUp() {
-    metrics = new MetricsSystemImpl();
+    metrics = DefaultMetricsSystem.instance();
     metrics.init("test");
   }
 
   @AfterEach
   public void tearDown() {
-    if (metrics != null) {
-      metrics.shutdown();
-      metrics = null;
-    }
-    // Source-name uniqueness is tracked in the JVM-global
-    // DefaultMetricsSystem registry, which the per-test instance above does
-    // not clear. Clear it here so it always runs, even when a test assertion
-    // fails before reaching its cleanup, keeping tests isolated from each
-    // other and from surefire reruns.
+    // DefaultMetricsSystem.shutdown() shuts down the underlying metrics system
+    // and, once its refCount reaches 0, clears the JVM-global source-name and
+    // MBean-name registries. Running it in @AfterEach guarantees cleanup even
+    // when a test assertion fails before reaching the end of the test body.
     DefaultMetricsSystem.shutdown();
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
@@ -31,11 +31,16 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.annotation.Metric.Type;
+import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,12 +53,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class TestPrometheusMetricsSink {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestPrometheusMetricsSink.class);
+
+  /**
+   * A dedicated metrics system per test to keep the tests isolated from the
+   * JVM-global {@code DefaultMetricsSystem} singleton. Sharing the singleton
+   * across tests is flaky: if any test leaks registered sources (e.g. when an
+   * assertion fails before the inline cleanup runs), subsequent tests/reruns
+   * fail with errors such as "Metrics source TestMetrics already exists!".
+   */
+  private MetricsSystem metrics;
+
+  @BeforeEach
+  public void setUp() {
+    metrics = new MetricsSystemImpl();
+    metrics.init("test");
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (metrics != null) {
+      metrics.shutdown();
+      metrics = null;
+    }
+    // Source-name uniqueness is tracked in the JVM-global
+    // DefaultMetricsSystem registry, which the per-test instance above does
+    // not clear. Clear it here so it always runs, even when a test assertion
+    // fails before reaching its cleanup, keeping tests isolated from each
+    // other and from surefire reruns.
+    DefaultMetricsSystem.shutdown();
+  }
+
   @Test
   public void testPublish() throws IOException {
     //GIVEN
-    MetricsSystem metrics = DefaultMetricsSystem.instance();
-
-    metrics.init("test");
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
     metrics.register("Prometheus", "Prometheus", sink);
     TestMetrics testMetrics = metrics
@@ -69,14 +103,10 @@ public class TestPrometheusMetricsSink {
     writer.flush();
 
     //THEN
-    String writtenMetrics = stream.toString(UTF_8.name());
-    System.out.println(writtenMetrics);
+    String writtenMetrics = stream.toString(UTF_8);
+    LOG.debug(writtenMetrics);
     assertTrue(writtenMetrics.contains("test_metrics_num_bucket_create_fails{context=\"dfs\""),
         "The expected metric line is missing from prometheus metrics output");
-
-    metrics.unregisterSource("TestMetrics");
-    metrics.stop();
-    metrics.shutdown();
   }
 
   /**
@@ -86,9 +116,6 @@ public class TestPrometheusMetricsSink {
   @Test
   public void testPublishMultiple() throws IOException {
     //GIVEN
-    MetricsSystem metrics = DefaultMetricsSystem.instance();
-
-    metrics.init("test");
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
     metrics.register("Prometheus", "Prometheus", sink);
     TestMetrics testMetrics1 = metrics
@@ -107,19 +134,14 @@ public class TestPrometheusMetricsSink {
     writer.flush();
 
     //THEN
-    String writtenMetrics = stream.toString(UTF_8.name());
-    System.out.println(writtenMetrics);
+    String writtenMetrics = stream.toString(UTF_8);
+    LOG.debug(writtenMetrics);
     assertTrue(writtenMetrics.contains(
         "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""),
         "The expected first metric line is missing from prometheus metrics output");
     assertTrue(writtenMetrics.contains(
         "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""),
         "The expected second metric line is missing from prometheus metrics output");
-
-    metrics.unregisterSource("TestMetrics1");
-    metrics.unregisterSource("TestMetrics2");
-    metrics.stop();
-    metrics.shutdown();
   }
 
   /**
@@ -128,9 +150,6 @@ public class TestPrometheusMetricsSink {
   @Test
   public void testPublishFlush() throws IOException {
     //GIVEN
-    MetricsSystem metrics = DefaultMetricsSystem.instance();
-
-    metrics.init("test");
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
     metrics.register("Prometheus", "Prometheus", sink);
     TestMetrics testMetrics = metrics
@@ -154,18 +173,14 @@ public class TestPrometheusMetricsSink {
     writer.flush();
 
     //THEN
-    String writtenMetrics = stream.toString(UTF_8.name());
-    System.out.println(writtenMetrics);
+    String writtenMetrics = stream.toString(UTF_8);
+    LOG.debug(writtenMetrics);
     assertFalse(writtenMetrics.contains(
         "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""),
         "The first metric should not exist after flushing");
     assertTrue(writtenMetrics.contains(
         "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""),
         "The expected metric line is missing from prometheus metrics output");
-
-    metrics.unregisterSource("TestMetrics");
-    metrics.stop();
-    metrics.shutdown();
   }
 
   @Test
@@ -223,10 +238,6 @@ public class TestPrometheusMetricsSink {
    */
   @Test
   public void testTopMetricsPublish() throws IOException {
-    MetricsSystem metrics = DefaultMetricsSystem.instance();
-
-    metrics.init("test");
-
     //GIVEN
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
 
@@ -248,8 +259,8 @@ public class TestPrometheusMetricsSink {
     writer.flush();
 
     //THEN
-    String writtenMetrics = stream.toString(UTF_8.name());
-    System.out.println(writtenMetrics);
+    String writtenMetrics = stream.toString(UTF_8);
+    LOG.debug(writtenMetrics);
 
     assertThat(writtenMetrics)
         .contains(
@@ -260,9 +271,6 @@ public class TestPrometheusMetricsSink {
             "nn_top_user_op_counts_window_ms_1500000_count{")
         .contains(
             "op=\"rename\",user=\"hadoop/TEST_HOSTNAME.com@HOSTNAME.COM\"");
-
-    metrics.stop();
-    metrics.shutdown();
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Fix flaky tests like https://github.com/kokonguyen191/hadoop/actions/runs/27467848524/job/81194100665

```
Error:  Errors: 
Error:  org.apache.hadoop.metrics2.sink.TestPrometheusMetricsSink.testPublish
Error:    Run 1: TestPrometheusMetricsSink.testPublish:60 » Metrics Metrics source TestMetrics already exists!
Error:    Run 2: TestPrometheusMetricsSink.testPublish:60 » Metrics Metrics source TestMetrics already exists!
Error:    Run 3: TestPrometheusMetricsSink.testPublish:60 » Metrics Metrics source TestMetrics already exists!
[INFO] 
Error:  org.apache.hadoop.metrics2.sink.TestPrometheusMetricsSink.testPublishFlush
Error:    Run 1: TestPrometheusMetricsSink.testPublishFlush:159 The first metric should not exist after flushing ==> expected: <false> but was: <true>
Error:    Run 2: TestPrometheusMetricsSink.testPublishFlush:137 » Metrics Metrics source TestMetrics already exists!
Error:    Run 3: TestPrometheusMetricsSink.testPublishFlush:137 » Metrics Metrics source TestMetrics already exists!
[INFO] 
Error:  org.apache.hadoop.metrics2.sink.TestPrometheusMetricsSink.testPublishMultiple
Error:    Run 1: TestPrometheusMetricsSink.testPublishMultiple:112 The expected first metric line is missing from prometheus metrics output ==> expected: <true> but was: <false>
Error:    Run 2: TestPrometheusMetricsSink.testPublishMultiple:95 » Metrics Metrics source TestMetrics1 already exists!
Error:    Run 3: TestPrometheusMetricsSink.testPublishMultiple:95 » Metrics Metrics source TestMetrics1 already exists!
[INFO] 
[INFO] 
Error:  Tests run: 5385, Failures: 0, Errors: 3, Skipped: 201
```

The root cause is the refCount-based global singleton:

- `DefaultMetricsSystem.instance()` returns a JVM-global singleton shared by all tests in hadoop-common.
- `init()` short-circuits (returns early without incrementing refCount) if monitoring is already `true`.
- `shutdown()` only clears `allSources`/`allSinks` when refCount hits 0.

So if any test (this class's own methods, or any other metrics test in the module) throws before its inline `stop()`/`shutdown()`, the singleton stays `monitoring=true` with leaked sources. Subsequent tests' `init()` becomes a no-op, sources never get cleared, and you get cascading "Metrics source TestMetrics already exists!" plus stale-data assertion failures — exactly what the CI shows (including on surefire reruns).

### How was this patch tested?

Pass GHA.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19920)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by Claude Opus 4.8