### PR TITLE
HADOOP-19909. ABFS: Improve error messages on auth setup failures (#8531)

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -953,7 +953,7 @@ public class AbfsConfiguration{
         Class<?> clazz = rawConfig.getClassByName(keyProviderClass);
         keyProviderObject = clazz.newInstance();
       } catch (Exception e) {
-        throw new KeyProviderException("Unable to load key provider class.", e);
+        throw new KeyProviderException("Unable to load key provider class " + keyProviderClass, e);
       }
       if (!(keyProviderObject instanceof KeyProvider)) {
         throw new KeyProviderException(keyProviderClass

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/FixedSASTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/FixedSASTokenProvider.java
@@ -36,7 +36,7 @@ public class FixedSASTokenProvider implements SASTokenProvider {
     this.fixedSASToken = fixedSASToken;
     if (fixedSASToken == null || fixedSASToken.isEmpty()) {
       throw new SASTokenProviderException(
-          String.format("Configured Fixed SAS Token is Invalid: %s", fixedSASToken));
+          "Configured Fixed SAS Token is empty or null.");
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ShellDecryptionKeyProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ShellDecryptionKeyProvider.java
@@ -45,7 +45,7 @@ public class ShellDecryptionKeyProvider extends SimpleKeyProvider {
     try {
       abfsConfig = new AbfsConfiguration(rawConfig, accountName);
     } catch(IllegalAccessException | IOException e) {
-      throw new KeyProviderException("Unable to get key from credential providers.", e);
+      throw new KeyProviderException("Unable to get key from credential provider for account " + accountName, e);
     }
 
     final String command = abfsConfig.get(ConfigurationKeys.AZURE_KEY_ACCOUNT_SHELLKEYPROVIDER_SCRIPT);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/SimpleKeyProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/SimpleKeyProvider.java
@@ -48,12 +48,10 @@ public class SimpleKeyProvider implements KeyProvider {
       // Validating the key.
       validateStorageAccountKey(key);
     } catch (IllegalAccessException | InvalidConfigurationValueException e) {
-      LOG.debug("Failure to retrieve storage account key for {}", accountName,
-          e);
+      LOG.debug("Failure to retrieve storage account key for {}", accountName, e);
       throw new KeyProviderException("Failure to initialize configuration for "
           + accountName
-          + " key =\"" + key + "\""
-          + ": " + e, e);
+          + ". Invalid base64 value in " + ConfigurationKeys.FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME, e);
     } catch(IOException ioe) {
       LOG.warn("Unable to get key for {} from credential providers. {}",
           accountName, ioe, ioe);


### PR DESCRIPTION


Explain why a key is invalid and print the relevant option name/account.

Backport of #8531 

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html