### PR TITLE
MAPREDUCE-7539. JobHistoryServer API fails to serve aggregated logs due to uuid mismatch

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
@@ -60,7 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -211,17 +211,15 @@ public class TestHsWebServicesIFileAggregatedLogs extends JerseyTestBase {
         .queryParam(YarnWebServiceParams.APP_ID, appId.toString())
         .request(MediaType.APPLICATION_JSON)
         .get(Response.class);
-    assertThat(response.getStatus())
-        .as("aggregated logs meta HTTP status for " + appId)
-        .isEqualTo(200);
+    assertEquals(200, response.getStatus(),
+        "aggregated logs meta HTTP status for " + appId);
     List<ContainerLogsInfo> responseList =
         response.readEntity(new GenericType<List<ContainerLogsInfo>>(){});
-    assertThat(responseList.size())
-        .as("aggregated logs meta entry count for " + appId)
-        .isEqualTo(1);
-    assertThat(responseList.get(0).getContainerId())
-        .as("aggregated logs container id for " + appId)
-        .isEqualTo(expectedContainerId.toString());
+    assertEquals(1, responseList.size(),
+        "aggregated logs meta entry count for " + appId);
+    assertEquals(expectedContainerId.toString(),
+        responseList.get(0).getContainerId(),
+        "aggregated logs container id for " + appId);
   }
 
   private static ApplicationReport newApplicationReport(ApplicationId appId,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression tests for HADOOP-15984: singleton {@link HsWebServices} reuses
+ * Regression tests for MAPREDUCE-7539: singleton {@link HsWebServices} reuses
  * {@link LogAggregationIndexedFileController} across requests, so IFile log
  * reads must not rely on per-instance UUID state from a prior application.
  */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesIFileAggregatedLogs.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.v2.app.AppContext;
+import org.apache.hadoop.mapreduce.v2.hs.HistoryContext;
+import org.apache.hadoop.mapreduce.v2.hs.MockHistoryContext;
+import org.apache.hadoop.mapreduce.v2.hs.webapp.reader.ContainerLogsInfoMessageBodyReader;
+import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.logaggregation.TestContainerLogsUtils;
+import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController;
+import org.apache.hadoop.yarn.logaggregation.filecontroller.ifile.LogAggregationIndexedFileController;
+import org.apache.hadoop.yarn.server.webapp.LogServlet;
+import org.apache.hadoop.yarn.server.webapp.YarnWebServiceParams;
+import org.apache.hadoop.yarn.server.webapp.dao.ContainerLogsInfo;
+import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
+import org.apache.hadoop.yarn.webapp.JerseyTestBase;
+import org.apache.hadoop.yarn.webapp.WebApp;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.jettison.JettisonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for HADOOP-15984: singleton {@link HsWebServices} reuses
+ * {@link LogAggregationIndexedFileController} across requests, so IFile log
+ * reads must not rely on per-instance UUID state from a prior application.
+ */
+public class TestHsWebServicesIFileAggregatedLogs extends JerseyTestBase {
+
+  private static final Configuration CONF = new YarnConfiguration();
+  private static FileSystem fs;
+
+  private static final String LOCAL_ROOT_LOG_DIR = "target/LocalLogsIFile";
+  private static final String REMOTE_LOG_ROOT_DIR = "target/logs-ifile/";
+  private static final String USER = "fakeUser";
+  private static final String FILE_NAME = "syslog";
+
+  private static final ApplicationId APPID_1 = ApplicationId.newInstance(1, 1);
+  private static final ApplicationId APPID_2 = ApplicationId.newInstance(10, 2);
+  private static final ApplicationAttemptId APP_ATTEMPT_1_1 =
+      ApplicationAttemptId.newInstance(APPID_1, 1);
+  private static final ApplicationAttemptId APP_ATTEMPT_2_2 =
+      ApplicationAttemptId.newInstance(APPID_2, 2);
+
+  private static final ContainerId CONTAINER_1_1_1 =
+      ContainerId.newContainerId(
+          ApplicationAttemptId.newInstance(APPID_1, 1), 1);
+  private static final ContainerId CONTAINER_2_2_1 =
+      ContainerId.newContainerId(
+          ApplicationAttemptId.newInstance(APPID_2, 2), 1);
+
+  @Override
+  protected Application configure() {
+    ResourceConfig config = new ResourceConfig();
+    config.register(new JerseyBinder());
+    config.register(HsWebServices.class);
+    config.register(GenericExceptionHandler.class);
+    config.register(new JettisonFeature()).register(JAXBContextResolver.class);
+    return config;
+  }
+
+  private final class JerseyBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+      HsWebApp webApp = mock(HsWebApp.class);
+      when(webApp.name()).thenReturn("hsmockwebapp");
+
+      MockHistoryContext appContext = new MockHistoryContext(0, 1, 2, 1);
+      ApplicationClientProtocol mockProtocol = mock(ApplicationClientProtocol.class);
+      try {
+        doAnswer(invocationOnMock -> {
+          GetApplicationReportRequest request = invocationOnMock.getArgument(0);
+          if (request.getApplicationId().equals(APPID_1)) {
+            return GetApplicationReportResponse.newInstance(
+                newApplicationReport(APPID_1, APP_ATTEMPT_1_1, false));
+          } else if (request.getApplicationId().equals(APPID_2)) {
+            return GetApplicationReportResponse.newInstance(
+                newApplicationReport(APPID_2, APP_ATTEMPT_2_2, false));
+          }
+          throw new RuntimeException("Unknown applicationId: " + request.getApplicationId());
+        }).when(mockProtocol).getApplicationReport(any());
+      } catch (Exception ignore) {
+        fail("Failed to setup mock protocol");
+      }
+
+      HsWebServices hsWebServices =
+          new HsWebServices(appContext, CONF, webApp, mockProtocol);
+      try {
+        LogServlet logServlet = spy(hsWebServices.getLogServlet());
+        doReturn(null).when(logServlet).getNMWebAddressFromRM(any());
+        hsWebServices.setLogServlet(logServlet);
+      } catch (Exception ignore) {
+        fail("Failed to setup LogServlet");
+      }
+
+      bind(webApp).to(WebApp.class).named("hsWebApp");
+      bind(appContext).to(AppContext.class);
+      bind(appContext).to(HistoryContext.class).named("ctx");
+      bind(CONF).to(Configuration.class).named("conf");
+      bind(mockProtocol).to(ApplicationClientProtocol.class).named("appClient");
+      final HttpServletResponse response = mock(HttpServletResponse.class);
+      bind(response).to(HttpServletResponse.class);
+      final HttpServletRequest request = mock(HttpServletRequest.class);
+      bind(request).to(HttpServletRequest.class);
+      hsWebServices.setResponse(response);
+      bind(hsWebServices).to(HsWebServices.class);
+    }
+  }
+
+  @BeforeAll
+  public static void setupClass() throws Exception {
+    CONF.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
+    CONF.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR, REMOTE_LOG_ROOT_DIR);
+    CONF.setStrings(YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS, "IFile");
+    CONF.setClass(String.format(
+        YarnConfiguration.LOG_AGGREGATION_FILE_CONTROLLER_FMT, "IFile"),
+        LogAggregationIndexedFileController.class,
+        LogAggregationFileController.class);
+    fs = FileSystem.get(CONF);
+
+    Map<ContainerId, String> app1Logs = new HashMap<>();
+    app1Logs.put(CONTAINER_1_1_1, "Hello-" + CONTAINER_1_1_1);
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(CONF, fs,
+        LOCAL_ROOT_LOG_DIR, APPID_1, app1Logs,
+        org.apache.hadoop.yarn.api.records.NodeId.newInstance("fakeHost1", 9951),
+        FILE_NAME, USER, true);
+
+    Map<ContainerId, String> app2Logs = new HashMap<>();
+    app2Logs.put(CONTAINER_2_2_1, "Hello-" + CONTAINER_2_2_1);
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(CONF, fs,
+        LOCAL_ROOT_LOG_DIR, APPID_2, app2Logs,
+        org.apache.hadoop.yarn.api.records.NodeId.newInstance("fakeHost1", 9951),
+        FILE_NAME, USER, false);
+  }
+
+  @AfterAll
+  public static void tearDownClass() throws Exception {
+    fs.delete(new Path(REMOTE_LOG_ROOT_DIR), true);
+    fs.delete(new Path(LOCAL_ROOT_LOG_DIR), true);
+  }
+
+  @Test
+  void testGetAggregatedLogsMetaForMultipleAppsWithReusedController() {
+    WebTarget r = target().register(ContainerLogsInfoMessageBodyReader.class);
+
+    assertAggregatedLogsMeta(r, APPID_1, CONTAINER_1_1_1);
+    assertAggregatedLogsMeta(r, APPID_2, CONTAINER_2_2_1);
+  }
+
+  @Test
+  void testGetAggregatedLogsMetaReverseOrderWithReusedController() {
+    WebTarget r = target().register(ContainerLogsInfoMessageBodyReader.class);
+
+    assertAggregatedLogsMeta(r, APPID_2, CONTAINER_2_2_1);
+    assertAggregatedLogsMeta(r, APPID_1, CONTAINER_1_1_1);
+  }
+
+  private static void assertAggregatedLogsMeta(WebTarget r,
+      ApplicationId appId, ContainerId expectedContainerId) {
+    Response response = r.path("ws").path("v1")
+        .path("history").path("aggregatedlogs")
+        .queryParam(YarnWebServiceParams.APP_ID, appId.toString())
+        .request(MediaType.APPLICATION_JSON)
+        .get(Response.class);
+    assertThat(response.getStatus())
+        .as("aggregated logs meta HTTP status for " + appId)
+        .isEqualTo(200);
+    List<ContainerLogsInfo> responseList =
+        response.readEntity(new GenericType<List<ContainerLogsInfo>>(){});
+    assertThat(responseList.size())
+        .as("aggregated logs meta entry count for " + appId)
+        .isEqualTo(1);
+    assertThat(responseList.get(0).getContainerId())
+        .as("aggregated logs container id for " + appId)
+        .isEqualTo(expectedContainerId.toString());
+  }
+
+  private static ApplicationReport newApplicationReport(ApplicationId appId,
+      ApplicationAttemptId appAttemptId, boolean running) {
+    return ApplicationReport.newInstance(appId, appAttemptId, USER,
+        "fakeQueue", "fakeApplicationName", "localhost", 0, null,
+        running ? YarnApplicationState.RUNNING : YarnApplicationState.FINISHED,
+        "fake an application report", "", 1000L, 1000L, 1000L, null, null,
+        "", 50f, "fakeApplicationType", null);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -126,7 +126,7 @@ public class LogAggregationIndexedFileController
   private long logAggregationTimeInThisCycle;
   private FSDataOutputStream fsDataOStream;
   private Algorithm compressAlgo;
-  private CachedIndexedLogsMeta cachedIndexedLogsMeta = null;
+  private ApplicationId currentWriteAppId = null;
   private boolean logAggregationSuccessfullyInThisCyCle = false;
   private long currentOffSet = 0;
   private Path remoteLogCheckSumFile;
@@ -162,6 +162,13 @@ public class LogAggregationIndexedFileController
     final ApplicationId appId = context.getAppId();
     final Path remoteLogFile = context.getRemoteNodeLogFileForApp();
     this.ugi = userUgi;
+    // Controller instances may be reused across applications (e.g. singleton
+    // web services after HADOOP-15984). Reset per-app write state on app change.
+    if (currentWriteAppId == null || !currentWriteAppId.equals(appId)) {
+      currentWriteAppId = appId;
+      indexedLogsMeta = null;
+      uuid = null;
+    }
     logAggregationSuccessfullyInThisCyCle = false;
     logsMetaInThisCycle = new IndexedPerAggregationLogMeta();
     logAggregationTimeInThisCycle = this.sysClock.getTime();
@@ -263,7 +270,7 @@ public class LogAggregationIndexedFileController
     // has invalid uuid.
     if (uuid == null) {
       uuid = loadUUIDFromLogFile(fc, remoteLogFile.getParent(),
-            appId, nodeId);
+          appId, nodeId);
     }
     Path currentRemoteLogFile = getCurrentRemoteLogFile(
         fc, remoteLogFile.getParent(), nodeId);
@@ -880,25 +887,13 @@ public class LogAggregationIndexedFileController
   public String getApplicationOwner(Path aggregatedLogPath,
       ApplicationId appId)
       throws IOException {
-    if (this.cachedIndexedLogsMeta == null
-        || !this.cachedIndexedLogsMeta.getRemoteLogPath()
-            .equals(aggregatedLogPath)) {
-      this.cachedIndexedLogsMeta = new CachedIndexedLogsMeta(
-          loadIndexedLogsMeta(aggregatedLogPath, appId), aggregatedLogPath);
-    }
-    return this.cachedIndexedLogsMeta.getCachedIndexedLogsMeta().getUser();
+    return loadIndexedLogsMeta(aggregatedLogPath, appId).getUser();
   }
 
   @Override
   public Map<ApplicationAccessType, String> getApplicationAcls(
       Path aggregatedLogPath, ApplicationId appId) throws IOException {
-    if (this.cachedIndexedLogsMeta == null
-        || !this.cachedIndexedLogsMeta.getRemoteLogPath()
-            .equals(aggregatedLogPath)) {
-      this.cachedIndexedLogsMeta = new CachedIndexedLogsMeta(
-          loadIndexedLogsMeta(aggregatedLogPath, appId), aggregatedLogPath);
-    }
-    return this.cachedIndexedLogsMeta.getCachedIndexedLogsMeta().getAcls();
+    return loadIndexedLogsMeta(aggregatedLogPath, appId).getAcls();
   }
 
   @Override
@@ -942,15 +937,16 @@ public class LogAggregationIndexedFileController
       byte[] uuidRead = new byte[UUID_LENGTH];
       fsDataIStream.readFully(uuidRead);
       int uuidReadLen = uuidRead.length;
-      if (this.uuid == null) {
-        this.uuid = createUUID(appId);
-      }
-      if (uuidReadLen != UUID_LENGTH || !Arrays.equals(this.uuid, uuidRead)) {
+      // Derive the expected UUID from the application being read. Do not use
+      // the instance field, which may hold a UUID from a different application
+      // when this controller is reused across requests.
+      byte[] expectedUuid = createUUID(appId);
+      if (uuidReadLen != UUID_LENGTH || !Arrays.equals(expectedUuid, uuidRead)) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("the length of loaded UUID:{}", uuidReadLen);
           LOG.debug("the loaded UUID:{}", new String(uuidRead,
               StandardCharsets.UTF_8));
-          LOG.debug("the expected UUID:{}", new String(this.uuid,
+          LOG.debug("the expected UUID:{}", new String(expectedUuid,
               StandardCharsets.UTF_8));
         }
         throw new IOException("The UUID from "
@@ -1218,24 +1214,6 @@ public class LogAggregationIndexedFileController
     }
   }
 
-  private static class CachedIndexedLogsMeta {
-    private final Path remoteLogPath;
-    private final IndexedLogsMeta indexedLogsMeta;
-    CachedIndexedLogsMeta(IndexedLogsMeta indexedLogsMeta,
-        Path remoteLogPath) {
-      this.indexedLogsMeta = indexedLogsMeta;
-      this.remoteLogPath = remoteLogPath;
-    }
-
-    public Path getRemoteLogPath() {
-      return this.remoteLogPath;
-    }
-
-    public IndexedLogsMeta getCachedIndexedLogsMeta() {
-      return this.indexedLogsMeta;
-    }
-  }
-
   @Private
   public static int getFSOutputBufferSize(Configuration conf) {
     return conf.getInt(FS_OUTPUT_BUF_SIZE_ATTR, 256 * 1024);
@@ -1318,6 +1296,7 @@ public class LogAggregationIndexedFileController
     FSDataInputStream fsDataInputStream = null;
     byte[] uuid = createUUID(appId);
     while(files.hasNext()) {
+      fsDataInputStream = null;
       try {
         Path checkPath = files.next().getPath();
         if (checkPath.getName().contains(LogAggregationUtils
@@ -1327,10 +1306,10 @@ public class LogAggregationIndexedFileController
           byte[] b = new byte[uuid.length];
           fsDataInputStream.readFully(b);
           int actual = b.length;
-          if (actual != uuid.length || Arrays.equals(b, uuid)) {
+          if (actual != uuid.length || !Arrays.equals(b, uuid)) {
             deleteFileWithRetries(fc, checkPath);
-          } else if (id == null){
-            id = uuid;
+          } else if (id == null) {
+            id = b;
           }
         }
       } finally {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -181,10 +181,14 @@ public class LogAggregationIndexedFileController
     final ApplicationId appId = context.getAppId();
     final Path remoteLogFile = context.getRemoteNodeLogFileForApp();
 
-    // Allocate a fresh WriteSession for every initializeWriter call so that
-    // all write-path state is completely isolated from other applications.
-    // This is safe whether the controller is used by a single NM aggregation
-    // thread or reused across requests by a singleton web service.
+    // Allocate a fresh WriteSession for every initializeWriter call.
+    // The write lifecycle (initializeWriter → write → postWrite → closeWriter)
+    // is always single-threaded: the NodeManager's AppLogAggregatorImpl calls
+    // these methods sequentially within one thread per application, so
+    // concurrent write sessions for the same controller instance are not
+    // possible in practice. The read-path methods (readAggregatedLogsMeta,
+    // readAggregatedLogs, getApplicationOwner, getApplicationAcls) do not
+    // access writeSession at all, so reads and writes are also independent.
     final WriteSession session = new WriteSession(createUUID(appId));
     session.ugi = userUgi;
     session.logAggregationSuccessfullyInThisCyCle = false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -121,21 +121,40 @@ public class LogAggregationIndexedFileController
   private int fsNumRetries = 3;
   private long fsRetryInterval = 1000L;
   private static final int VERSION = 1;
-  private IndexedLogsMeta indexedLogsMeta = null;
-  private IndexedPerAggregationLogMeta logsMetaInThisCycle;
-  private long logAggregationTimeInThisCycle;
-  private FSDataOutputStream fsDataOStream;
   private Algorithm compressAlgo;
-  private ApplicationId currentWriteAppId = null;
-  private boolean logAggregationSuccessfullyInThisCyCle = false;
-  private long currentOffSet = 0;
-  private Path remoteLogCheckSumFile;
-  private FileContext fc;
-  private UserGroupInformation ugi;
-  private byte[] uuid = null;
   private final int UUID_LENGTH = 32;
   private long logRollOverMaxFileSize;
   private Clock sysClock;
+
+  /**
+   * All mutable state that belongs to a single write session
+   * (one {@link #initializeWriter} / {@link #write} / {@link #postWrite} /
+   * {@link #closeWriter} lifecycle). Bundling it here means the read path
+   * cannot accidentally touch write-path state, regardless of whether the
+   * controller instance is shared across applications.
+   */
+  private static final class WriteSession {
+    /** UUID derived from the application being written. */
+    private final byte[] uuid;
+    /** Accumulated log metadata for the current aggregated file. */
+    private IndexedLogsMeta indexedLogsMeta;
+    /** Log metadata accumulated within this single write cycle. */
+    private IndexedPerAggregationLogMeta logsMetaInThisCycle;
+    private long logAggregationTimeInThisCycle;
+    private boolean logAggregationSuccessfullyInThisCyCle = false;
+    private long currentOffSet = 0;
+    private Path remoteLogCheckSumFile;
+    private FileContext fc;
+    private UserGroupInformation ugi;
+    private FSDataOutputStream fsDataOStream;
+
+    WriteSession(byte[] uuid) {
+      this.uuid = uuid;
+    }
+  }
+
+  /** Non-null while a write session is in progress; null otherwise. */
+  private WriteSession writeSession = null;
 
   public LogAggregationIndexedFileController() {}
 
@@ -161,37 +180,36 @@ public class LogAggregationIndexedFileController
     final String nodeId = context.getNodeId().toString();
     final ApplicationId appId = context.getAppId();
     final Path remoteLogFile = context.getRemoteNodeLogFileForApp();
-    this.ugi = userUgi;
-    // Controller instances may be reused across applications (e.g. singleton
-    // web services after HADOOP-15984). Reset per-app write state on app change.
-    if (currentWriteAppId == null || !currentWriteAppId.equals(appId)) {
-      currentWriteAppId = appId;
-      indexedLogsMeta = null;
-      uuid = null;
-    }
-    logAggregationSuccessfullyInThisCyCle = false;
-    logsMetaInThisCycle = new IndexedPerAggregationLogMeta();
-    logAggregationTimeInThisCycle = this.sysClock.getTime();
-    logsMetaInThisCycle.setUploadTimeStamp(logAggregationTimeInThisCycle);
-    logsMetaInThisCycle.setRemoteNodeFile(remoteLogFile.getName());
+
+    // Allocate a fresh WriteSession for every initializeWriter call so that
+    // all write-path state is completely isolated from other applications.
+    // This is safe whether the controller is used by a single NM aggregation
+    // thread or reused across requests by a singleton web service.
+    final WriteSession session = new WriteSession(createUUID(appId));
+    session.ugi = userUgi;
+    session.logAggregationSuccessfullyInThisCyCle = false;
+    session.logsMetaInThisCycle = new IndexedPerAggregationLogMeta();
+    session.logAggregationTimeInThisCycle = this.sysClock.getTime();
+    session.logsMetaInThisCycle.setUploadTimeStamp(
+        session.logAggregationTimeInThisCycle);
+    session.logsMetaInThisCycle.setRemoteNodeFile(remoteLogFile.getName());
     try {
       userUgi.doAs(new PrivilegedExceptionAction<Object>() {
         @Override
         public Object run() throws Exception {
-          fc = FileContext.getFileContext(
+          session.fc = FileContext.getFileContext(
               remoteRootLogDir.toUri(), conf);
-          fc.setUMask(APP_LOG_FILE_UMASK);
-          if (indexedLogsMeta == null) {
-            indexedLogsMeta = new IndexedLogsMeta();
-            indexedLogsMeta.setVersion(VERSION);
-            indexedLogsMeta.setUser(userUgi.getShortUserName());
-            indexedLogsMeta.setAcls(appAcls);
-            indexedLogsMeta.setNodeId(nodeId);
-            String compressName = conf.get(
-                YarnConfiguration.NM_LOG_AGG_COMPRESSION_TYPE,
-                YarnConfiguration.DEFAULT_NM_LOG_AGG_COMPRESSION_TYPE);
-            indexedLogsMeta.setCompressName(compressName);
-          }
+          session.fc.setUMask(APP_LOG_FILE_UMASK);
+          session.indexedLogsMeta = new IndexedLogsMeta();
+          session.indexedLogsMeta.setVersion(VERSION);
+          session.indexedLogsMeta.setUser(userUgi.getShortUserName());
+          session.indexedLogsMeta.setAcls(appAcls);
+          session.indexedLogsMeta.setNodeId(nodeId);
+          String compressName = conf.get(
+              YarnConfiguration.NM_LOG_AGG_COMPRESSION_TYPE,
+              YarnConfiguration.DEFAULT_NM_LOG_AGG_COMPRESSION_TYPE);
+          session.indexedLogsMeta.setCompressName(compressName);
+
           Path aggregatedLogFile = null;
           Pair<Path, Boolean> initializationResult = null;
           boolean createdNew;
@@ -200,42 +218,39 @@ public class LogAggregationIndexedFileController
             // In rolling log aggregation we need special initialization
             // done in initializeWriterInRolling.
             initializationResult = initializeWriterInRolling(
-                remoteLogFile, appId, nodeId);
+                session, remoteLogFile, appId, nodeId);
             aggregatedLogFile = initializationResult.getLeft();
             createdNew = initializationResult.getRight();
           } else {
             aggregatedLogFile = remoteLogFile;
-            fsDataOStream = fc.create(remoteLogFile,
+            session.fsDataOStream = session.fc.create(remoteLogFile,
                 EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE),
                 new Options.CreateOpts[] {});
-            if (uuid == null) {
-              uuid = createUUID(appId);
-            }
-            fsDataOStream.write(uuid);
-            fsDataOStream.flush();
+            session.fsDataOStream.write(session.uuid);
+            session.fsDataOStream.flush();
             createdNew = true;
           }
 
           // If we have created a new file, we know that the offset is zero.
           // Otherwise we should get this information through getFileStatus.
           if (createdNew) {
-            currentOffSet = 0;
+            session.currentOffSet = 0;
           } else {
-            long aggregatedLogFileLength = fc.getFileStatus(
+            long aggregatedLogFileLength = session.fc.getFileStatus(
                 aggregatedLogFile).getLen();
             // append a simple character("\n") to move the writer cursor, so
             // we could get the correct position when we call
             // fsOutputStream.getStartPos()
             final byte[] dummyBytes = "\n".getBytes(StandardCharsets.UTF_8);
-            fsDataOStream.write(dummyBytes);
-            fsDataOStream.flush();
+            session.fsDataOStream.write(dummyBytes);
+            session.fsDataOStream.flush();
 
-            if (fsDataOStream.getPos() < (aggregatedLogFileLength
+            if (session.fsDataOStream.getPos() < (aggregatedLogFileLength
                 + dummyBytes.length)) {
-              currentOffSet = fc.getFileStatus(
+              session.currentOffSet = session.fc.getFileStatus(
                       aggregatedLogFile).getLen();
             } else {
-              currentOffSet = 0;
+              session.currentOffSet = 0;
             }
           }
           return null;
@@ -244,12 +259,14 @@ public class LogAggregationIndexedFileController
     } catch (Exception e) {
       throw new IOException(e);
     }
+    this.writeSession = session;
   }
 
   /**
    * Initializes the write for the log aggregation controller in the
    * rolling case. It sets up / modifies checksum and meta files if needed.
    *
+   * @param session the current write session
    * @param remoteLogFile the Path of the remote log file
    * @param appId the application id
    * @param nodeId the node id
@@ -259,33 +276,31 @@ public class LogAggregationIndexedFileController
    * @throws Exception
    */
   private Pair<Path, Boolean> initializeWriterInRolling(
+      final WriteSession session,
       final Path remoteLogFile, final ApplicationId appId,
       final String nodeId) throws Exception {
     boolean createdNew = false;
     Path aggregatedLogFile = null;
-    // check uuid
-    // if we can not find uuid, we would load the uuid
-    // from previous aggregated log files, and at the same
-    // time, we would delete any aggregated log files which
-    // has invalid uuid.
-    if (uuid == null) {
-      uuid = loadUUIDFromLogFile(fc, remoteLogFile.getParent(),
-          appId, nodeId);
-    }
+    // Validate existing log files for this node: delete any whose stored UUID
+    // does not match this application's UUID. The session UUID is always the
+    // deterministic SHA-256 of the ApplicationId string, so existing valid
+    // files will match and corrupt/stale files will be removed.
+    loadUUIDFromLogFile(session.fc, remoteLogFile.getParent(), appId, nodeId);
     Path currentRemoteLogFile = getCurrentRemoteLogFile(
-        fc, remoteLogFile.getParent(), nodeId);
+        session.fc, remoteLogFile.getParent(), nodeId);
     // check checksum file
     boolean overwriteCheckSum = true;
-    remoteLogCheckSumFile = new Path(remoteLogFile.getParent(),
+    session.remoteLogCheckSumFile = new Path(remoteLogFile.getParent(),
         (remoteLogFile.getName() + CHECK_SUM_FILE_SUFFIX));
-    if(fc.util().exists(remoteLogCheckSumFile)) {
+    if(session.fc.util().exists(session.remoteLogCheckSumFile)) {
       // if the checksum file exists, we should reset cached
       // indexedLogsMeta.
-      indexedLogsMeta.getLogMetas().clear();
+      session.indexedLogsMeta.getLogMetas().clear();
       if (currentRemoteLogFile != null) {
         FSDataInputStream checksumFileInputStream = null;
         try {
-          checksumFileInputStream = fc.open(remoteLogCheckSumFile);
+          checksumFileInputStream = session.fc.open(
+              session.remoteLogCheckSumFile);
           int nameLength = checksumFileInputStream.readInt();
           byte[] b = new byte[nameLength];
           checksumFileInputStream.readFully(b);
@@ -300,7 +315,7 @@ public class LogAggregationIndexedFileController
               IndexedLogsMeta recoveredLogsMeta = loadIndexedLogsMeta(
                   currentRemoteLogFile, endIndex, appId);
               if (recoveredLogsMeta != null) {
-                indexedLogsMeta = recoveredLogsMeta;
+                session.indexedLogsMeta = recoveredLogsMeta;
               }
             }
           }
@@ -311,21 +326,21 @@ public class LogAggregationIndexedFileController
     }
     // check whether we need roll over old logs
     if (currentRemoteLogFile == null || isRollover(
-        fc, currentRemoteLogFile)) {
-      indexedLogsMeta.getLogMetas().clear();
+        session.fc, currentRemoteLogFile)) {
+      session.indexedLogsMeta.getLogMetas().clear();
       overwriteCheckSum = true;
       aggregatedLogFile = new Path(remoteLogFile.getParent(),
           remoteLogFile.getName() + "_" + sysClock.getTime());
-      fsDataOStream = fc.create(aggregatedLogFile,
+      session.fsDataOStream = session.fc.create(aggregatedLogFile,
           EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE),
           new Options.CreateOpts[] {});
       // writes the uuid
-      fsDataOStream.write(uuid);
-      fsDataOStream.flush();
+      session.fsDataOStream.write(session.uuid);
+      session.fsDataOStream.flush();
       createdNew = true;
     } else {
       aggregatedLogFile = currentRemoteLogFile;
-      fsDataOStream = fc.create(currentRemoteLogFile,
+      session.fsDataOStream = session.fc.create(currentRemoteLogFile,
           EnumSet.of(CreateFlag.CREATE, CreateFlag.APPEND),
           new Options.CreateOpts[] {});
     }
@@ -335,12 +350,13 @@ public class LogAggregationIndexedFileController
       if (createdNew) {
         currentAggregatedLogFileLength = 0;
       } else {
-        currentAggregatedLogFileLength = fc
+        currentAggregatedLogFileLength = session.fc
             .getFileStatus(aggregatedLogFile).getLen();
       }
       FSDataOutputStream checksumFileOutputStream = null;
       try {
-        checksumFileOutputStream = fc.create(remoteLogCheckSumFile,
+        checksumFileOutputStream = session.fc.create(
+            session.remoteLogCheckSumFile,
             EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE),
             new Options.CreateOpts[] {});
         String fileName = aggregatedLogFile.getName();
@@ -360,7 +376,9 @@ public class LogAggregationIndexedFileController
 
   @Override
   public void closeWriter() {
-    IOUtils.cleanupWithLogger(LOG, this.fsDataOStream);
+    if (writeSession != null) {
+      IOUtils.cleanupWithLogger(LOG, writeSession.fsDataOStream);
+    }
   }
 
   @Override
@@ -382,7 +400,8 @@ public class LogAggregationIndexedFileController
       IndexedFileOutputStreamState outputStreamState = null;
       try {
         outputStreamState = new IndexedFileOutputStreamState(
-            this.compressAlgo, this.fsDataOStream, conf, this.currentOffSet);
+            this.compressAlgo, writeSession.fsDataOStream, conf,
+            writeSession.currentOffSet);
         byte[] buf = new byte[65535];
         int len = 0;
         long bytesLeft = fileLength;
@@ -403,7 +422,7 @@ public class LogAggregationIndexedFileController
           LOG.warn("Aggregated logs truncated by approximately "+
               (newLength-fileLength) +" bytes.");
         }
-        logAggregationSuccessfullyInThisCyCle = true;
+        writeSession.logAggregationSuccessfullyInThisCyCle = true;
       } catch (IOException e) {
         String message = logErrorMessage(logFile, e);
         if (outputStreamState != null &&
@@ -427,7 +446,7 @@ public class LogAggregationIndexedFileController
       meta.setLastModifiedTime(logFile.lastModified());
       metas.add(meta);
     }
-    logsMetaInThisCycle.addContainerLogMeta(containerId, metas);
+    writeSession.logsMetaInThisCycle.addContainerLogMeta(containerId, metas);
   }
 
   @Override
@@ -435,15 +454,16 @@ public class LogAggregationIndexedFileController
       throws Exception {
     // always aggregate the previous logsMeta, and append them together
     // at the end of the file
-    indexedLogsMeta.addLogMeta(logsMetaInThisCycle);
-    byte[] b = SerializationUtils.serialize(indexedLogsMeta);
-    this.fsDataOStream.write(b);
+    writeSession.indexedLogsMeta.addLogMeta(writeSession.logsMetaInThisCycle);
+    byte[] b = SerializationUtils.serialize(writeSession.indexedLogsMeta);
+    writeSession.fsDataOStream.write(b);
     int length = b.length;
-    this.fsDataOStream.writeInt(length);
-    this.fsDataOStream.write(uuid);
-    if (logAggregationSuccessfullyInThisCyCle &&
+    writeSession.fsDataOStream.writeInt(length);
+    writeSession.fsDataOStream.write(writeSession.uuid);
+    if (writeSession.logAggregationSuccessfullyInThisCyCle &&
         record.isLogAggregationInRolling()) {
-      deleteFileWithRetries(fc, ugi, remoteLogCheckSumFile);
+      deleteFileWithRetries(writeSession.fc, writeSession.ugi,
+          writeSession.remoteLogCheckSumFile);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -95,6 +96,12 @@ import org.slf4j.LoggerFactory;
 /**
  * The Indexed Log Aggregation File Format implementation.
  *
+ * <p>Write methods ({@link #initializeWriter}, {@link #write}, {@link #postWrite},
+ * {@link #closeWriter}) must be used as a single lifecycle on one thread; callers
+ * must not invoke {@link #write} or {@link #postWrite} unless the preceding
+ * {@link #initializeWriter} completed successfully. Read-path methods are stateless
+ * with respect to the application id and may be invoked on a shared controller
+ * instance (for example on the Job History Server).
  */
 @Private
 @Unstable
@@ -181,14 +188,12 @@ public class LogAggregationIndexedFileController
     final ApplicationId appId = context.getAppId();
     final Path remoteLogFile = context.getRemoteNodeLogFileForApp();
 
-    // Allocate a fresh WriteSession for every initializeWriter call.
-    // The write lifecycle (initializeWriter → write → postWrite → closeWriter)
-    // is always single-threaded: the NodeManager's AppLogAggregatorImpl calls
-    // these methods sequentially within one thread per application, so
-    // concurrent write sessions for the same controller instance are not
-    // possible in practice. The read-path methods (readAggregatedLogsMeta,
-    // readAggregatedLogs, getApplicationOwner, getApplicationAcls) do not
-    // access writeSession at all, so reads and writes are also independent.
+    // End any prior session before allocating a new one.
+    closeWriter();
+
+    // One write lifecycle per initializeWriter call (initializeWriter → write →
+    // postWrite → closeWriter), single-threaded per controller in
+    // AppLogAggregatorImpl. Read-path methods do not touch writeSession.
     final WriteSession session = new WriteSession(createUUID(appId));
     session.ugi = userUgi;
     session.logAggregationSuccessfullyInThisCyCle = false;
@@ -260,10 +265,20 @@ public class LogAggregationIndexedFileController
           return null;
         }
       });
+
+      this.writeSession = session;
+
     } catch (Exception e) {
-      throw new IOException(e);
+      // writeSession is not assigned yet; closeWriter() would not reach this stream.
+      IOUtils.cleanupWithLogger(LOG, session.fsDataOStream);
+
+      Throwable cause = (e instanceof PrivilegedActionException)
+          ? ((PrivilegedActionException) e).getException() : e;
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      throw new IOException(cause.getMessage(), cause);
     }
-    this.writeSession = session;
   }
 
   /**
@@ -382,11 +397,20 @@ public class LogAggregationIndexedFileController
   public void closeWriter() {
     if (writeSession != null) {
       IOUtils.cleanupWithLogger(LOG, writeSession.fsDataOStream);
+      writeSession = null;
     }
+  }
+
+  private WriteSession requireWriteSession() throws IOException {
+    if (writeSession == null) {
+      throw new IOException("No active write session; call initializeWriter first");
+    }
+    return writeSession;
   }
 
   @Override
   public void write(LogKey logKey, LogValue logValue) throws IOException {
+    WriteSession session = requireWriteSession();
     String containerId = logKey.toString();
     Set<File> pendingUploadFiles = logValue
         .getPendingLogFilesToUploadForThisContainer();
@@ -404,8 +428,8 @@ public class LogAggregationIndexedFileController
       IndexedFileOutputStreamState outputStreamState = null;
       try {
         outputStreamState = new IndexedFileOutputStreamState(
-            this.compressAlgo, writeSession.fsDataOStream, conf,
-            writeSession.currentOffSet);
+            this.compressAlgo, session.fsDataOStream, conf,
+            session.currentOffSet);
         byte[] buf = new byte[65535];
         int len = 0;
         long bytesLeft = fileLength;
@@ -426,7 +450,7 @@ public class LogAggregationIndexedFileController
           LOG.warn("Aggregated logs truncated by approximately "+
               (newLength-fileLength) +" bytes.");
         }
-        writeSession.logAggregationSuccessfullyInThisCyCle = true;
+        session.logAggregationSuccessfullyInThisCyCle = true;
       } catch (IOException e) {
         String message = logErrorMessage(logFile, e);
         if (outputStreamState != null &&
@@ -450,24 +474,25 @@ public class LogAggregationIndexedFileController
       meta.setLastModifiedTime(logFile.lastModified());
       metas.add(meta);
     }
-    writeSession.logsMetaInThisCycle.addContainerLogMeta(containerId, metas);
+    session.logsMetaInThisCycle.addContainerLogMeta(containerId, metas);
   }
 
   @Override
   public void postWrite(LogAggregationFileControllerContext record)
       throws Exception {
+    WriteSession session = requireWriteSession();
     // always aggregate the previous logsMeta, and append them together
     // at the end of the file
-    writeSession.indexedLogsMeta.addLogMeta(writeSession.logsMetaInThisCycle);
-    byte[] b = SerializationUtils.serialize(writeSession.indexedLogsMeta);
-    writeSession.fsDataOStream.write(b);
+    session.indexedLogsMeta.addLogMeta(session.logsMetaInThisCycle);
+    byte[] b = SerializationUtils.serialize(session.indexedLogsMeta);
+    session.fsDataOStream.write(b);
     int length = b.length;
-    writeSession.fsDataOStream.writeInt(length);
-    writeSession.fsDataOStream.write(writeSession.uuid);
-    if (writeSession.logAggregationSuccessfullyInThisCyCle &&
+    session.fsDataOStream.writeInt(length);
+    session.fsDataOStream.write(session.uuid);
+    if (session.logAggregationSuccessfullyInThisCyCle &&
         record.isLogAggregationInRolling()) {
-      deleteFileWithRetries(writeSession.fc, writeSession.ugi,
-          writeSession.remoteLogCheckSumFile);
+      deleteFileWithRetries(session.fc, session.ugi,
+          session.remoteLogCheckSumFile);
     }
   }
 
@@ -911,12 +936,16 @@ public class LogAggregationIndexedFileController
   public String getApplicationOwner(Path aggregatedLogPath,
       ApplicationId appId)
       throws IOException {
+    // Read from the log file each time; do not cache on the controller instance
+    // because it may be shared across applications (e.g. on the JHS).
     return loadIndexedLogsMeta(aggregatedLogPath, appId).getUser();
   }
 
   @Override
   public Map<ApplicationAccessType, String> getApplicationAcls(
       Path aggregatedLogPath, ApplicationId appId) throws IOException {
+    // Read from the log file each time; do not cache on the controller instance
+    // because it may be shared across applications (e.g. on the JHS).
     return loadIndexedLogsMeta(aggregatedLogPath, appId).getAcls();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/fs/local/TrackingLocalFs.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/fs/local/TrackingLocalFs.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.local;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Options.ChecksumOpt;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+
+/**
+ * Test {@link LocalFs} that tracks open output streams and injects I/O failures.
+ *
+ * <p>Create failures: path suffix match on {@link #createInternal}. Flush failures:
+ * {@link #setFailOnFlushExcludingPathSuffix(String, int)} counts only streams
+ * whose path name does <em>not</em> end with the given suffix (e.g. skip checksum
+ * side files during rolling aggregation).
+ *
+ * <p>In {@code org.apache.hadoop.fs.local} for the package-private URI constructor.
+ * Register as {@code fs.AbstractFileSystem.file.impl}.
+ *
+ * <p>Uses JVM-wide static state; not safe under parallel test execution unless tests
+ * acquire {@link #RESOURCE_LOCK} (see {@code @ResourceLock}).
+ */
+public class TrackingLocalFs extends LocalFs {
+
+  /** JUnit {@code @ResourceLock} name for serializing tests that use this class. */
+  public static final String RESOURCE_LOCK =
+      "org.apache.hadoop.fs.local.TrackingLocalFs";
+
+  /** Output streams returned from {@link #createInternal} that remain open. */
+  public static final Set<FSDataOutputStream> OPEN_STREAMS =
+      ConcurrentHashMap.newKeySet();
+
+  /** {@link #createInternal} calls since {@link #reset()}. */
+  public static final AtomicInteger CREATE_CALLS = new AtomicInteger();
+
+  private static final AtomicBoolean FAILURE_INJECTED = new AtomicBoolean();
+  private static volatile String failOnPathSuffix = null;
+  /** When set, only non-matching paths participate in scoped flush counting. */
+  private static volatile String failOnFlushExcludeSuffix = null;
+  /** 1-based scoped {@code flush} ordinal; {@code -1} disables. */
+  private static volatile int failOnScopedFlushCall = -1;
+  private static final AtomicInteger SCOPED_FLUSH_CALLS = new AtomicInteger();
+
+  /** Fail the next {@link #createInternal} whose path name ends with {@code suffix}. */
+  public static void setFailOnPathSuffix(String suffix) {
+    failOnPathSuffix = suffix;
+  }
+
+  /**
+   * Fail on the {@code nthFlush}-th {@code flush()} of streams whose path name
+   * does not end with {@code excludeSuffix}.
+   */
+  public static void setFailOnFlushExcludingPathSuffix(
+      String excludeSuffix, int nthFlush) {
+    failOnFlushExcludeSuffix = excludeSuffix;
+    failOnScopedFlushCall = nthFlush;
+  }
+
+  /** Whether an injected create or flush failure has been triggered. */
+  public static boolean wasFailureInjected() {
+    return FAILURE_INJECTED.get();
+  }
+
+  /** Clears counters, open-stream set, and injection settings. */
+  public static void reset() {
+    OPEN_STREAMS.clear();
+    CREATE_CALLS.set(0);
+    SCOPED_FLUSH_CALLS.set(0);
+    FAILURE_INJECTED.set(false);
+    failOnPathSuffix = null;
+    failOnFlushExcludeSuffix = null;
+    failOnScopedFlushCall = -1;
+  }
+
+  public TrackingLocalFs(final URI theUri, final Configuration conf)
+      throws IOException, URISyntaxException {
+    super(theUri, conf);
+  }
+
+  @Override
+  public FSDataOutputStream createInternal(Path f,
+      EnumSet<CreateFlag> createFlag, FsPermission absolutePermission,
+      int bufferSize, short replication, long blockSize, Progressable progress,
+      ChecksumOpt checksumOpt, boolean createParent) throws IOException {
+    CREATE_CALLS.incrementAndGet();
+    if (failOnPathSuffix != null && f.getName().endsWith(failOnPathSuffix)) {
+      FAILURE_INJECTED.set(true);
+      throw new IOException("Injected createInternal() failure for path " + f);
+    }
+    FSDataOutputStream real = super.createInternal(f, createFlag,
+        absolutePermission, bufferSize, replication, blockSize, progress,
+        checksumOpt, createParent);
+    final String pathName = f.getName();
+    FSDataOutputStream tracked = new FSDataOutputStream(real, null) {
+      private final AtomicBoolean closed = new AtomicBoolean();
+
+      @Override
+      public void flush() throws IOException {
+        if (failOnFlushExcludeSuffix != null
+            && !pathName.endsWith(failOnFlushExcludeSuffix)) {
+          int flushN = SCOPED_FLUSH_CALLS.incrementAndGet();
+          if (flushN == failOnScopedFlushCall) {
+            FAILURE_INJECTED.set(true);
+            throw new IOException("Injected flush() failure #" + flushN
+                + " on path " + pathName);
+          }
+        }
+        super.flush();
+      }
+
+      @Override
+      public void close() throws IOException {
+        try {
+          super.close();
+        } finally {
+          if (closed.compareAndSet(false, true)) {
+            OPEN_STREAMS.remove(this);
+          }
+        }
+      }
+    };
+    OPEN_STREAMS.add(tracked);
+    return tracked;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/TestContainerLogsUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/TestContainerLogsUtils.java
@@ -141,7 +141,7 @@ public final class TestContainerLogsUtils {
       appAcls.put(ApplicationAccessType.VIEW_APP, ugi.getUserName());
       LogAggregationFileControllerContext context
           = new LogAggregationFileControllerContext(
-              path, path, true, 1000,
+              path, path, false, -1,
               appId, appAcls, nodeId, ugi);
       fileController.initializeWriter(context);
       for (ContainerId containerId : containerIds) {
@@ -149,6 +149,8 @@ public final class TestContainerLogsUtils {
             new AggregatedLogFormat.LogValue(rootLogDirs, containerId,
                 ugi.getShortUserName()));
       }
+      context.setUploadedLogsInThisCycle(true);
+      fileController.postWrite(context);
     } finally {
       fileController.closeWriter();
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
@@ -27,11 +27,17 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +67,7 @@ import org.apache.hadoop.yarn.logaggregation.ContainerLogMeta;
 import org.apache.hadoop.yarn.logaggregation.ContainerLogsRequest;
 import org.apache.hadoop.yarn.logaggregation.ExtendedLogMetaRequest;
 import org.apache.hadoop.yarn.logaggregation.LogAggregationUtils;
+import org.apache.hadoop.yarn.logaggregation.TestContainerLogsUtils;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerContext;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerFactory;
@@ -132,7 +139,7 @@ public class TestLogAggregationIndexedFileController
   }
 
   @Test
-  @Timeout(15000)
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
   void testLogAggregationIndexFileFormat() throws Exception {
     if (fs.exists(rootLocalLogDirPath)) {
       fs.delete(rootLocalLogDirPath, true);
@@ -384,7 +391,7 @@ public class TestLogAggregationIndexedFileController
   }
 
   @Test
-  @Timeout(15000)
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
   void testFetchApplicationLogsHar() throws Exception {
     List<String> newLogTypes = new ArrayList<>();
     newLogTypes.add("syslog");
@@ -473,6 +480,303 @@ public class TestLogAggregationIndexedFileController
 
   private String logMessage(ContainerId containerId, String logType) {
     return "Hello " + containerId + " in " + logType + "!";
+  }
+
+  @Test
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testReadAggregatedLogsMetaForMultipleAppsWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    assertReadAggregatedLogsMeta(controller, fixture.appId1, fixture.user,
+        fixture.containerId1);
+    assertReadAggregatedLogsMeta(controller, fixture.appId2, fixture.user,
+        fixture.containerId2);
+  }
+
+  @Test
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testGetApplicationOwnerAndAclsForMultipleAppsWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    Path app1LogFile = findAggregatedLogFile(
+        controller.getRemoteAppLogDir(fixture.appId1, fixture.user));
+    Path app2LogFile = findAggregatedLogFile(
+        controller.getRemoteAppLogDir(fixture.appId2, fixture.user));
+
+    assertEquals(fixture.user,
+        controller.getApplicationOwner(app1LogFile, fixture.appId1),
+        "Application owner mismatch for app1");
+    assertNotNull(controller.getApplicationAcls(app1LogFile, fixture.appId1),
+        "Application ACLs should not be null for app1");
+    assertEquals(fixture.user,
+        controller.getApplicationOwner(app2LogFile, fixture.appId2),
+        "Application owner mismatch for app2");
+    assertNotNull(controller.getApplicationAcls(app2LogFile, fixture.appId2),
+        "Application ACLs should not be null for app2");
+  }
+
+  @Test
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testReadAggregatedLogsMetaReverseOrderWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    assertReadAggregatedLogsMeta(controller, fixture.appId2, fixture.user,
+        fixture.containerId2);
+    assertReadAggregatedLogsMeta(controller, fixture.appId1, fixture.user,
+        fixture.containerId1);
+  }
+
+  @Test
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testConcurrentReadAggregatedLogsMetaWithReusedController()
+      throws Exception {
+    TwoAppIFileFixture fixture = prepareTwoAppIFileFixture();
+    LogAggregationFileController controller =
+        fixture.factory.getFileControllerForRead(fixture.appId1, fixture.user);
+
+    ContainerLogsRequest app1Request = new ContainerLogsRequest();
+    app1Request.setAppId(fixture.appId1);
+    app1Request.setAppOwner(fixture.user);
+    ContainerLogsRequest app2Request = new ContainerLogsRequest();
+    app2Request.setAppId(fixture.appId2);
+    app2Request.setAppOwner(fixture.user);
+
+    // Use a barrier to guarantee both threads are in-flight simultaneously.
+    CountDownLatch barrier = new CountDownLatch(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<List<ContainerLogMeta>> app1Future = executor.submit(() -> {
+        barrier.countDown();
+        barrier.await();
+        return controller.readAggregatedLogsMeta(app1Request);
+      });
+      Future<List<ContainerLogMeta>> app2Future = executor.submit(() -> {
+        barrier.countDown();
+        barrier.await();
+        return controller.readAggregatedLogsMeta(app2Request);
+      });
+      List<ContainerLogMeta> app1Meta = app1Future.get();
+      List<ContainerLogMeta> app2Meta = app2Future.get();
+      assertEquals(1, app1Meta.size(),
+          "Expected one container log meta entry for app1");
+      assertEquals(fixture.containerId1.toString(), app1Meta.get(0).getContainerId(),
+          "Unexpected container id for app1");
+      assertEquals(1, app2Meta.size(),
+          "Expected one container log meta entry for app2");
+      assertEquals(fixture.containerId2.toString(), app2Meta.get(0).getContainerId(),
+          "Unexpected container id for app2");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testWriteSessionResetForMultipleAppsWithReusedController()
+      throws Exception {
+    Configuration ifileConf = newIFileConfiguration();
+    ApplicationId appId1 = ApplicationId.newInstance(20, 1);
+    ApplicationId appId2 = ApplicationId.newInstance(20, 2);
+    ContainerId containerId1 = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(appId1, 1), 1);
+    ContainerId containerId2 = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(appId2, 1), 1);
+    String user = USER_UGI.getShortUserName();
+
+    LogAggregationIndexedFileController controller =
+        new LogAggregationIndexedFileController();
+    controller.initialize(ifileConf, "IFile");
+    uploadAppLogsWithController(controller, appId1, containerId1, user, true);
+    uploadAppLogsWithController(controller, appId2, containerId2, user, false);
+
+    LogAggregationFileControllerFactory factory =
+        new LogAggregationFileControllerFactory(ifileConf);
+    LogAggregationFileController reader =
+        factory.getFileControllerForRead(appId1, user);
+    assertReadAggregatedLogsMeta(reader, appId1, user, containerId1);
+    assertReadAggregatedLogsMeta(reader, appId2, user, containerId2);
+  }
+
+  @Test
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testLoadUUIDFromLogFilePreservesValidAggregatedLogFile()
+      throws Exception {
+    Configuration ifileConf = newIFileConfiguration();
+    ApplicationId appId1 = ApplicationId.newInstance(30, 1);
+    ContainerId containerId1 = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(appId1, 1), 1);
+    String user = USER_UGI.getShortUserName();
+
+    LogAggregationIndexedFileController writer1 =
+        new LogAggregationIndexedFileController();
+    writer1.initialize(ifileConf, "IFile");
+    uploadAppLogsWithController(writer1, appId1, containerId1, user, true);
+
+    Path logFile = findAggregatedLogFile(
+        writer1.getRemoteAppLogDir(appId1, user));
+    assertTrue(fs.exists(logFile),
+        "Aggregated log file should exist before rolling init");
+
+    LogAggregationIndexedFileController writer2 =
+        new LogAggregationIndexedFileController();
+    writer2.initialize(ifileConf, "IFile");
+    Path nodePath = new Path(writer2.getRemoteAppLogDir(appId1, user),
+        LogAggregationUtils.getNodeString(nodeId));
+    Map<ApplicationAccessType, String> appAcls = new HashMap<>();
+    LogAggregationFileControllerContext context =
+        new LogAggregationFileControllerContext(
+            nodePath, nodePath, true, 1000, appId1, appAcls, nodeId, USER_UGI);
+    writer2.initializeWriter(context);
+    writer2.closeWriter();
+
+    assertTrue(fs.exists(logFile),
+        "Aggregated log file should exist after rolling init");
+    ContainerLogsRequest request = new ContainerLogsRequest();
+    request.setAppId(appId1);
+    request.setAppOwner(user);
+    assertEquals(1, writer1.readAggregatedLogsMeta(request).size(),
+        "Expected one container log meta entry after rolling init");
+  }
+
+  private Configuration newIFileConfiguration() {
+    Configuration ifileConf = new YarnConfiguration();
+    ifileConf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
+    ifileConf.setStrings(YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS, "IFile");
+    ifileConf.setClass(String.format(
+        YarnConfiguration.LOG_AGGREGATION_FILE_CONTROLLER_FMT, "IFile"),
+        LogAggregationIndexedFileController.class,
+        LogAggregationFileController.class);
+    ifileConf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR, remoteLogDir);
+    ifileConf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR_SUFFIX, "logs");
+    return ifileConf;
+  }
+
+  private static final class TwoAppIFileFixture {
+    private final LogAggregationFileControllerFactory factory;
+    private final ApplicationId appId1;
+    private final ApplicationId appId2;
+    private final ContainerId containerId1;
+    private final ContainerId containerId2;
+    private final String user;
+
+    private TwoAppIFileFixture(LogAggregationFileControllerFactory factory,
+        ApplicationId appId1, ApplicationId appId2, ContainerId containerId1,
+        ContainerId containerId2, String user) {
+      this.factory = factory;
+      this.appId1 = appId1;
+      this.appId2 = appId2;
+      this.containerId1 = containerId1;
+      this.containerId2 = containerId2;
+      this.user = user;
+    }
+  }
+
+  private TwoAppIFileFixture prepareTwoAppIFileFixture() throws Exception {
+    Configuration ifileConf = newIFileConfiguration();
+    // Use cluster-time 100/101 to avoid colliding with the IDs used by
+    // TestHsWebServicesIFileAggregatedLogs (1,1) and (10,2).
+    ApplicationId appId1 = ApplicationId.newInstance(100, 1);
+    ApplicationId appId2 = ApplicationId.newInstance(101, 2);
+    ApplicationAttemptId attemptId1 =
+        ApplicationAttemptId.newInstance(appId1, 1);
+    ApplicationAttemptId attemptId2 =
+        ApplicationAttemptId.newInstance(appId2, 1);
+    ContainerId containerId1 =
+        ContainerId.newContainerId(attemptId1, 1);
+    ContainerId containerId2 =
+        ContainerId.newContainerId(attemptId2, 1);
+    String user = USER_UGI.getShortUserName();
+    String fileName = "syslog";
+
+    Map<ContainerId, String> app1Logs = new HashMap<>();
+    app1Logs.put(containerId1, logMessage(containerId1, fileName));
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(ifileConf, fs,
+        rootLocalLogDir, appId1, app1Logs, nodeId, fileName, user, true);
+    Map<ContainerId, String> app2Logs = new HashMap<>();
+    app2Logs.put(containerId2, logMessage(containerId2, fileName));
+    TestContainerLogsUtils.createContainerLogFileInRemoteFS(ifileConf, fs,
+        rootLocalLogDir, appId2, app2Logs, nodeId, fileName, user, false);
+
+    LogAggregationFileControllerFactory factory =
+        new LogAggregationFileControllerFactory(ifileConf);
+    return new TwoAppIFileFixture(factory, appId1, appId2, containerId1,
+        containerId2, user);
+  }
+
+  private void assertReadAggregatedLogsMeta(
+      LogAggregationFileController controller, ApplicationId targetAppId, String user,
+      ContainerId expectedContainerId) throws IOException {
+    ContainerLogsRequest request = new ContainerLogsRequest();
+    request.setAppId(targetAppId);
+    request.setAppOwner(user);
+    List<ContainerLogMeta> meta = controller.readAggregatedLogsMeta(request);
+    assertEquals(1, meta.size(), "Expected one container log meta entry");
+    assertEquals(expectedContainerId.toString(), meta.get(0).getContainerId(),
+        "Unexpected container id");
+  }
+
+  private void uploadAppLogsWithController(
+      LogAggregationIndexedFileController controller, ApplicationId targetAppId,
+      ContainerId targetContainerId, String user, boolean deleteRemoteLogDir)
+      throws Exception {
+    Path localAppDir = new Path(rootLocalLogDirPath, targetAppId.toString());
+    if (fs.exists(localAppDir)) {
+      fs.delete(localAppDir, true);
+    }
+    assertTrue(fs.mkdirs(localAppDir), "Failed to create local app log directory");
+    Path containerLogDir = new Path(localAppDir, targetContainerId.toString());
+    assertTrue(fs.mkdirs(containerLogDir),
+        "Failed to create local container log directory");
+    createAndWriteLocalLogFile(containerLogDir, "syslog",
+        logMessage(targetContainerId, "syslog"));
+
+    List<String> rootLogDirList = Collections.singletonList(rootLocalLogDir);
+    Path appDir = controller.getRemoteAppLogDir(targetAppId, user);
+    if (fs.exists(appDir) && deleteRemoteLogDir) {
+      fs.delete(appDir, true);
+    }
+    assertTrue(fs.mkdirs(appDir), "Failed to create remote app log directory");
+    Path nodePath = new Path(appDir, LogAggregationUtils.getNodeString(nodeId));
+
+    Map<ApplicationAccessType, String> appAcls = new HashMap<>();
+    appAcls.put(ApplicationAccessType.VIEW_APP, user);
+    LogAggregationFileControllerContext context =
+        new LogAggregationFileControllerContext(
+            nodePath, nodePath, true, 1000, targetAppId, appAcls, nodeId, USER_UGI);
+    try {
+      controller.initializeWriter(context);
+      controller.write(new LogKey(targetContainerId.toString()),
+          new LogValue(rootLogDirList, targetContainerId, user));
+      controller.postWrite(context);
+    } finally {
+      controller.closeWriter();
+    }
+  }
+
+  private Path findAggregatedLogFile(Path appDir) throws IOException {
+    for (FileStatus nodeDir : fs.listStatus(appDir)) {
+      String nodeName = nodeDir.getPath().getName();
+      if (nodeName.endsWith(LogAggregationIndexedFileController
+          .CHECK_SUM_FILE_SUFFIX)) {
+        continue;
+      }
+      for (FileStatus logFile : fs.listStatus(nodeDir.getPath())) {
+        if (!logFile.getPath().getName().endsWith(
+            LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX)) {
+          return logFile.getPath();
+        }
+      }
+    }
+    throw new IOException("No aggregated log file found under " + appDir);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
@@ -43,14 +43,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.AbstractFileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.local.TrackingLocalFs;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -78,6 +81,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -910,5 +914,179 @@ public class TestLogAggregationIndexedFileController
       }
     }
 
+  }
+
+  /** Rolling init: failure after aggregated-log stream open (checksum create). */
+  @Test
+  @ResourceLock(TrackingLocalFs.RESOURCE_LOCK)
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testInitializeWriterClosesStreamWhenPostOpenOperationThrows()
+      throws Exception {
+    runWithTrackingLocalFs(() -> {
+      TrackingLocalFs.setFailOnPathSuffix(
+          LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX);
+
+      LogAggregationIndexedFileController fileFormat =
+          setupTrackingController();
+      LogAggregationFileControllerContext context =
+          newWriterContext(fileFormat, /*logAggregationInRolling=*/true);
+
+      assertThrows(IOException.class,
+          () -> fileFormat.initializeWriter(context),
+          "initializeWriter must propagate the injected failure");
+      assertTrue(TrackingLocalFs.wasFailureInjected(),
+          "Expected failure when creating the checksum file");
+      assertTrue(TrackingLocalFs.CREATE_CALLS.get() >= 2,
+          "Expected at least two createInternal() calls (aggregated log + "
+              + "checksum), got " + TrackingLocalFs.CREATE_CALLS.get());
+
+      assertStreamsClosedByInitializeWriterCatch(fileFormat);
+    });
+  }
+
+  /** Non-rolling init: failure on flush after aggregated-log stream open. */
+  @Test
+  @ResourceLock(TrackingLocalFs.RESOURCE_LOCK)
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testInitializeWriterClosesStreamWhenNonRollingFlushThrows()
+      throws Exception {
+    runWithTrackingLocalFs(() -> {
+      TrackingLocalFs.setFailOnFlushExcludingPathSuffix(
+          LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX, 1);
+
+      LogAggregationIndexedFileController fileFormat =
+          setupTrackingController();
+      LogAggregationFileControllerContext context =
+          newWriterContext(fileFormat, /*logAggregationInRolling=*/false);
+
+      assertThrows(IOException.class,
+          () -> fileFormat.initializeWriter(context),
+          "initializeWriter must propagate the injected flush failure");
+      assertTrue(TrackingLocalFs.wasFailureInjected(),
+          "Expected failure on the aggregated-log flush");
+      assertEquals(1, TrackingLocalFs.CREATE_CALLS.get(),
+          "Non-rolling init should open exactly one output stream");
+
+      assertStreamsClosedByInitializeWriterCatch(fileFormat);
+    });
+  }
+
+  /** Rolling append init: failure on flush after append stream open. */
+  @Test
+  @ResourceLock(TrackingLocalFs.RESOURCE_LOCK)
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testInitializeWriterClosesStreamWhenRollingAppendFlushThrows()
+      throws Exception {
+    runWithTrackingLocalFs(() -> {
+      LogAggregationIndexedFileController fileFormat =
+          setupTrackingController();
+      uploadAppLogsWithController(fileFormat, appId, containerId,
+          USER_UGI.getShortUserName(), /*deleteRemoteLogDir=*/false);
+      TrackingLocalFs.reset();
+
+      TrackingLocalFs.setFailOnFlushExcludingPathSuffix(
+          LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX, 1);
+      LogAggregationFileControllerContext context =
+          newWriterContext(fileFormat, /*logAggregationInRolling=*/true);
+
+      assertThrows(IOException.class,
+          () -> fileFormat.initializeWriter(context),
+          "initializeWriter must propagate the injected flush failure");
+      assertTrue(TrackingLocalFs.wasFailureInjected(),
+          "Expected failure on append-path aggregated-log flush");
+
+      assertStreamsClosedByInitializeWriterCatch(fileFormat);
+    });
+  }
+
+  /** Re-init without closeWriter must close the previous session's stream. */
+  @Test
+  @ResourceLock(TrackingLocalFs.RESOURCE_LOCK)
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  void testInitializeWriterClosesStaleSessionOnReInit() throws Exception {
+    runWithTrackingLocalFs(() -> {
+      LogAggregationIndexedFileController fileFormat =
+          setupTrackingController();
+      LogAggregationFileControllerContext context =
+          newWriterContext(fileFormat, /*logAggregationInRolling=*/true);
+
+      fileFormat.initializeWriter(context);
+      assertEquals(1, TrackingLocalFs.OPEN_STREAMS.size(),
+          "Successful init should leave one aggregated-log stream open");
+
+      fileFormat.initializeWriter(context);
+      assertEquals(1, TrackingLocalFs.OPEN_STREAMS.size(),
+          "Re-init must close the prior stream, not accumulate a second one");
+
+      fileFormat.closeWriter();
+      assertTrue(TrackingLocalFs.OPEN_STREAMS.isEmpty(),
+          "closeWriter must close the active session stream");
+    });
+  }
+
+  @FunctionalInterface
+  private interface TrackingLocalFsTest {
+    void run() throws Exception;
+  }
+
+  private void runWithTrackingLocalFs(TrackingLocalFsTest test) throws Exception {
+    TrackingLocalFs.reset();
+    try {
+      test.run();
+    } finally {
+      TrackingLocalFs.reset();
+    }
+  }
+
+  private Configuration newTrackingConf() {
+    Configuration conf = getTestConf();
+    conf.setClass("fs.AbstractFileSystem.file.impl",
+        TrackingLocalFs.class, AbstractFileSystem.class);
+    conf.set(YarnConfiguration.NM_LOG_AGG_COMPRESSION_TYPE, "none");
+    return conf;
+  }
+
+  private LogAggregationIndexedFileController setupTrackingController()
+      throws IOException {
+    Configuration conf = newTrackingConf();
+    if (fs.exists(rootLocalLogDirPath)) {
+      fs.delete(rootLocalLogDirPath, true);
+    }
+    assertTrue(fs.mkdirs(rootLocalLogDirPath));
+
+    LogAggregationIndexedFileController fileFormat =
+        new LogAggregationIndexedFileController();
+    fileFormat.initialize(conf, "Indexed");
+
+    FileContext fc = FileContext.getFileContext(conf);
+    Path appDir = fileFormat.getRemoteAppLogDir(appId,
+        USER_UGI.getShortUserName());
+    if (fc.util().exists(appDir)) {
+      fc.delete(appDir, true);
+    }
+    fc.mkdir(appDir, FileContext.DEFAULT_PERM, true);
+    return fileFormat;
+  }
+
+  private LogAggregationFileControllerContext newWriterContext(
+      LogAggregationIndexedFileController fileFormat,
+      boolean logAggregationInRolling) throws IOException {
+    Path logPath = fileFormat.getRemoteNodeLogFileForApp(
+        appId, USER_UGI.getShortUserName(), nodeId);
+    Map<ApplicationAccessType, String> appAcls = new HashMap<>();
+    return new LogAggregationFileControllerContext(
+        logPath, logPath, logAggregationInRolling, 1000,
+        appId, appAcls, nodeId, USER_UGI);
+  }
+
+  /** Failed init must close streams in the catch block, not in closeWriter. */
+  private void assertStreamsClosedByInitializeWriterCatch(
+      LogAggregationIndexedFileController fileFormat) {
+    assertTrue(TrackingLocalFs.OPEN_STREAMS.isEmpty(),
+        "initializeWriter catch must close all opened streams, but "
+            + TrackingLocalFs.OPEN_STREAMS.size() + " remained open");
+    fileFormat.closeWriter();
+    assertTrue(TrackingLocalFs.OPEN_STREAMS.isEmpty(),
+        "closeWriter must remain a no-op after a failed initializeWriter");
   }
 }


### PR DESCRIPTION
Fix IFile aggregated log reads after HADOOP-15984 singleton web services.

HADOOP-15984 made HsWebServices a singleton, so LogAggregationIndexedFileController is reused across /ws/v1/history/aggregatedlogs requests. IFile log meta reads validated UUIDs against a cached instance field from the first application, causing aggregated logs for other apps to fail until JHS restart.

Derive the expected UUID from the application being read. Add regression tests and call postWrite() in test log upload helpers so IFile metadata is written.

Contains content generated by Cursor <cursoragent@cursor.com>

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: MAPREDUCE-7539. JobHistoryServer API fails to serve aggregated logs due to uuid mismatch

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html