### PR TITLE
HADOOP-19928. Move to Avro 1.12.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -363,7 +363,7 @@ io.swagger:swagger-annotations:1.5.4
 javax.inject:javax.inject:1
 net.java.dev.jna:jna:5.2.0
 net.minidev:accessors-smart:1.21
-org.apache.avro:avro:1.11.5
+org.apache.avro:avro:1.12.1
 org.apache.commons:commons-compress:1.26.1
 org.apache.commons:commons-configuration2:2.10.1
 org.apache.commons:commons-csv:1.9.0

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/serializer/avro/TestAvroSerialization.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/serializer/avro/TestAvroSerialization.java
@@ -18,8 +18,9 @@
 
 package org.apache.hadoop.io.serializer.avro;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.serializer.SerializationFactory;
@@ -35,7 +36,7 @@ public class TestAvroSerialization {
     AvroRecord before = new AvroRecord();
     before.setIntField(5);
     AvroRecord after = SerializationTestUtil.testSerialization(conf, before);
-    assertEquals(before, after);
+    assertThat(after).isEqualTo(before);
   }
 
   @Test
@@ -45,14 +46,14 @@ public class TestAvroSerialization {
     conf.set(AvroReflectSerialization.AVRO_REFLECT_PACKAGES, 
         before.getClass().getPackage().getName());
     Record after = SerializationTestUtil.testSerialization(conf, before);
-    assertEquals(before, after);
+    assertThat(after).isEqualTo(before);
   }
 
   @Test
   public void testAcceptHandlingPrimitivesAndArrays() throws Exception {
     SerializationFactory factory = new SerializationFactory(conf);
-    assertNull(factory.getSerializer(byte[].class));
-    assertNull(factory.getSerializer(byte.class));
+    assertThat(factory.getSerializer(byte[].class)).isNull();
+    assertThat(factory.getSerializer(byte.class)).isNull();
   }
 
   @Test
@@ -62,18 +63,34 @@ public class TestAvroSerialization {
     conf.set(AvroReflectSerialization.AVRO_REFLECT_PACKAGES, 
         before.getClass().getPackage().getName());
     InnerRecord after = SerializationTestUtil.testSerialization(conf, before);
-    assertEquals(before, after);
+    assertThat(after).isEqualTo(before);
   }
 
   @Test
   public void testReflect() throws Exception {
     RefSerializable before = new RefSerializable();
     before.x = 10;
-    RefSerializable after = 
+    RefSerializable after =
       SerializationTestUtil.testSerialization(conf, before);
-    assertEquals(before, after);
+    assertThat(after).isEqualTo(before);
   }
-  
+
+  /**
+   * Round-trip a reflect-serializable record that carries a String field.
+   * String handling is the part of the Avro API most affected by changes to
+   * {@code org.apache.avro.util.Utf8}, so this guards the reflect serialization
+   * path across Avro upgrades.
+   */
+  @Test
+  public void testReflectStringField() throws Exception {
+    StringRecord before = new StringRecord();
+    before.x = 10;
+    before.s = "value";
+    StringRecord after =
+        SerializationTestUtil.testSerialization(conf, before);
+    assertThat(after).isEqualTo(before);
+  }
+
   public static class InnerRecord {
     public int x = 7;
 
@@ -84,20 +101,21 @@ public class TestAvroSerialization {
 
     @Override
     public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
         return true;
-      if (obj == null)
+      }
+      if (obj == null) {
         return false;
-      if (getClass() != obj.getClass())
+      }
+      if (getClass() != obj.getClass()) {
         return false;
+      }
       final InnerRecord other = (InnerRecord) obj;
-      if (x != other.x)
-        return false;
-      return true;
+      return x == other.x;
     }
   }
 
-  public static class RefSerializable implements AvroReflectSerializable {
+  public static final class RefSerializable implements AvroReflectSerializable {
     public int x = 7;
 
     @Override
@@ -107,16 +125,45 @@ public class TestAvroSerialization {
 
     @Override
     public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
         return true;
-      if (obj == null)
+      }
+      if (obj == null) {
         return false;
-      if (getClass() != obj.getClass())
+      }
+      if (getClass() != obj.getClass()) {
         return false;
+      }
       final RefSerializable other = (RefSerializable) obj;
-      if (x != other.x)
+      return x == other.x;
+    }
+  }
+
+  public static final class StringRecord implements AvroReflectSerializable {
+    public int x = 7;
+    public String s = "";
+
+    @Override
+    public int hashCode() {
+      return x * 31 + (s == null ? 0 : s.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
         return false;
-      return true;
+      }
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+      final StringRecord other = (StringRecord) obj;
+      if (x != other.x) {
+        return false;
+      }
+      return Objects.equals(s, other.s);
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -72,7 +70,7 @@ public class TestEvents {
     assertThat(test.getTaskId()).isEqualTo(tid);
     assertThat(test.getTaskStatus()).isEqualTo("TEST");
     assertThat(test.getTaskType()).isEqualTo(TaskType.REDUCE);
-    assertEquals(234, test.getStartTime());
+    assertThat(test.getStartTime()).isEqualTo(234);
   }
 
   /**
@@ -121,88 +119,109 @@ public class TestEvents {
   /*
    * test EventReader EventReader should read the list of events and return
    * instance of HistoryEvent Different HistoryEvent should have a different
-   * datum.
+   * datum. Uses the Avro-Json encoding.
    */
   @Test
   @Timeout(value = 10)
   public void testEvents() throws Exception {
+    verifyEvents(getEvents(EventWriter.WriteMode.JSON));
+  }
+
+  /*
+   * As {@link #testEvents()} but exercising the Avro-Binary encoding, which is
+   * the format job history files are written in. This guards the
+   * SpecificDatumWriter/SpecificDatumReader binary round-trip across Avro
+   * upgrades.
+   */
+  @Test
+  @Timeout(value = 10)
+  public void testEventsBinary() throws Exception {
+    verifyEvents(getEvents(EventWriter.WriteMode.BINARY));
+  }
+
+  private void verifyEvents(byte[] events) throws Exception {
 
     EventReader reader = new EventReader(new DataInputStream(
-        new ByteArrayInputStream(getEvents())));
+        new ByteArrayInputStream(events)));
     HistoryEvent e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.JOB_PRIORITY_CHANGED));
-    assertEquals("ID", ((JobPriorityChange) e.getDatum()).getJobid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.JOB_PRIORITY_CHANGED);
+    assertThat(((JobPriorityChange) e.getDatum()).getJobid().toString())
+        .isEqualTo("ID");
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.JOB_STATUS_CHANGED));
-    assertEquals("ID", ((JobStatusChanged) e.getDatum()).getJobid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.JOB_STATUS_CHANGED);
+    assertThat(((JobStatusChanged) e.getDatum()).getJobid().toString())
+        .isEqualTo("ID");
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.TASK_UPDATED));
-    assertEquals("ID", ((TaskUpdated) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.TASK_UPDATED);
+    assertThat(((TaskUpdated) e.getDatum()).getTaskid().toString())
+        .isEqualTo("ID");
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
-    assertEquals(taskId,
-        ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_KILLED);
+    assertThat(((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.JOB_KILLED));
-    assertEquals("ID",
-        ((JobUnsuccessfulCompletion) e.getDatum()).getJobid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.JOB_KILLED);
+    assertThat(((JobUnsuccessfulCompletion) e.getDatum()).getJobid().toString())
+        .isEqualTo("ID");
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_STARTED));
-    assertEquals(taskId,
-        ((TaskAttemptStarted) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_STARTED);
+    assertThat(((TaskAttemptStarted) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_FINISHED));
-    assertEquals(taskId,
-        ((TaskAttemptFinished) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_FINISHED);
+    assertThat(((TaskAttemptFinished) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
-    assertEquals(taskId,
-        ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_KILLED);
+    assertThat(((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
-    assertEquals(taskId,
-        ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_KILLED);
+    assertThat(((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_STARTED));
-    assertEquals(taskId,
-        ((TaskAttemptStarted) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_STARTED);
+    assertThat(((TaskAttemptStarted) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_FINISHED));
-    assertEquals(taskId,
-        ((TaskAttemptFinished) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_FINISHED);
+    assertThat(((TaskAttemptFinished) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
-    assertEquals(taskId,
-        ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_KILLED);
+    assertThat(((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
-    assertEquals(taskId,
-        ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
+    assertThat(e.getEventType()).isEqualTo(EventType.REDUCE_ATTEMPT_KILLED);
+    assertThat(((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString())
+        .isEqualTo(taskId);
 
     reader.close();
   }
 
-  /*
-   * makes array of bytes with History events
+  /**
+   * makes array of bytes with History events, encoded in the given write mode.
+   * @param mode write mode.
+   * @return the marshalled output
+   * @throws Exception failure
    */
-  private byte[] getEvents() throws Exception {
+  private byte[] getEvents(EventWriter.WriteMode mode) throws Exception {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     FSDataOutputStream fsOutput = new FSDataOutputStream(output,
         new FileSystem.Statistics("scheme"));
-    EventWriter writer = new EventWriter(fsOutput,
-        EventWriter.WriteMode.JSON);
+    EventWriter writer = new EventWriter(fsOutput, mode);
     writer.write(getJobPriorityChangedEvent());
     writer.write(getJobStatusChangedEvent());
     writer.write(getTaskUpdatedEvent());

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -62,7 +62,7 @@
     <java.security.egd>file:///dev/urandom</java.security.egd>
 
     <!-- avro version -->
-    <avro.version>1.11.5</avro.version>
+    <avro.version>1.12.1</avro.version>
 
     <!-- jersey version -->
     <jersey2.version>2.46</jersey2.version>


### PR DESCRIPTION

Upgrade to Avro 1.12

- this is going to be breaking of generated code, but it should be welcome precisely as it pushes the update down

### How was this patch tested?

existing tests were extended (claude) and moved from junit asserts to assertJ (stevel)

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html