### PR TITLE
HDFS-17938. Add the metrics NumBlocks in datanode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3905,5 +3905,10 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   public long getPendingAsyncDeletions() {
     return asyncDiskService.countPendingDeletions();
   }
+
+  @Override
+  public long getNumBlocks() throws IOException {
+    return volumes.getNumBlocks();
+  }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeList.java
@@ -557,4 +557,16 @@ class FsVolumeList {
       }
     }
   }
+
+  long getNumBlocks() throws IOException {
+    long numBlocks = 0L;
+    for (FsVolumeImpl v : volumes) {
+      try(FsVolumeReference ref = v.obtainReference()) {
+        numBlocks += v.getNumBlocks();
+      } catch (ClosedChannelException e) {
+        // ignore.
+      }
+    }
+    return numBlocks;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetricHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetricHelper.java
@@ -76,7 +76,9 @@ public class DataNodeMetricHelper {
         "Finish time of the last directory scan"), beanClass.getLastDirScannerFinishTime())
         .addGauge(Interns.info("PendingAsyncDeletions",
             "The count of pending and running asynchronous disk operations"),
-            beanClass.getPendingAsyncDeletions());
+            beanClass.getPendingAsyncDeletions())
+        .addGauge(Interns.info("NumBlocks", "Datanode number of blocks"),
+            beanClass.getNumBlocks());
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
@@ -136,5 +136,5 @@ public interface FSDatasetMBean extends MetricsSource {
   /**
    * Returns the number of blocks that the datanode
    */
-  public long getNumBlocks() throws IOException;
+  long getNumBlocks() throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
@@ -132,4 +132,9 @@ public interface FSDatasetMBean extends MetricsSource {
    * Returns the count of pending and running asynchronous disk operations.
    */
   long getPendingAsyncDeletions();
+
+  /**
+   * Returns the number of blocks that the datanode
+   */
+  public long getNumBlocks() throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
@@ -411,7 +411,6 @@ public class TestFileCreation {
         assertEquals(fileSize, dataset.getDfsUsed());
         assertEquals(SimulatedFSDataset.DEFAULT_CAPACITY - fileSize,
             dataset.getRemaining());
-        assertEquals(numBlocks + 1, dataset.getNumBlocks());
       }
     } finally {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
@@ -411,6 +411,7 @@ public class TestFileCreation {
         assertEquals(fileSize, dataset.getDfsUsed());
         assertEquals(SimulatedFSDataset.DEFAULT_CAPACITY - fileSize,
             dataset.getRemaining());
+        assertEquals(numBlocks + 1, dataset.getNumBlocks());
       }
     } finally {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -1653,5 +1653,10 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   public void setLastDirScannerFinishTime(long time) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public long getNumBlocks() throws IOException {
+    return 0L;
+  }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -493,4 +493,9 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   public long getPendingAsyncDeletions() {
     return 0;
   }
+
+  @Override
+  public long getNumBlocks() throws IOException {
+    return 0;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -2165,4 +2165,33 @@ public class TestFsDatasetImpl {
       }
     }
   }
+
+  @Test
+  @Timeout(value = 30)
+  public void testGetNumBlocks() throws Exception {
+    Configuration config = new HdfsConfiguration();
+    config.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024);
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(config)
+        .numDataNodes(1)
+        .storagesPerDatanode(1)
+        .build()) {
+      cluster.waitActive();
+      FileSystem fs = cluster.getFileSystem();
+      DataNode dataNode = cluster.getDataNodes().get(0);
+      FsDatasetImpl fsDataSetImpl = (FsDatasetImpl) dataNode.getFSDataset();
+
+      long initialBlocks = fsDataSetImpl.getNumBlocks();
+
+      int numFiles = 5;
+      int fileSize = 2048;
+      for (int i = 0; i < numFiles; i++) {
+        Path filePath = new Path("/testFile" + i);
+        DFSTestUtil.createFile(fs, filePath, fileSize, (short) 1, 0);
+      }
+
+      long expectedBlocks = initialBlocks + numFiles * (fileSize / 1024);
+      assertEquals(expectedBlocks, fsDataSetImpl.getNumBlocks(),
+          "Number of blocks should match expected count");
+    }
+  }
 }


### PR DESCRIPTION
Add the NumBlocks metric, which can be used to warn about the heap size of the DataNode.