### PR TITLE
MAPREDUCE-7539. JobHistoryServer API fails to serve aggregated logs d…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.v2.app.AppContext;
+import org.apache.hadoop.mapreduce.v2.hs.HistoryContext;
+import org.apache.hadoop.mapreduce.v2.hs.MockHistoryContext;
+import org.apache.hadoop.mapreduce.v2.hs.webapp.reader.ContainerLogsInfoMessageBodyReader;
+import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.logaggregation.TestContainerLogsUtils;
+import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController;
+import org.apache.hadoop.yarn.logaggregation.filecontroller.ifile.LogAggregationIndexedFileController;
+import org.apache.hadoop.yarn.server.webapp.LogServlet;
+import org.apache.hadoop.yarn.server.webapp.YarnWebServiceParams;
+import org.apache.hadoop.yarn.server.webapp.dao.ContainerLogsInfo;
+import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
+import org.apache.hadoop.yarn.webapp.JerseyTestBase;
+import org.apache.hadoop.yarn.webapp.WebApp;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.jettison.JettisonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for HADOOP-15984: singleton {@link HsWebServices} reuses
+ * {@link LogAggregationIndexedFileController} across requests, so IFile log
+ * reads must not rely on per-instance UUID state from a prior application.
+ */
+public class TestHsWebServicesIFileAggregatedLogs extends JerseyTestBase {
+
+  private static final Configuration CONF = new YarnConfiguration();
+  private static FileSystem fs;
+
+  private static final String LOCAL_ROOT_LOG_DIR = "target/LocalLogsIFile";
+  private static final String REMOTE_LOG_ROOT_DIR = "target/logs-ifile/";
+  private static final String USER = "fakeUser";
+  private static final String FILE_NAME = "syslog";
+
+  private static final ApplicationId APPID_1 = ApplicationId.newInstance(1, 1);
+  private static final ApplicationId APPID_2 = ApplicationId.newInstance(10, 2);
+  private static final ApplicationAttemptId APP_ATTEMPT_1_1 =
+      ApplicationAttemptId.newInstance(APPID_1, 1);
+  private static final ApplicationAttemptId APP_ATTEMPT_2_2 =
+      ApplicationAttemptId.newInstance(APPID_2, 2);
+
+  private static final ContainerId CONTAINER_1_1_1 =
+      ContainerId.newContainerId(
+          ApplicationAttemptId.newInstance(APPID_1, 1), 1);
+  private static final ContainerId CONTAINER_2_2_1 =
+      ContainerId.newContainerId(
+          ApplicationAttemptId.newInstance(APPID_2, 2), 1);
+
+  @Override
+  protected Application configure() {
+    ResourceConfig config = new ResourceConfig();
+    config.register(new JerseyBinder());
+    config.register(HsWebServices.class);
+    config.register(GenericExceptionHandler.class);
+    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    return config;
+  }
+
+  private class JerseyBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+      HsWebApp webApp = mock(HsWebApp.class);
+      when(webApp.name()).thenReturn("hsmockwebapp");
+
+      MockHistoryContext appContext = new MockHistoryContext(0, 1, 2, 1);
+      ApplicationClientProtocol mockProtocol = mock(ApplicationClientProtocol.class);
+      try {
+        doAnswer(invocationOnMock -> {
+          GetApplicationReportRequest request = invocationOnMock.getArgument(0);
+          if (request.getApplicationId().equals(APPID_1)) {
+            return GetApplicationReportResponse.newInstance(
+                newApplicationReport(APPID_1, APP_ATTEMPT_1_1, false));
+          } else if (request.getApplicationId().equals(APPID_2)) {
+            return GetApplicationReportResponse.newInstance(
+                newApplicationReport(APPID_2, APP_ATTEMPT_2_2, false));
+          }
+          throw new RuntimeException("Unknown applicationId: " + request.getApplicationId());
+        }).when(mockProtocol).getApplicationReport(any());
+      } catch (Exception ignore) {
+        fail("Failed to setup mock protocol");
+      }
+
+      HsWebServices hsWebServices =
+          new HsWebServices(appContext, CONF, webApp, mockProtocol);
+      try {
+        LogServlet logServlet = spy(hsWebServices.getLogServlet());
+        doReturn(null).when(logServlet).getNMWebAddressFromRM(any());
+        hsWebServices.setLogServlet(logServlet);
+      } catch (Exception ignore) {
+        fail("Failed to setup LogServlet");
+      }
+
+      bind(webApp).to(WebApp.class).named("hsWebApp");
+      bind(appContext).to(AppContext.class);
+      bind(appContext).to(HistoryContext.class).named("ctx");
+      bind(CONF).to(Configuration.class).named("conf");
+      bind(mockProtocol).to(ApplicationClientProtocol.class).named("appClient");
+      final HttpServletResponse response = mock(HttpServletResponse.class);
+      bind(response).to(HttpServletResponse.class);
+      final HttpServletRequest request = mock(HttpServletRequest.class);
+      bind(request).to(HttpServletRequest.class);
+      hsWebServices.setResponse(response);
+      bind(hsWebServices).to(HsWebServices.class);
+    }
+  }
+
+  @BeforeAll
+  public static void setupClass() throws Exception {
+    CONF.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
+    CONF.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR, REMOTE_LOG_ROOT_DIR);
+    CONF.setStrings(YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS, "IFile");
+    CONF.setClass(String.format(
+        YarnConfiguration.LOG_AGGREGATION_FILE_CONTROLLER_FMT, "IFile"),
+        LogAggregationIndexedFileController.class,
+        LogAggregationFileController.class);
+    fs = FileSystem.get(CONF);
+
+    Map<ContainerId, String> app1Logs = new HashMap<>();
+    app1Logs.put(CONTAINER_1_1_1, "Hello-" + CONTAINER_1_1_1);
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(CONF, fs,
+        LOCAL_ROOT_LOG_DIR, APPID_1, app1Logs,
+        org.apache.hadoop.yarn.api.records.NodeId.newInstance("fakeHost1", 9951),
+        FILE_NAME, USER, true);
+
+    Map<ContainerId, String> app2Logs = new HashMap<>();
+    app2Logs.put(CONTAINER_2_2_1, "Hello-" + CONTAINER_2_2_1);
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(CONF, fs,
+        LOCAL_ROOT_LOG_DIR, APPID_2, app2Logs,
+        org.apache.hadoop.yarn.api.records.NodeId.newInstance("fakeHost1", 9951),
+        FILE_NAME, USER, false);
+  }
+
+  @AfterAll
+  public static void tearDownClass() throws Exception {
+    fs.delete(new Path(REMOTE_LOG_ROOT_DIR), true);
+    fs.delete(new Path(LOCAL_ROOT_LOG_DIR), true);
+  }
+
+  @Test
+  void testGetAggregatedLogsMetaForMultipleAppsWithReusedController() {
+    WebTarget r = target().register(ContainerLogsInfoMessageBodyReader.class);
+
+    assertAggregatedLogsMeta(r, APPID_1, CONTAINER_1_1_1);
+    assertAggregatedLogsMeta(r, APPID_2, CONTAINER_2_2_1);
+  }
+
+  @Test
+  void testGetAggregatedLogsMetaReverseOrderWithReusedController() {
+    WebTarget r = target().register(ContainerLogsInfoMessageBodyReader.class);
+
+    assertAggregatedLogsMeta(r, APPID_2, CONTAINER_2_2_1);
+    assertAggregatedLogsMeta(r, APPID_1, CONTAINER_1_1_1);
+  }
+
+  private static void assertAggregatedLogsMeta(WebTarget r,
+      ApplicationId appId, ContainerId expectedContainerId) {
+    Response response = r.path("ws").path("v1")
+        .path("history").path("aggregatedlogs")
+        .queryParam(YarnWebServiceParams.APP_ID, appId.toString())
+        .request(MediaType.APPLICATION_JSON)
+        .get(Response.class);
+    assertThat(response.getStatus())
+        .as("aggregated logs meta HTTP status for " + appId)
+        .isEqualTo(200);
+    List<ContainerLogsInfo> responseList =
+        response.readEntity(new GenericType<List<ContainerLogsInfo>>(){});
+    assertThat(responseList.size())
+        .as("aggregated logs meta entry count for " + appId)
+        .isEqualTo(1);
+    assertThat(responseList.get(0).getContainerId())
+        .as("aggregated logs container id for " + appId)
+        .isEqualTo(expectedContainerId.toString());
+  }
+
+  private static ApplicationReport newApplicationReport(ApplicationId appId,
+      ApplicationAttemptId appAttemptId, boolean running) {
+    return ApplicationReport.newInstance(appId, appAttemptId, USER,
+        "fakeQueue", "fakeApplicationName", "localhost", 0, null,
+        running ? YarnApplicationState.RUNNING : YarnApplicationState.FINISHED,
+        "fake an application report", "", 1000L, 1000L, 1000L, null, null,
+        "", 50f, "fakeApplicationType", null);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -126,7 +126,7 @@ public class LogAggregationIndexedFileController
   private long logAggregationTimeInThisCycle;
   private FSDataOutputStream fsDataOStream;
   private Algorithm compressAlgo;
-  private CachedIndexedLogsMeta cachedIndexedLogsMeta = null;
+  private ApplicationId currentWriteAppId = null;
   private boolean logAggregationSuccessfullyInThisCyCle = false;
   private long currentOffSet = 0;
   private Path remoteLogCheckSumFile;
@@ -162,6 +162,13 @@ public class LogAggregationIndexedFileController
     final ApplicationId appId = context.getAppId();
     final Path remoteLogFile = context.getRemoteNodeLogFileForApp();
     this.ugi = userUgi;
+    // Controller instances may be reused across applications (e.g. singleton
+    // web services after HADOOP-15984). Reset per-app write state on app change.
+    if (currentWriteAppId == null || !currentWriteAppId.equals(appId)) {
+      currentWriteAppId = appId;
+      indexedLogsMeta = null;
+      uuid = null;
+    }
     logAggregationSuccessfullyInThisCyCle = false;
     logsMetaInThisCycle = new IndexedPerAggregationLogMeta();
     logAggregationTimeInThisCycle = this.sysClock.getTime();
@@ -263,7 +270,7 @@ public class LogAggregationIndexedFileController
     // has invalid uuid.
     if (uuid == null) {
       uuid = loadUUIDFromLogFile(fc, remoteLogFile.getParent(),
-            appId, nodeId);
+          appId, nodeId);
     }
     Path currentRemoteLogFile = getCurrentRemoteLogFile(
         fc, remoteLogFile.getParent(), nodeId);
@@ -880,25 +887,13 @@ public class LogAggregationIndexedFileController
   public String getApplicationOwner(Path aggregatedLogPath,
       ApplicationId appId)
       throws IOException {
-    if (this.cachedIndexedLogsMeta == null
-        || !this.cachedIndexedLogsMeta.getRemoteLogPath()
-            .equals(aggregatedLogPath)) {
-      this.cachedIndexedLogsMeta = new CachedIndexedLogsMeta(
-          loadIndexedLogsMeta(aggregatedLogPath, appId), aggregatedLogPath);
-    }
-    return this.cachedIndexedLogsMeta.getCachedIndexedLogsMeta().getUser();
+    return loadIndexedLogsMeta(aggregatedLogPath, appId).getUser();
   }
 
   @Override
   public Map<ApplicationAccessType, String> getApplicationAcls(
       Path aggregatedLogPath, ApplicationId appId) throws IOException {
-    if (this.cachedIndexedLogsMeta == null
-        || !this.cachedIndexedLogsMeta.getRemoteLogPath()
-            .equals(aggregatedLogPath)) {
-      this.cachedIndexedLogsMeta = new CachedIndexedLogsMeta(
-          loadIndexedLogsMeta(aggregatedLogPath, appId), aggregatedLogPath);
-    }
-    return this.cachedIndexedLogsMeta.getCachedIndexedLogsMeta().getAcls();
+    return loadIndexedLogsMeta(aggregatedLogPath, appId).getAcls();
   }
 
   @Override
@@ -942,15 +937,16 @@ public class LogAggregationIndexedFileController
       byte[] uuidRead = new byte[UUID_LENGTH];
       fsDataIStream.readFully(uuidRead);
       int uuidReadLen = uuidRead.length;
-      if (this.uuid == null) {
-        this.uuid = createUUID(appId);
-      }
-      if (uuidReadLen != UUID_LENGTH || !Arrays.equals(this.uuid, uuidRead)) {
+      // Derive the expected UUID from the application being read. Do not use
+      // the instance field, which may hold a UUID from a different application
+      // when this controller is reused across requests.
+      byte[] expectedUuid = createUUID(appId);
+      if (uuidReadLen != UUID_LENGTH || !Arrays.equals(expectedUuid, uuidRead)) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("the length of loaded UUID:{}", uuidReadLen);
           LOG.debug("the loaded UUID:{}", new String(uuidRead,
               StandardCharsets.UTF_8));
-          LOG.debug("the expected UUID:{}", new String(this.uuid,
+          LOG.debug("the expected UUID:{}", new String(expectedUuid,
               StandardCharsets.UTF_8));
         }
         throw new IOException("The UUID from "
@@ -1218,24 +1214,6 @@ public class LogAggregationIndexedFileController
     }
   }
 
-  private static class CachedIndexedLogsMeta {
-    private final Path remoteLogPath;
-    private final IndexedLogsMeta indexedLogsMeta;
-    CachedIndexedLogsMeta(IndexedLogsMeta indexedLogsMeta,
-        Path remoteLogPath) {
-      this.indexedLogsMeta = indexedLogsMeta;
-      this.remoteLogPath = remoteLogPath;
-    }
-
-    public Path getRemoteLogPath() {
-      return this.remoteLogPath;
-    }
-
-    public IndexedLogsMeta getCachedIndexedLogsMeta() {
-      return this.indexedLogsMeta;
-    }
-  }
-
   @Private
   public static int getFSOutputBufferSize(Configuration conf) {
     return conf.getInt(FS_OUTPUT_BUF_SIZE_ATTR, 256 * 1024);
@@ -1327,10 +1305,10 @@ public class LogAggregationIndexedFileController
           byte[] b = new byte[uuid.length];
           fsDataInputStream.readFully(b);
           int actual = b.length;
-          if (actual != uuid.length || Arrays.equals(b, uuid)) {
+          if (actual != uuid.length || !Arrays.equals(b, uuid)) {
             deleteFileWithRetries(fc, checkPath);
-          } else if (id == null){
-            id = uuid;
+          } else if (id == null) {
+            id = b;
           }
         }
       } finally {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/TestContainerLogsUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/TestContainerLogsUtils.java
@@ -149,6 +149,7 @@ public final class TestContainerLogsUtils {
             new AggregatedLogFormat.LogValue(rootLogDirs, containerId,
                 ugi.getShortUserName()));
       }
+      fileController.postWrite(context);
     } finally {
       fileController.closeWriter();
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
@@ -27,11 +27,15 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +65,7 @@ import org.apache.hadoop.yarn.logaggregation.ContainerLogMeta;
 import org.apache.hadoop.yarn.logaggregation.ContainerLogsRequest;
 import org.apache.hadoop.yarn.logaggregation.ExtendedLogMetaRequest;
 import org.apache.hadoop.yarn.logaggregation.LogAggregationUtils;
+import org.apache.hadoop.yarn.logaggregation.TestContainerLogsUtils;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerContext;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerFactory;
@@ -473,6 +478,293 @@ public class TestLogAggregationIndexedFileController
 
   private String logMessage(ContainerId containerId, String logType) {
     return "Hello " + containerId + " in " + logType + "!";
+  }
+
+  @Test
+  @Timeout(15000)
+  void testReadAggregatedLogsMetaForMultipleAppsWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    assertReadAggregatedLogsMeta(controller, fixture.appId1, fixture.user,
+        fixture.containerId1);
+    assertReadAggregatedLogsMeta(controller, fixture.appId2, fixture.user,
+        fixture.containerId2);
+  }
+
+  @Test
+  @Timeout(15000)
+  void testGetApplicationOwnerAndAclsForMultipleAppsWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    Path app1LogFile = findAggregatedLogFile(
+        controller.getRemoteAppLogDir(fixture.appId1, fixture.user));
+    Path app2LogFile = findAggregatedLogFile(
+        controller.getRemoteAppLogDir(fixture.appId2, fixture.user));
+
+    assertEquals(fixture.user,
+        controller.getApplicationOwner(app1LogFile, fixture.appId1),
+        "Application owner mismatch for app1");
+    assertNotNull(controller.getApplicationAcls(app1LogFile, fixture.appId1),
+        "Application ACLs should not be null for app1");
+    assertEquals(fixture.user,
+        controller.getApplicationOwner(app2LogFile, fixture.appId2),
+        "Application owner mismatch for app2");
+    assertNotNull(controller.getApplicationAcls(app2LogFile, fixture.appId2),
+        "Application ACLs should not be null for app2");
+  }
+
+  @Test
+  @Timeout(15000)
+  void testReadAggregatedLogsMetaReverseOrderWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    assertReadAggregatedLogsMeta(controller, fixture.appId2, fixture.user,
+        fixture.containerId2);
+    assertReadAggregatedLogsMeta(controller, fixture.appId1, fixture.user,
+        fixture.containerId1);
+  }
+
+  @Test
+  @Timeout(15000)
+  void testConcurrentReadAggregatedLogsMetaWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    ContainerLogsRequest app1Request = new ContainerLogsRequest();
+    app1Request.setAppId(fixture.appId1);
+    app1Request.setAppOwner(fixture.user);
+    ContainerLogsRequest app2Request = new ContainerLogsRequest();
+    app2Request.setAppId(fixture.appId2);
+    app2Request.setAppOwner(fixture.user);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<List<ContainerLogMeta>> app1Future = executor.submit(
+          () -> controller.readAggregatedLogsMeta(app1Request));
+      Future<List<ContainerLogMeta>> app2Future = executor.submit(
+          () -> controller.readAggregatedLogsMeta(app2Request));
+      List<ContainerLogMeta> app1Meta = app1Future.get();
+      List<ContainerLogMeta> app2Meta = app2Future.get();
+      assertEquals(1, app1Meta.size(),
+          "Expected one container log meta entry for app1");
+      assertEquals(fixture.containerId1.toString(), app1Meta.get(0).getContainerId(),
+          "Unexpected container id for app1");
+      assertEquals(1, app2Meta.size(),
+          "Expected one container log meta entry for app2");
+      assertEquals(fixture.containerId2.toString(), app2Meta.get(0).getContainerId(),
+          "Unexpected container id for app2");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  @Timeout(15000)
+  void testWriteSessionResetForMultipleAppsWithReusedController()
+      throws Exception {
+    Configuration ifileConf = newIFileConfiguration();
+    ApplicationId appId1 = ApplicationId.newInstance(20, 1);
+    ApplicationId appId2 = ApplicationId.newInstance(20, 2);
+    ContainerId containerId1 = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(appId1, 1), 1);
+    ContainerId containerId2 = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(appId2, 1), 1);
+    String user = USER_UGI.getShortUserName();
+
+    LogAggregationIndexedFileController controller =
+        new LogAggregationIndexedFileController();
+    controller.initialize(ifileConf, "IFile");
+    uploadAppLogsWithController(controller, appId1, containerId1, user, true);
+    uploadAppLogsWithController(controller, appId2, containerId2, user, false);
+
+    LogAggregationFileControllerFactory factory =
+        new LogAggregationFileControllerFactory(ifileConf);
+    LogAggregationFileController reader =
+        factory.getFileControllerForRead(appId1, user);
+    assertReadAggregatedLogsMeta(reader, appId1, user, containerId1);
+    assertReadAggregatedLogsMeta(reader, appId2, user, containerId2);
+  }
+
+  @Test
+  @Timeout(15000)
+  void testLoadUUIDFromLogFilePreservesValidAggregatedLogFile()
+      throws Exception {
+    Configuration ifileConf = newIFileConfiguration();
+    ApplicationId appId1 = ApplicationId.newInstance(30, 1);
+    ContainerId containerId1 = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(appId1, 1), 1);
+    String user = USER_UGI.getShortUserName();
+
+    LogAggregationIndexedFileController writer1 =
+        new LogAggregationIndexedFileController();
+    writer1.initialize(ifileConf, "IFile");
+    uploadAppLogsWithController(writer1, appId1, containerId1, user, true);
+
+    Path logFile = findAggregatedLogFile(
+        writer1.getRemoteAppLogDir(appId1, user));
+    assertTrue(fs.exists(logFile),
+        "Aggregated log file should exist before rolling init");
+
+    LogAggregationIndexedFileController writer2 =
+        new LogAggregationIndexedFileController();
+    writer2.initialize(ifileConf, "IFile");
+    Path nodePath = new Path(writer2.getRemoteAppLogDir(appId1, user),
+        LogAggregationUtils.getNodeString(nodeId));
+    Map<ApplicationAccessType, String> appAcls = new HashMap<>();
+    LogAggregationFileControllerContext context =
+        new LogAggregationFileControllerContext(
+            nodePath, nodePath, true, 1000, appId1, appAcls, nodeId, USER_UGI);
+    writer2.initializeWriter(context);
+    writer2.closeWriter();
+
+    assertTrue(fs.exists(logFile),
+        "Aggregated log file should exist after rolling init");
+    ContainerLogsRequest request = new ContainerLogsRequest();
+    request.setAppId(appId1);
+    request.setAppOwner(user);
+    assertEquals(1, writer1.readAggregatedLogsMeta(request).size(),
+        "Expected one container log meta entry after rolling init");
+  }
+
+  private Configuration newIFileConfiguration() {
+    Configuration ifileConf = new YarnConfiguration();
+    ifileConf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
+    ifileConf.setStrings(YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS, "IFile");
+    ifileConf.setClass(String.format(
+        YarnConfiguration.LOG_AGGREGATION_FILE_CONTROLLER_FMT, "IFile"),
+        LogAggregationIndexedFileController.class,
+        LogAggregationFileController.class);
+    ifileConf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR, remoteLogDir);
+    ifileConf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR_SUFFIX, "logs");
+    return ifileConf;
+  }
+
+  private static class TwoAppIFileFixture {
+    private final LogAggregationFileControllerFactory factory;
+    private final ApplicationId appId1;
+    private final ApplicationId appId2;
+    private final ContainerId containerId1;
+    private final ContainerId containerId2;
+    private final String user;
+
+    private TwoAppIFileFixture(LogAggregationFileControllerFactory factory,
+        ApplicationId appId1, ApplicationId appId2, ContainerId containerId1,
+        ContainerId containerId2, String user) {
+      this.factory = factory;
+      this.appId1 = appId1;
+      this.appId2 = appId2;
+      this.containerId1 = containerId1;
+      this.containerId2 = containerId2;
+      this.user = user;
+    }
+  }
+
+  private TwoAppIFileFixture prepareTwoAppIFileFixture() throws Exception {
+    Configuration ifileConf = newIFileConfiguration();
+    ApplicationId appId1 = ApplicationId.newInstance(1, 1);
+    ApplicationId appId2 = ApplicationId.newInstance(10, 2);
+    ApplicationAttemptId attemptId1 =
+        ApplicationAttemptId.newInstance(appId1, 1);
+    ApplicationAttemptId attemptId2 =
+        ApplicationAttemptId.newInstance(appId2, 1);
+    ContainerId containerId1 =
+        ContainerId.newContainerId(attemptId1, 1);
+    ContainerId containerId2 =
+        ContainerId.newContainerId(attemptId2, 1);
+    String user = USER_UGI.getShortUserName();
+    String fileName = "syslog";
+
+    Map<ContainerId, String> app1Logs = new HashMap<>();
+    app1Logs.put(containerId1, logMessage(containerId1, fileName));
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(ifileConf, fs,
+        rootLocalLogDir, appId1, app1Logs, nodeId, fileName, user, true);
+    Map<ContainerId, String> app2Logs = new HashMap<>();
+    app2Logs.put(containerId2, logMessage(containerId2, fileName));
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(ifileConf, fs,
+        rootLocalLogDir, appId2, app2Logs, nodeId, fileName, user, false);
+
+    LogAggregationFileControllerFactory factory =
+        new LogAggregationFileControllerFactory(ifileConf);
+    return new TwoAppIFileFixture(factory, appId1, appId2, containerId1,
+        containerId2, user);
+  }
+
+  private void assertReadAggregatedLogsMeta(
+      LogAggregationFileController controller, ApplicationId appId, String user,
+      ContainerId expectedContainerId) throws IOException {
+    ContainerLogsRequest request = new ContainerLogsRequest();
+    request.setAppId(appId);
+    request.setAppOwner(user);
+    List<ContainerLogMeta> meta = controller.readAggregatedLogsMeta(request);
+    assertEquals(1, meta.size(), "Expected one container log meta entry");
+    assertEquals(expectedContainerId.toString(), meta.get(0).getContainerId(),
+        "Unexpected container id");
+  }
+
+  private void uploadAppLogsWithController(
+      LogAggregationIndexedFileController controller, ApplicationId appId,
+      ContainerId containerId, String user, boolean deleteRemoteLogDir)
+      throws Exception {
+    Path localAppDir = new Path(rootLocalLogDirPath, appId.toString());
+    if (fs.exists(localAppDir)) {
+      fs.delete(localAppDir, true);
+    }
+    assertTrue(fs.mkdirs(localAppDir), "Failed to create local app log directory");
+    Path containerLogDir = new Path(localAppDir, containerId.toString());
+    assertTrue(fs.mkdirs(containerLogDir),
+        "Failed to create local container log directory");
+    createAndWriteLocalLogFile(containerLogDir, "syslog",
+        logMessage(containerId, "syslog"));
+
+    List<String> rootLogDirList = Collections.singletonList(rootLocalLogDir);
+    Path appDir = controller.getRemoteAppLogDir(appId, user);
+    if (fs.exists(appDir) && deleteRemoteLogDir) {
+      fs.delete(appDir, true);
+    }
+    assertTrue(fs.mkdirs(appDir), "Failed to create remote app log directory");
+    Path nodePath = new Path(appDir, LogAggregationUtils.getNodeString(nodeId));
+
+    Map<ApplicationAccessType, String> appAcls = new HashMap<>();
+    appAcls.put(ApplicationAccessType.VIEW_APP, user);
+    LogAggregationFileControllerContext context =
+        new LogAggregationFileControllerContext(
+            nodePath, nodePath, true, 1000, appId, appAcls, nodeId, USER_UGI);
+    try {
+      controller.initializeWriter(context);
+      controller.write(new LogKey(containerId.toString()),
+          new LogValue(rootLogDirList, containerId, user));
+      controller.postWrite(context);
+    } finally {
+      controller.closeWriter();
+    }
+  }
+
+  private Path findAggregatedLogFile(Path appDir) throws IOException {
+    for (FileStatus nodeDir : fs.listStatus(appDir)) {
+      String nodeName = nodeDir.getPath().getName();
+      if (nodeName.endsWith(LogAggregationIndexedFileController
+          .CHECK_SUM_FILE_SUFFIX)) {
+        continue;
+      }
+      for (FileStatus logFile : fs.listStatus(nodeDir.getPath())) {
+        if (!logFile.getPath().getName().endsWith(
+            LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX)) {
+          return logFile.getPath();
+        }
+      }
+    }
+    throw new IOException("No aggregated log file found under " + appDir);
   }
 
   @Test


### PR DESCRIPTION
…ue to uuid mismatch

Fix IFile aggregated log reads after HADOOP-15984 singleton web services.

HADOOP-15984 made HsWebServices a singleton, so LogAggregationIndexedFileController is reused across /ws/v1/history/aggregatedlogs requests. IFile log meta reads validated UUIDs against a cached instance field from the first application, causing aggregated logs for other apps to fail until JHS restart.

Derive the expected UUID from the application being read. Add regression tests and call postWrite() in test log upload helpers so IFile metadata is written.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html