### PR TITLE
HDFS-17939. StripedReader should only scan data blocks when initializing zero stripe indices

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedReader.java
@@ -202,11 +202,9 @@ class StripedReader {
 
     BitSet bitset = reconstructor.getLiveBitSet();
     int k = 0;
-    for (int i = 0; i < dataBlkNum + parityBlkNum; i++) {
-      if (!bitset.get(i)) {
-        if (reconstructor.getBlockLen(i) <= 0) {
-          zeroStripeIndices[k++] = (short)i;
-        }
+    for (int i = 0; i < dataBlkNum; i++) {
+      if (!bitset.get(i) && reconstructor.getBlockLen(i) <= 0) {
+        zeroStripeIndices[k++] = (short)i;
       }
     }
   }


### PR DESCRIPTION
HDFS-17939. StripedReader should only scan data blocks when initializing zero stripe indices

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In StripedReader#initZeroStrip(), zeroStripeIndices is initialized by scanning all internal blocks, including parity blocks.

 

The loop should only scan data block indices, which would make the implementation match the meaning and allocated size of zeroStripeIndices, and avoid suggesting that parity block indices may be populated as zero stripe indices.
 

### How was this patch tested?
Existing reconstruction tests already cover partial block groups where zero data strips are padded for decoding. The proposed change should not affect observable behavior, since parity indices are never valid zero stripe indices for non-empty block groups.
