### PR TITLE
use secure xml factories in AbfsBlobClient blob-endpoint response parsers

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
 import org.apache.hadoop.fs.azurebfs.utils.ListUtils;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+import org.apache.hadoop.util.XMLUtils;
 
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
@@ -1711,7 +1712,7 @@ public class AbfsBlobClient extends AbfsClient {
     // Convert the input stream to a Document object
 
     try {
-      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      DocumentBuilderFactory factory = XMLUtils.newSecureDocumentBuilderFactory();
       Document doc = factory.newDocumentBuilder().parse(stream);
 
       // Find the CommittedBlocks element and extract the list of block IDs
@@ -1977,7 +1978,12 @@ public class AbfsBlobClient extends AbfsClient {
   }
 
   private final ThreadLocal<SAXParser> saxParserThreadLocal = ThreadLocal.withInitial(() -> {
-    SAXParserFactory factory = SAXParserFactory.newInstance();
+    SAXParserFactory factory;
+    try {
+      factory = XMLUtils.newSecureSAXParserFactory();
+    } catch (SAXException | ParserConfigurationException e) {
+      throw new RuntimeException("Unable to create SAXParserFactory", e);
+    }
     factory.setNamespaceAware(true);
     try {
       return factory.newSAXParser();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/TestBlobListXmlParser.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/TestBlobListXmlParser.java
@@ -31,7 +31,9 @@ import org.xml.sax.SAXException;
 import org.apache.hadoop.fs.azurebfs.contracts.services.BlobListResultEntrySchema;
 import org.apache.hadoop.fs.azurebfs.contracts.services.BlobListResultSchema;
 import org.apache.hadoop.fs.azurebfs.contracts.services.BlobListXmlParser;
+import org.apache.hadoop.util.XMLUtils;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestBlobListXmlParser {
   @Test
@@ -164,13 +166,29 @@ public class TestBlobListXmlParser {
     assertThat(listResultSchema.getNextMarker()).isNull();
   }
 
+  /**
+   * A blob list response body that declares an external entity pointing at a
+   * local file. The Blob endpoint never returns a DOCTYPE, so parsing it as XXE
+   * would only serve an attacker controlling the response.
+   */
+  @Test
+  public void testExternalEntityRejected() {
+    String xxeResponse = ""
+        + "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<!DOCTYPE EnumerationResults [<!ENTITY xxe SYSTEM \"file:///etc/hostname\">]>"
+        + "<EnumerationResults ServiceEndpoint=\"https://a.blob.core.windows.net/\" ContainerName=\"c\">"
+        + "<Blobs><Blob><Name>&xxe;</Name></Blob></Blobs>"
+        + "</EnumerationResults>";
+    assertThrows(SAXException.class, () -> getResultSchema(xxeResponse));
+  }
+
   private static final ThreadLocal<SAXParser> SAX_PARSER_THREAD_LOCAL
       = new ThreadLocal<SAXParser>() {
     @Override
     public SAXParser initialValue() {
-      SAXParserFactory factory = SAXParserFactory.newInstance();
-      factory.setNamespaceAware(true);
       try {
+        SAXParserFactory factory = XMLUtils.newSecureSAXParserFactory();
+        factory.setNamespaceAware(true);
         return factory.newSAXParser();
       } catch (SAXException e) {
         throw new RuntimeException("Unable to create SAXParser", e);


### PR DESCRIPTION
### Description of PR

`AbfsBlobClient` parses the XML bodies returned by the Blob endpoint with default JAXP factories: `parseBlockListResponse` builds a `DocumentBuilderFactory.newInstance()` for GetBlockList, and the shared `saxParserThreadLocal` (used by `parseListPathResults`) builds a `SAXParserFactory.newInstance()`. Both process DTDs and external entities by default, so a list/block response coming from a malicious or intercepted endpoint can declare an external entity and read local files off the client host (XXE).

Route both through `XMLUtils.newSecureDocumentBuilderFactory()` / `newSecureSAXParserFactory()`, the secure factories already used elsewhere in hadoop (Configuration, HDFS ECPolicyLoader, YARN AllocationFileLoaderService, rumen, etc.). Legitimate ListBlob/GetBlockList responses never carry a DOCTYPE, so valid parsing is unchanged; only entity/DTD-bearing payloads are now rejected.

### How was this patch tested?

Added `TestBlobListXmlParser#testExternalEntityRejected`, which feeds a blob-list body that declares an external-entity DOCTYPE through the same secure SAX parser the client now constructs and asserts the parse is rejected. The existing valid-response cases in that test (which have no DOCTYPE) are unaffected.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html