### PR TITLE
HDFS-17940. WebHDFS to log at TRACE better

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
@@ -143,6 +143,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -598,7 +599,9 @@ public class WebHdfsFileSystem extends FileSystem
     InetSocketAddress nnAddr = getCurrentNNAddr();
     final URL url = new URL(getTransportScheme(), nnAddr.getHostName(),
         nnAddr.getPort(), path + '?' + query);
-    LOG.trace("url={}", url);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("url={}", getMaskedUrlForLog(url));
+    }
     return url;
   }
 
@@ -640,7 +643,9 @@ public class WebHdfsFileSystem extends FileSystem
         + Param.toSortedString("&", getAuthParameters(op))
         + Param.toSortedString("&", parameters);
     final URL url = getNamenodeURL(path, query);
-    LOG.trace("url={}", url);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("url={}", getMaskedUrlForLog(url));
+    }
     return url;
   }
 
@@ -1686,6 +1691,52 @@ public class WebHdfsFileSystem extends FileSystem
   }
 
   private static final String OFFSET_PARAM_PREFIX = OffsetParam.NAME + "=";
+  private static final String LOG_MASKED_PARAM_VALUE = "XXXXX";
+  private static final String[] LOG_MASKED_PARAM_PREFIXES = {
+      DelegationParam.NAME + "=",
+      TokenArgumentParam.NAME + "="
+  };
+
+  @VisibleForTesting
+  static String getMaskedUrlForLog(final URL url) {
+    final String query = url.getQuery();
+    if (query == null) {
+      return url.toString();
+    }
+    final String lower = query.toLowerCase(Locale.ROOT);
+    boolean mask = false;
+    for (String prefix : LOG_MASKED_PARAM_PREFIXES) {
+      if (lower.startsWith(prefix) || lower.contains("&" + prefix)) {
+        mask = true;
+        break;
+      }
+    }
+    if (!mask) {
+      return url.toString();
+    }
+
+    final StringBuilder b = new StringBuilder("?");
+    for (final StringTokenizer st = new StringTokenizer(query, "&");
+        st.hasMoreTokens();) {
+      if (b.length() > 1) {
+        b.append('&');
+      }
+      b.append(maskQueryTokenForLog(st.nextToken()));
+    }
+
+    final String urlStr = url.toString();
+    return urlStr.substring(0, urlStr.indexOf('?')) + b;
+  }
+
+  private static String maskQueryTokenForLog(final String token) {
+    final String lower = token.toLowerCase(Locale.ROOT);
+    for (String prefix : LOG_MASKED_PARAM_PREFIXES) {
+      if (lower.startsWith(prefix) && token.length() > prefix.length()) {
+        return token.substring(0, prefix.length()) + LOG_MASKED_PARAM_VALUE;
+      }
+    }
+    return token;
+  }
 
   /** Remove offset parameter, if there is any, from the url */
   static URL removeOffsetParam(final URL url) throws MalformedURLException {
@@ -1693,7 +1744,7 @@ public class WebHdfsFileSystem extends FileSystem
     if (query == null) {
       return url;
     }
-    final String lower = StringUtils.toLowerCase(query);
+    final String lower = query.toLowerCase(Locale.ROOT);
     if (!lower.startsWith(OFFSET_PARAM_PREFIX)
         && !lower.contains("&" + OFFSET_PARAM_PREFIX)) {
       return url;
@@ -1704,7 +1755,7 @@ public class WebHdfsFileSystem extends FileSystem
     for(final StringTokenizer st = new StringTokenizer(query, "&");
         st.hasMoreTokens();) {
       final String token = st.nextToken();
-      if (!StringUtils.toLowerCase(token).startsWith(OFFSET_PARAM_PREFIX)) {
+      if (!token.toLowerCase(Locale.ROOT).startsWith(OFFSET_PARAM_PREFIX)) {
         if (b == null) {
           b = new StringBuilder("?").append(token);
         } else {
@@ -2622,7 +2673,7 @@ public class WebHdfsFileSystem extends FileSystem
       final String cl = conn.getHeaderField(HttpHeaders.CONTENT_LENGTH);
       InputStream inStream = conn.getInputStream();
       if (LOG.isDebugEnabled()) {
-        LOG.debug("open file: " + conn.getURL());
+        LOG.debug("open file: {}", getMaskedUrlForLog(conn.getURL()));
       }
       if (cl != null) {
         long streamLength = Long.parseLong(cl);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsUrlLogging.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsUrlLogging.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class TestWebHdfsUrlLogging {
+
+  @Test
+  public void testMaskedUrlForLog() throws IOException {
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(
+        new URL("http://test/Abc")))
+        .isEqualTo("http://test/Abc");
+
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(
+        new URL("http://test/Abc?op=OPEN&length=99")))
+        .isEqualTo("http://test/Abc?op=OPEN&length=99");
+
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(
+        new URL("http://test/Abc?delegation=secret&op=OPEN")))
+        .isEqualTo("http://test/Abc?delegation=XXXXX&op=OPEN");
+
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(
+        new URL("http://test/Abc?op=OPEN&Token=secret&length=99")))
+        .isEqualTo("http://test/Abc?op=OPEN&Token=XXXXX&length=99");
+
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(
+        new URL("http://test/Abc?token=first&op=OPEN&token=second")))
+        .isEqualTo("http://test/Abc?token=XXXXX&op=OPEN&token=XXXXX");
+
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(
+        new URL("http://test/Abc?token=&delegation=&op=OPEN")))
+        .isEqualTo("http://test/Abc?token=&delegation=&op=OPEN");
+
+    final String similarNames =
+        "http://test/Abc?mytoken=secret&delegationx=secret&op=OPEN";
+    assertThat(WebHdfsFileSystem.getMaskedUrlForLog(new URL(similarNames)))
+        .isEqualTo(similarNames);
+
+    final String masked = WebHdfsFileSystem.getMaskedUrlForLog(new URL(
+        "http://test/Abc?op=OPEN&delegation=secret&token=another"));
+    assertThat(masked)
+        .doesNotContain("secret")
+        .doesNotContain("another");
+  }
+}


### PR DESCRIPTION
### Description of PR

Mask WebHDFS delegation token query parameters before URLs are written to client logs. This keeps the request URL unchanged for WebHDFS operations and only changes TRACE/DEBUG log rendering for `delegation` and token argument query parameters.

The masking uses locale-independent case conversion for query parameter matching.

### How was this patch tested?

- `./mvnw -pl hadoop-hdfs-project/hadoop-hdfs-client -am -DskipTests -DskipShade -DskipDist -DskipDocs -DskipJavadoc install`
- `./mvnw -pl hadoop-hdfs-project/hadoop-hdfs-client -Dtest=TestWebHdfsUrlLogging test`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation? Not applicable.
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? Only an existing managed test dependency on AssertJ is added to `hadoop-hdfs-client`.
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? Not applicable.

### AI Tooling

Contains content generated by OpenAI Codex.

- [x] The PR includes the phrase "Contains content generated by OpenAI Codex".
- [x] My use of AI contributions follows the ASF legal policy https://www.apache.org/legal/generative-tooling.html