### PR TITLE
restrict deserialized classes in LeveldbConfigurationStore log decode

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/LeveldbConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/LeveldbConfigurationStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.conf;
 
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.yarn.server.resourcemanager.DBManager;
 import org.slf4j.Logger;
@@ -40,11 +41,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -239,8 +239,10 @@ public class LeveldbConfigurationStore extends YarnConfigurationStore {
       return new LinkedList<>();
     }
 
-    try (ObjectInput input = new ObjectInputStream(
+    try (ValidatingObjectInputStream input = new ValidatingObjectInputStream(
         new ByteArrayInputStream(mutations))) {
+      input.accept(LinkedList.class, LogMutation.class, HashMap.class,
+          String.class);
       return (LinkedList<LogMutation>) input.readObject();
     } catch (ClassNotFoundException e) {
       throw new IOException(e);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestLeveldbConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestLeveldbConfigurationStore.java
@@ -36,9 +36,14 @@ import org.junit.jupiter.api.Test;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.PriorityQueue;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -103,6 +108,34 @@ public class TestLeveldbConfigurationStore extends
     }
     assertFalse(logKeyPresent, "Audit Log is not disabled");
     confStore.close();
+  }
+
+  /**
+   * The store directory is writable outside the RM, so the mutation log
+   * decoder must only accept the classes the store itself writes and reject
+   * anything else planted under the log key instead of instantiating it.
+   */
+  @Test
+  public void testDeserializationIsRestricted() throws Exception {
+    confStore.initialize(conf, schedConf, rmContext);
+    try {
+      prepareLogMutation("key1", "val1");
+      LinkedList<LogMutation> logs = confStore.getLogs();
+      assertEquals(1, logs.size());
+      assertEquals("val1", logs.get(0).getUpdates().get("key1"));
+
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+        oos.writeObject(new PriorityQueue<String>());
+      }
+      ((LeveldbConfigurationStore) confStore).getDB().put(
+          "log".getBytes(StandardCharsets.UTF_8), baos.toByteArray());
+      InvalidClassException e = assertThrows(InvalidClassException.class,
+          () -> confStore.getLogs());
+      assertTrue(e.getMessage().contains(PriorityQueue.class.getName()));
+    } finally {
+      confStore.close();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR

`LeveldbConfigurationStore.deserLogMutations` reads the scheduler configuration mutation log back from the LevelDB store with a raw `ObjectInputStream.readObject()`. Anyone who can write the store directory (`yarn.scheduler.configuration.leveldb-store.path`) can replace the serialized `LinkedList<LogMutation>` with a gadget payload, and the RM will instantiate arbitrary Serializable classes off the classpath on the next load/recovery.

The sibling `ZKConfigurationStore` already decodes the same `LinkedList<LogMutation>` through commons-io `ValidatingObjectInputStream` with an explicit class allowlist; the LevelDB store was left on the unrestricted path. This change applies the same allowlist (`LinkedList`, `LogMutation`, `HashMap`, `String`) inside the decode helper so the restriction lives next to the read rather than relying on the store being trusted.

### How was this patch tested?

Added `TestLeveldbConfigurationStore#testDeserializationIsRestricted`: a normal mutation log still round-trips through the store, and a serialized object of a class outside the allowlist planted under the `log` key is rejected with `InvalidClassException ("Class name not accepted")` instead of being constructed. Also built `hadoop-yarn-server-resourcemanager` and verified the same behavior manually against the patched decode path.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
