### PR TITLE
HADOOP-19872: Exclude Engine API when building with OpenSSL 3.x

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/random/OpensslSecureRandom.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/random/OpensslSecureRandom.c
@@ -49,11 +49,13 @@ static void (*dlsym_CRYPTO_set_id_callback) (unsigned long (*)());
 static void (*dlsym_ENGINE_load_rdrand) (void);
 static void (*dlsym_ENGINE_cleanup) (void);
 #endif
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 static ENGINE * (*dlsym_ENGINE_by_id) (const char *);
 static int (*dlsym_ENGINE_init) (ENGINE *);
 static int (*dlsym_ENGINE_set_default) (ENGINE *, unsigned int);
 static int (*dlsym_ENGINE_finish) (ENGINE *);
 static int (*dlsym_ENGINE_free) (ENGINE *);
+#endif
 static int (*dlsym_RAND_bytes) (unsigned char *, int);
 static unsigned long (*dlsym_ERR_get_error) (void);
 #endif
@@ -126,12 +128,14 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_crypto_random_OpensslSecureRandom_
                       openssl, "ENGINE_load_rdrand");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_cleanup, env, openssl, "ENGINE_cleanup");
 #endif
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_by_id, env, openssl, "ENGINE_by_id");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_init, env, openssl, "ENGINE_init");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_set_default, env,  \
                       openssl, "ENGINE_set_default");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_finish, env, openssl, "ENGINE_finish");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_free, env, openssl, "ENGINE_free");
+#endif
   LOAD_DYNAMIC_SYMBOL(dlsym_RAND_bytes, env, openssl, "RAND_bytes");
   LOAD_DYNAMIC_SYMBOL(dlsym_ERR_get_error, env, openssl, "ERR_get_error");
 #endif
@@ -308,6 +312,7 @@ static unsigned long pthreads_thread_id(void)
  */
 static ENGINE * openssl_rand_init(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
   locks_setup();
   
@@ -339,10 +344,12 @@ static ENGINE * openssl_rand_init(void)
   }
   
   return eng;
+#endif
 }
 
 static void openssl_rand_clean(ENGINE *eng, int clean_locks)
 {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   if (NULL != eng) {
     dlsym_ENGINE_finish(eng);
     dlsym_ENGINE_free(eng);
@@ -352,6 +359,7 @@ static void openssl_rand_clean(ENGINE *eng, int clean_locks)
   if (clean_locks) {
     locks_cleanup();
   }
+#endif
 #endif
 }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Native build of hadoop-common fails on RHEL 10 with:

```
error: 'ENGINE_METHOD_RAND' undeclared
make failed with error code 2
```

Root Cause: RHEL 10 ships OpenSSL 3.2.x, which was compiled with OPENSSL_NO_ENGINE — completely removing the OpenSSL Engine API (ENGINE_* functions and constants). The native file OpensslSecureRandom.c used ENGINE_METHOD_RAND and other Engine API symbols without any OpenSSL 3.x compatibility guard, causing a compile-time failure.

Fix: Added #if OPENSSL_VERSION_NUMBER < 0x30000000L guards in OpensslSecureRandom.c to exclude Engine API usage when building against OpenSSL 3.x

Contains content generated by Claude

### How was this patch tested?
RHEL 10 build passed. No breakage reported in RHEL 9 arm64 too.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [X] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html