### PR TITLE
HADOOP-19922. Add configurable warn threshold for large IPC RPC request data length

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -84,6 +84,17 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
   /** Default value for IPC_MAXIMUM_DATA_LENGTH. */
   public static final int IPC_MAXIMUM_DATA_LENGTH_DEFAULT = 128 * 1024 * 1024;
 
+  /**
+   * Threshold in bytes above which a WARN log is emitted for large IPC
+   * requests, even when the request is still within
+   * {@link #IPC_MAXIMUM_DATA_LENGTH}.
+   */
+  public static final String IPC_DATA_LENGTH_WARN_THRESHOLD =
+      "ipc.data.length.warn.threshold";
+  /** Default value for IPC_DATA_LENGTH_WARN_THRESHOLD. */
+  public static final int IPC_DATA_LENGTH_WARN_THRESHOLD_DEFAULT =
+      64 * 1024 * 1024;
+
   /** Max response size a client will accept. */
   public static final String IPC_MAXIMUM_RESPONSE_LENGTH =
       "ipc.maximum.response.length";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -497,6 +497,7 @@ public abstract class Server {
   };
   private int socketSendBufferSize;
   private final int maxDataLength;
+  private final int warnDataLength;
   private final boolean tcpNoDelay; // if T then disable Nagle's Algorithm
 
   volatile private boolean running = true;         // true while server runs
@@ -2524,6 +2525,10 @@ public abstract class Server {
             maxDataLength + ".  RPC came from " + getHostAddress();
         LOG.warn(error);
         throw new IOException(error);
+      } else if (warnDataLength > 0 && dataLength > warnDataLength) {
+        LOG.warn(
+            "Requested data length {} exceeds warn threshold of {}. RPC came from {}",
+            dataLength, warnDataLength, getHostAddress());
       }
     }
 
@@ -3422,6 +3427,9 @@ public abstract class Server {
     this.auxiliaryListenerMap = null;
     this.maxDataLength = conf.getInt(CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH,
         CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH_DEFAULT);
+    this.warnDataLength = conf.getInt(
+        CommonConfigurationKeys.IPC_DATA_LENGTH_WARN_THRESHOLD,
+        CommonConfigurationKeys.IPC_DATA_LENGTH_WARN_THRESHOLD_DEFAULT);
     if (queueSizePerHandler != -1) {
       this.maxQueueSize = handlerCount * queueSizePerHandler;
     } else {

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2637,6 +2637,15 @@ The switch to turn S3A auditing on or off.
 </property>
 
 <property>
+  <name>ipc.data.length.warn.threshold</name>
+  <value>67108864</value>
+  <description>Threshold in bytes above which the IPC server emits a WARN log
+    for a large incoming RPC request, even when the request is still within
+    ipc.maximum.data.length. Set to -1 to disable.
+  </description>
+</property>
+
+<property>
   <name>ipc.maximum.response.length</name>
   <value>134217728</value>
   <description>This indicates the maximum IPC message length (bytes) that can be

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -1801,6 +1801,58 @@ public class TestIPC {
   }
 
   @Test
+  public void testWarnDataLengthThreshold() throws Throwable {
+    Configuration serverConf = new Configuration();
+    Client.setPingInterval(serverConf, PING_INTERVAL);
+    // Set a very small warn threshold so any real RPC packet triggers it.
+    serverConf.setInt(CommonConfigurationKeys.IPC_DATA_LENGTH_WARN_THRESHOLD, 1);
+    Server server = new TestServer(1, false, serverConf);
+    InetSocketAddress addr = NetUtils.getConnectAddress(server);
+    server.start();
+    try {
+      GenericTestUtils.LogCapturer logCapturer =
+          GenericTestUtils.LogCapturer.captureLogs(Server.LOG);
+      Client client = new Client(LongWritable.class, conf);
+      try {
+        call(client, 0, addr, conf);
+      } finally {
+        client.stop();
+        logCapturer.stopCapturing();
+      }
+      assertTrue(logCapturer.getOutput().contains("exceeds warn threshold"),
+          "Expected warn-threshold log message");
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testWarnDataLengthThresholdDisabled() throws Throwable {
+    Configuration serverConf = new Configuration();
+    Client.setPingInterval(serverConf, PING_INTERVAL);
+    // Disable warn threshold.
+    serverConf.setInt(CommonConfigurationKeys.IPC_DATA_LENGTH_WARN_THRESHOLD, -1);
+    Server server = new TestServer(1, false, serverConf);
+    InetSocketAddress addr = NetUtils.getConnectAddress(server);
+    server.start();
+    try {
+      GenericTestUtils.LogCapturer logCapturer =
+          GenericTestUtils.LogCapturer.captureLogs(Server.LOG);
+      Client client = new Client(LongWritable.class, conf);
+      try {
+        call(client, 0, addr, conf);
+      } finally {
+        client.stop();
+        logCapturer.stopCapturing();
+      }
+      assertFalse(logCapturer.getOutput().contains("exceeds warn threshold"),
+          "Expected no warn-threshold log message when threshold is disabled");
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
   public void testUserBinding() throws Exception {
     checkUserBinding(false);
   }


### PR DESCRIPTION
### Description of PR
The IPC \`Server\` currently enforces a hard upper limit on RPC request size via \`ipc.maximum.data.length\` (default 128 MB). Requests that exceed this limit are rejected immediately. However, requests that are abnormally large but still within the limit pass through silently, potentially causing GC pressure and cascading failures before any operator is aware.

This patch adds a configurable warn threshold \`ipc.data.length.warn.threshold\` (default 64 MB). When a request exceeds this threshold but is still within the hard limit, a WARN log is emitted. Set to \`-1\` to disable.

### How was this patch tested?

Added two unit tests to \`TestIPC\`:
- \`testWarnDataLengthThreshold\`: verifies a WARN log is emitted when a request exceeds the configured threshold but is within the hard limit.
- \`testWarnDataLengthThresholdDisabled\`: verifies no WARN log is emitted when the threshold is set to \`-1\` (disabled).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the \`LICENSE\`, \`LICENSE-binary\`, \`NOTICE-binary\` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html