### PR TITLE
HDFS-17949. Add optional FedBalance content summary verification

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/rbfbalance/RouterFedBalance.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/rbfbalance/RouterFedBalance.java
@@ -57,6 +57,9 @@ import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.BANDWIDTH;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DELAY_DURATION;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DIFF_THRESHOLD;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.TRASH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.VERIFY;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.VERIFY_ENABLED;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.VERIFY_ENABLED_DEFAULT;
 
 /**
  * Balance data in router-based federation cluster. From src sub-namespace to
@@ -92,6 +95,8 @@ public class RouterFedBalance extends Configured implements Tool {
     private long delayDuration = TimeUnit.SECONDS.toMillis(1);
     /* Specify the threshold of diff entries. */
     private int diffThreshold = 0;
+    /* Whether to run the optional verification phase. */
+    private boolean verify = false;
     /* The source input. This specifies the source path. */
     private final String inputSrc;
     /* The dst input. This specifies the dst path. */
@@ -157,6 +162,15 @@ public class RouterFedBalance extends Configured implements Tool {
     }
 
     /**
+     * Specify whether the optional verification phase should run.
+     * @param value true if running verification.
+     */
+    public Builder setVerify(boolean value) {
+      this.verify = value;
+      return this;
+    }
+
+    /**
      * Build the balance job.
      */
     public BalanceJob build() throws IOException {
@@ -172,6 +186,8 @@ public class RouterFedBalance extends Configured implements Tool {
           .setForceCloseOpenFiles(forceCloseOpen).setUseMountReadOnly(true)
           .setMapNum(map).setBandwidthLimit(bandwidth).setTrash(trashOpt)
           .setDelayDuration(delayDuration).setDiffThreshold(diffThreshold)
+          .setVerify(verify || getConf().getBoolean(VERIFY_ENABLED,
+              VERIFY_ENABLED_DEFAULT))
           .build();
 
       LOG.info(context.toString());
@@ -280,6 +296,9 @@ public class RouterFedBalance extends Configured implements Tool {
     if (command.hasOption(DIFF_THRESHOLD.getOpt())) {
       builder.setDiffThreshold(Integer.parseInt(
           command.getOptionValue(DIFF_THRESHOLD.getOpt())));
+    }
+    if (command.hasOption(VERIFY.getOpt())) {
+      builder.setVerify(true);
     }
     if (command.hasOption(TRASH.getOpt())) {
       String val = command.getOptionValue(TRASH.getOpt());

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/DistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/DistCpProcedure.java
@@ -64,6 +64,7 @@ import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.LAST_SNAPSHOT
  *                          no diff.
  * DISABLE_WRITE           :disable write operations.
  * FINAL_DISTCP            :close all open files and do the final round distcp.
+ * VERIFY                  :optional verification after the final distcp.
  * FINISH                  :procedure finish.
  */
 public class DistCpProcedure extends BalanceProcedure {
@@ -73,7 +74,9 @@ public class DistCpProcedure extends BalanceProcedure {
 
   /* Stages of this procedure. */
   public enum Stage {
-    PRE_CHECK, INIT_DISTCP, DIFF_DISTCP, DISABLE_WRITE, FINAL_DISTCP, FINISH
+    PRE_CHECK, INIT_DISTCP, DIFF_DISTCP, DISABLE_WRITE, FINAL_DISTCP, FINISH,
+    /** Optionally verify source and destination content summaries. */
+    VERIFY
   }
 
   private FedBalanceContext context; // the balance context.
@@ -91,6 +94,8 @@ public class DistCpProcedure extends BalanceProcedure {
   private boolean useMountReadOnly;
   /* The threshold of diff entries. */
   private int diffThreshold;
+  /* Whether to run the optional verification phase. */
+  private boolean verify;
 
   private FsPermission fPerm; // the permission of the src.
   private AclStatus acl; // the acl of the src.
@@ -145,6 +150,7 @@ public class DistCpProcedure extends BalanceProcedure {
     this.forceCloseOpenFiles = context.getForceCloseOpenFiles();
     this.useMountReadOnly = context.getUseMountReadOnly();
     this.diffThreshold = context.getDiffThreshold();
+    this.verify = context.getVerify();
     srcFs = (DistributedFileSystem) context.getSrc().getFileSystem(conf);
     dstFs = (DistributedFileSystem) context.getDst().getFileSystem(conf);
   }
@@ -167,6 +173,9 @@ public class DistCpProcedure extends BalanceProcedure {
       return false;
     case FINAL_DISTCP:
       finalDistCp();
+      return false;
+    case VERIFY:
+      verify();
       return false;
     case FINISH:
       finish();
@@ -295,7 +304,7 @@ public class DistCpProcedure extends BalanceProcedure {
       if (job.isComplete()) {
         jobId = null; // unset jobId because the job is done.
         if (job.isSuccessful()) {
-          updateStage(Stage.FINISH);
+          updateStage(verify ? Stage.VERIFY : Stage.FINISH);
           return;
         } else {
           throw new IOException(
@@ -307,6 +316,28 @@ public class DistCpProcedure extends BalanceProcedure {
     } else {
       submitDiffDistCp();
     }
+  }
+
+  void verify() throws RetryException, IOException {
+    if (!verify) {
+      updateStage(Stage.FINISH);
+      return;
+    }
+    FedBalanceVerifier verifier =
+        new FedBalanceVerifier(srcFs, dstFs, src, dst);
+    FedBalanceVerifier.VerificationSummary summary;
+    try {
+      summary = verifier.verify();
+    } catch (IOException e) {
+      LOG.warn("FedBalance verification hit an error reading content "
+          + "summary, will retry.", e);
+      throw new RetryException();
+    }
+    if (!summary.matches()) {
+      throw new IOException("FedBalance verification failed. " + summary);
+    }
+    LOG.info("FedBalance verification succeeded. {}", summary);
+    updateStage(Stage.FINISH);
   }
 
   void finish() throws IOException {
@@ -564,6 +595,8 @@ public class DistCpProcedure extends BalanceProcedure {
     bandWidth = context.getBandwidthLimit();
     forceCloseOpenFiles = context.getForceCloseOpenFiles();
     useMountReadOnly = context.getUseMountReadOnly();
+    diffThreshold = context.getDiffThreshold();
+    verify = context.getVerify();
     this.client = new JobClient(conf);
   }
 

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalance.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalance.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.VERIFY_ENABLED;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.VERIFY_ENABLED_DEFAULT;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.FORCE_CLOSE_OPEN;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.MAP;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.BANDWIDTH;
@@ -45,6 +47,7 @@ import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.TRASH;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DELAY_DURATION;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.CLI_OPTIONS;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DIFF_THRESHOLD;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.VERIFY;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TrashOption;
 
 /**
@@ -83,6 +86,8 @@ public class FedBalance extends Configured implements Tool {
     private long delayDuration = TimeUnit.SECONDS.toMillis(1);
     /* Specify the threshold of diff entries. */
     private int diffThreshold = 0;
+    /* Whether to run the optional verification phase. */
+    private boolean verify = false;
     /* The source input. This specifies the source path. */
     private final String inputSrc;
     /* The dst input. This specifies the dst path. */
@@ -148,6 +153,15 @@ public class FedBalance extends Configured implements Tool {
     }
 
     /**
+     * Specify whether the optional verification phase should run.
+     * @param value true if running verification.
+     */
+    public Builder setVerify(boolean value) {
+      this.verify = value;
+      return this;
+    }
+
+    /**
      * Build the balance job.
      */
     public BalanceJob build() throws IOException {
@@ -164,7 +178,10 @@ public class FedBalance extends Configured implements Tool {
       context = new FedBalanceContext.Builder(src, dst, NO_MOUNT, getConf())
           .setForceCloseOpenFiles(forceCloseOpen).setUseMountReadOnly(false)
           .setMapNum(map).setBandwidthLimit(bandwidth).setTrash(trashOpt)
-          .setDiffThreshold(diffThreshold).build();
+          .setDiffThreshold(diffThreshold)
+          .setVerify(verify || getConf().getBoolean(VERIFY_ENABLED,
+              VERIFY_ENABLED_DEFAULT))
+          .build();
 
       LOG.info(context.toString());
       // Construct the balance job.
@@ -267,6 +284,9 @@ public class FedBalance extends Configured implements Tool {
     if (command.hasOption(DIFF_THRESHOLD.getOpt())) {
       builder.setDiffThreshold(Integer.parseInt(
           command.getOptionValue(DIFF_THRESHOLD.getOpt())));
+    }
+    if (command.hasOption(VERIFY.getOpt())) {
+      builder.setVerify(true);
     }
     if (command.hasOption(TRASH.getOpt())) {
       String val = command.getOptionValue(TRASH.getOpt());

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
@@ -44,6 +44,16 @@ public final class FedBalanceConfigs {
       "hdfs.fedbalance.procedure.scheduler.journal.uri";
   public static final String JOB_PREFIX = "JOB-";
   public static final String TMP_TAIL = ".tmp";
+  /**
+   * Whether FedBalance should run content summary verification after the final
+   * DistCp succeeds.
+   */
+  public static final String VERIFY_ENABLED =
+      "hdfs.fedbalance.verify.enabled";
+  /**
+   * Default value for {@link #VERIFY_ENABLED}.
+   */
+  public static final boolean VERIFY_ENABLED_DEFAULT = false;
 
   private FedBalanceConfigs(){}
 }

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceContext.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceContext.java
@@ -56,6 +56,8 @@ public class FedBalanceContext implements Writable {
   private long delayDuration;
   /* The threshold of diff entries. */
   private int diffThreshold;
+  /* Whether to run the optional verification phase. */
+  private boolean verify;
 
   private Configuration conf;
 
@@ -97,6 +99,15 @@ public class FedBalanceContext implements Writable {
     return diffThreshold;
   }
 
+  /**
+   * Get whether the optional verification phase should run.
+   *
+   * @return true if the optional verification phase should run.
+   */
+  public boolean getVerify() {
+    return verify;
+  }
+
   public TrashOption getTrashOpt() {
     return trashOpt;
   }
@@ -114,6 +125,7 @@ public class FedBalanceContext implements Writable {
     out.writeInt(trashOpt.ordinal());
     out.writeLong(delayDuration);
     out.writeInt(diffThreshold);
+    out.writeBoolean(verify);
   }
 
   @Override
@@ -130,6 +142,7 @@ public class FedBalanceContext implements Writable {
     trashOpt = TrashOption.values()[in.readInt()];
     delayDuration = in.readLong();
     diffThreshold = in.readInt();
+    verify = in.readBoolean();
   }
 
   @Override
@@ -155,6 +168,7 @@ public class FedBalanceContext implements Writable {
         .append(trashOpt, bc.trashOpt)
         .append(delayDuration, bc.delayDuration)
         .append(diffThreshold, bc.diffThreshold)
+        .append(verify, bc.verify)
         .isEquals();
   }
 
@@ -171,6 +185,7 @@ public class FedBalanceContext implements Writable {
         .append(trashOpt)
         .append(delayDuration)
         .append(diffThreshold)
+        .append(verify)
         .build();
   }
 
@@ -204,6 +219,7 @@ public class FedBalanceContext implements Writable {
       break;
     }
     builder.append(" Delay duration is ").append(delayDuration).append("ms.");
+    builder.append(" Verify is ").append(verify).append(".");
     return builder.toString();
   }
 
@@ -219,6 +235,7 @@ public class FedBalanceContext implements Writable {
     private TrashOption trashOpt;
     private long delayDuration;
     private int diffThreshold;
+    private boolean verify;
 
     /**
      * This class helps building the FedBalanceContext.
@@ -306,6 +323,16 @@ public class FedBalanceContext implements Writable {
     }
 
     /**
+     * Specify whether the optional verification phase should run.
+     * @param value true if running verification.
+     * @return the builder.
+     */
+    public Builder setVerify(boolean value) {
+      this.verify = value;
+      return this;
+    }
+
+    /**
      * Build the FedBalanceContext.
      *
      * @return the FedBalanceContext obj.
@@ -323,6 +350,7 @@ public class FedBalanceContext implements Writable {
       context.trashOpt = this.trashOpt;
       context.delayDuration = this.delayDuration;
       context.diffThreshold = this.diffThreshold;
+      context.verify = this.verify;
       return context;
     }
   }

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceOptions.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceOptions.java
@@ -82,6 +82,14 @@ public final class FedBalanceOptions {
           + " used. If the trash is disabled in the server side, the default"
           + " trash interval 60 minutes is used.");
 
+  /**
+   * Run the optional FedBalance verification phase.
+   */
+  public final static Option VERIFY =
+      new Option("verify", false,
+          "Run the optional FedBalance verification phase after the final "
+              + "DistCp succeeds.");
+
   public final static Options CLI_OPTIONS = new Options();
 
   static {
@@ -90,5 +98,6 @@ public final class FedBalanceOptions {
     CLI_OPTIONS.addOption(BANDWIDTH);
     CLI_OPTIONS.addOption(DELAY_DURATION);
     CLI_OPTIONS.addOption(TRASH);
+    CLI_OPTIONS.addOption(VERIFY);
   }
 }

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceVerifier.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceVerifier.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools.fedbalance;
+
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
+import java.io.IOException;
+
+/**
+ * Optional FedBalance verification helpers.
+ */
+final class FedBalanceVerifier {
+
+  private final DistributedFileSystem srcFs;
+  private final DistributedFileSystem dstFs;
+  private final Path src;
+  private final Path dst;
+
+  FedBalanceVerifier(DistributedFileSystem srcFs, DistributedFileSystem dstFs,
+      Path src, Path dst) {
+    this.srcFs = srcFs;
+    this.dstFs = dstFs;
+    this.src = src;
+    this.dst = dst;
+  }
+
+  VerificationSummary verify() throws IOException {
+    ContentSummary srcSummary = srcFs.getContentSummary(src);
+    ContentSummary dstSummary = dstFs.getContentSummary(dst);
+    return new VerificationSummary(
+        getDirectoryCount(srcSummary), getDirectoryCount(dstSummary),
+        getFileCount(srcSummary), getFileCount(dstSummary),
+        getLength(srcSummary), getLength(dstSummary));
+  }
+
+  private long getDirectoryCount(ContentSummary summary) {
+    return summary.getDirectoryCount() - summary.getSnapshotDirectoryCount();
+  }
+
+  private long getFileCount(ContentSummary summary) {
+    return summary.getFileCount() - summary.getSnapshotFileCount();
+  }
+
+  private long getLength(ContentSummary summary) {
+    return summary.getLength() - summary.getSnapshotLength();
+  }
+
+  static final class VerificationSummary {
+    private final long srcDirs;
+    private final long dstDirs;
+    private final long srcFiles;
+    private final long dstFiles;
+    private final long srcLength;
+    private final long dstLength;
+
+    private VerificationSummary(long sourceDirs, long targetDirs,
+        long sourceFiles, long targetFiles, long sourceLength,
+        long targetLength) {
+      this.srcDirs = sourceDirs;
+      this.dstDirs = targetDirs;
+      this.srcFiles = sourceFiles;
+      this.dstFiles = targetFiles;
+      this.srcLength = sourceLength;
+      this.dstLength = targetLength;
+    }
+
+    boolean matches() {
+      return srcDirs == dstDirs && srcFiles == dstFiles
+          && srcLength == dstLength;
+    }
+
+    @Override
+    public String toString() {
+      return "srcDirs=" + srcDirs
+          + ", dstDirs=" + dstDirs
+          + ", srcFiles=" + srcFiles
+          + ", dstFiles=" + dstFiles
+          + ", srcLength=" + srcLength
+          + ", dstLength=" + dstLength;
+    }
+  }
+}

--- a/hadoop-tools/hadoop-federation-balance/src/main/resources/hdfs-fedbalance-default.xml
+++ b/hadoop-tools/hadoop-federation-balance/src/main/resources/hdfs-fedbalance-default.xml
@@ -38,4 +38,15 @@
         </description>
     </property>
 
+    <property>
+        <name>hdfs.fedbalance.verify.enabled</name>
+        <value>false</value>
+        <description>
+            Whether FedBalance should run the optional verification phase after
+            the final DistCp succeeds. The verification compares the source
+            and destination ContentSummary directory count, file count, and
+            length after excluding snapshot content.
+        </description>
+    </property>
+
 </configuration>

--- a/hadoop-tools/hadoop-federation-balance/src/site/markdown/HDFSFederationBalance.md
+++ b/hadoop-tools/hadoop-federation-balance/src/site/markdown/HDFSFederationBalance.md
@@ -100,6 +100,7 @@ Command `submit` has the following options:
 | -delay | Specify the delayed duration(millie seconds) when the job needs to retry. | 1000 |
 | -moveToTrash | This options has 3 values: `trash` (move the source path to trash), `delete` (delete the source path directly) and `skip` (skip both trash and deletion). By default the server side trash interval is used. If the trash is disabled in the server side, the default trash interval 60 minutes is used. | trash |
 | -diffThreshold | Specify the threshold of the diff entries that used in incremental copy stage. If the diff entries size is no greater than the threshold and the open files check is satisfied(no open files or force close all open files), the fedBalance will go to the final round of distcp. Setting to 0 means waiting until there is no diff.| 0 |
+| -verify | Run an optional verification phase after the final DistCp succeeds. The verification compares source and target ContentSummary directory count, file count, and length after excluding snapshot content. | Disabled |
 
 ### Configuration Options
 --------------------
@@ -110,6 +111,7 @@ Set configuration options at hdfs-fedbalance-site.xml.
 | ------------------------------ | ------------------------------------ | ------- |
 | hdfs.fedbalance.procedure.work.thread.num | The worker threads number of the BalanceProcedureScheduler. BalanceProcedureScheduler is responsible for scheduling a balance job, including submit, run, delay and recover. | 10 |
 | hdfs.fedbalance.procedure.scheduler.journal.uri | The uri of the journal, the journal file is used for handling the job persistence and recover. | hdfs://localhost:8020/tmp/procedure |
+| hdfs.fedbalance.verify.enabled | Whether FedBalance should run the optional verification phase after the final DistCp succeeds. The verification compares source and target ContentSummary directory count, file count, and length after excluding snapshot content. | false |
 
 Architecture of HDFS Federation Balance
 ----------------------
@@ -145,7 +147,7 @@ Architecture of HDFS Federation Balance
   procedures:
 
   * DistCpProcedure: This is the first procedure. It handles all the data copy
-    works. There are 6 stages:
+    works. There are 7 stages:
     * PRE_CHECK: Do the pre-check of the src and dst path.
     * INIT_DISTCP: Create a snapshot of the source path and distcp it to the
       target.
@@ -158,6 +160,8 @@ Architecture of HDFS Federation Balance
       In normal federation mode it is done by cancelling all the permissions of
       the source path.
     * FINAL_DISTCP: Force close all the open files and submit the final distcp.
+    * VERIFY: Optionally compare source and target ContentSummary directory
+      count, file count, and length after the final DistCp succeeds.
     * FINISH: Do the cleanup works. In normal federation mode the finish stage
       also restores the permission of the dst path.
 

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
@@ -201,6 +201,39 @@ public class TestDistCpProcedure {
   }
 
   @Test
+  public void testVerifyContentSummary() throws Exception {
+    String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
+    DistributedFileSystem fs =
+        (DistributedFileSystem) FileSystem.get(URI.create(nnUri), conf);
+    createFiles(fs, testRoot, srcfiles);
+    Path src = new Path(testRoot, SRCDAT);
+    Path dst = new Path(testRoot, DSTDAT);
+
+    FedBalanceContext context = new FedBalanceContext.Builder(src, dst, MOUNT,
+        conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setVerify(true)
+        .build();
+    DistCpProcedure dcProcedure =
+        new DistCpProcedure("distcp-procedure", null, 1000, context);
+    executeProcedure(dcProcedure, Stage.DIFF_DISTCP,
+        () -> dcProcedure.initDistCp());
+    executeProcedure(dcProcedure, Stage.VERIFY,
+        () -> dcProcedure.finalDistCp());
+    dcProcedure.verify();
+    assertEquals(Stage.FINISH, dcProcedure.getStage());
+
+    fs.mkdirs(new Path(dst, "extra"));
+    dcProcedure.updateStage(Stage.VERIFY);
+    intercept(IOException.class, "FedBalance verification failed",
+        () -> dcProcedure.verify());
+    cleanup(fs, new Path(testRoot));
+  }
+
+  @Test
   public void testDiffDistCp() throws Exception {
     String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
     DistributedFileSystem fs =

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestFedBalance.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestFedBalance.java
@@ -18,9 +18,20 @@
 package org.apache.hadoop.tools.fedbalance;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.VERIFY_ENABLED;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TrashOption;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.WORK_THREAD_NUM;
 
@@ -30,5 +41,35 @@ public class TestFedBalance {
     Configuration conf = FedBalance.getDefaultConf();
     assertNotNull(conf.get(SCHEDULER_JOURNAL_URI));
     assertNotNull(conf.get(WORK_THREAD_NUM));
+    assertFalse(conf.getBoolean(VERIFY_ENABLED, true));
+  }
+
+  @Test
+  public void testFedBalanceOptionsRegistered() {
+    assertTrue(FedBalanceOptions.CLI_OPTIONS.hasOption(
+        FedBalanceOptions.VERIFY.getOpt()));
+  }
+
+  @Test
+  public void testFedBalanceContextVerifySerialization() throws IOException {
+    Configuration conf = new Configuration(false);
+    FedBalanceContext context = new FedBalanceContext.Builder(
+        new Path("hdfs://src.example.com/src"),
+        new Path("hdfs://dst.example.com/dst"), FedBalance.NO_MOUNT, conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setVerify(true)
+        .build();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    context.write(new DataOutputStream(out));
+
+    FedBalanceContext recovered = new FedBalanceContext();
+    recovered.readFields(new DataInputStream(
+        new ByteArrayInputStream(out.toByteArray())));
+
+    assertTrue(recovered.getVerify());
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR adds an optional FedBalance verification phase after the final DistCp succeeds.

The verification is disabled by default. When enabled, FedBalance compares the source and destination ContentSummary directory count, file count, and length after excluding snapshot content. A mismatch fails the job, while transient ContentSummary read failures are retried by the procedure scheduler.

This provides a lightweight built-in verification mechanism without changing the default FedBalance behavior.

### How was this patch tested?

Ran FedBalance unit tests locally and validated on a production cluster.

### AI Tooling

Contains content generated by Codex.
