### PR TITLE
HDFS-17950. Add FedBalance operational control switches

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/rbfbalance/RouterFedBalance.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/rbfbalance/RouterFedBalance.java
@@ -50,12 +50,21 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.tools.fedbalance.FedBalance.FED_BALANCE_DEFAULT_XML;
 import static org.apache.hadoop.tools.fedbalance.FedBalance.FED_BALANCE_SITE_XML;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.FORCE_CLOSE_SENTINEL_PATH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.FORCE_CLOSE_SENTINEL_PATH_DEFAULT;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TIME_WINDOW_SENTINEL_PATH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TIME_WINDOW_SENTINEL_PATH_DEFAULT;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.CLI_OPTIONS;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.FORCE_CLOSE_OPEN;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.FORCE_CLOSE_SENTINEL;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.MAP;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.BANDWIDTH;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DELAY_DURATION;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DIFF_THRESHOLD;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.START_FROM_INCREMENTAL;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.STOP_AFTER_INITIAL_COPY;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.STOP_ON_SMALL_DIFF;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.TIME_WINDOW_SENTINEL;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.TRASH;
 
 /**
@@ -92,6 +101,16 @@ public class RouterFedBalance extends Configured implements Tool {
     private long delayDuration = TimeUnit.SECONDS.toMillis(1);
     /* Specify the threshold of diff entries. */
     private int diffThreshold = 0;
+    /* Whether to stop after the initial DistCp job succeeds. */
+    private boolean stopAfterInitialCopy = false;
+    /* Whether to start from the incremental DistCp stage. */
+    private boolean startFromIncremental = false;
+    /* Whether to stop when a small diff cannot move to final copy. */
+    private boolean stopOnSmallDiff = false;
+    /* Sentinel path that gates leaving the incremental DistCp stage. */
+    private String timeWindowSentinelPath;
+    /* Sentinel path that allows force-closing open files. */
+    private String forceCloseSentinelPath;
     /* The source input. This specifies the source path. */
     private final String inputSrc;
     /* The dst input. This specifies the dst path. */
@@ -157,6 +176,52 @@ public class RouterFedBalance extends Configured implements Tool {
     }
 
     /**
+     * Specify whether to stop after the initial DistCp job succeeds.
+     * @param value true if stopping after initial copy.
+     */
+    public Builder setStopAfterInitialCopy(boolean value) {
+      this.stopAfterInitialCopy = value;
+      return this;
+    }
+
+    /**
+     * Specify whether to start from the incremental DistCp stage.
+     * @param value true if starting from the incremental DistCp stage.
+     */
+    public Builder setStartFromIncremental(boolean value) {
+      this.startFromIncremental = value;
+      return this;
+    }
+
+    /**
+     * Specify whether to stop when a small diff cannot move to final copy.
+     * @param value true if stopping on small diff.
+     */
+    public Builder setStopOnSmallDiff(boolean value) {
+      this.stopOnSmallDiff = value;
+      return this;
+    }
+
+    /**
+     * Specify the sentinel path that gates leaving the incremental DistCp
+     * stage.
+     * @param value the sentinel path.
+     */
+    public Builder setTimeWindowSentinelPath(String value) {
+      this.timeWindowSentinelPath = value;
+      return this;
+    }
+
+    /**
+     * Specify the sentinel path that allows force-closing open files.
+     * @param value the sentinel path.
+     */
+    public Builder setForceCloseSentinelPath(String value) {
+      this.forceCloseSentinelPath = value;
+      return this;
+    }
+
+    /**
      * Build the balance job.
      */
     public BalanceJob build() throws IOException {
@@ -172,6 +237,13 @@ public class RouterFedBalance extends Configured implements Tool {
           .setForceCloseOpenFiles(forceCloseOpen).setUseMountReadOnly(true)
           .setMapNum(map).setBandwidthLimit(bandwidth).setTrash(trashOpt)
           .setDelayDuration(delayDuration).setDiffThreshold(diffThreshold)
+          .setStopAfterInitialCopy(stopAfterInitialCopy)
+          .setStartFromIncremental(startFromIncremental)
+          .setStopOnSmallDiff(stopOnSmallDiff)
+          .setTimeWindowSentinelPath(getSentinelPath(timeWindowSentinelPath,
+              TIME_WINDOW_SENTINEL_PATH, TIME_WINDOW_SENTINEL_PATH_DEFAULT))
+          .setForceCloseSentinelPath(getSentinelPath(forceCloseSentinelPath,
+              FORCE_CLOSE_SENTINEL_PATH, FORCE_CLOSE_SENTINEL_PATH_DEFAULT))
           .build();
 
       LOG.info(context.toString());
@@ -281,6 +353,23 @@ public class RouterFedBalance extends Configured implements Tool {
       builder.setDiffThreshold(Integer.parseInt(
           command.getOptionValue(DIFF_THRESHOLD.getOpt())));
     }
+    if (command.hasOption(STOP_AFTER_INITIAL_COPY.getOpt())) {
+      builder.setStopAfterInitialCopy(true);
+    }
+    if (command.hasOption(START_FROM_INCREMENTAL.getOpt())) {
+      builder.setStartFromIncremental(true);
+    }
+    if (command.hasOption(STOP_ON_SMALL_DIFF.getOpt())) {
+      builder.setStopOnSmallDiff(true);
+    }
+    if (command.hasOption(TIME_WINDOW_SENTINEL.getOpt())) {
+      builder.setTimeWindowSentinelPath(command.getOptionValue(
+          TIME_WINDOW_SENTINEL.getOpt()));
+    }
+    if (command.hasOption(FORCE_CLOSE_SENTINEL.getOpt())) {
+      builder.setForceCloseSentinelPath(command.getOptionValue(
+          FORCE_CLOSE_SENTINEL.getOpt()));
+    }
     if (command.hasOption(TRASH.getOpt())) {
       String val = command.getOptionValue(TRASH.getOpt());
       if (val.equalsIgnoreCase("skip")) {
@@ -311,6 +400,12 @@ public class RouterFedBalance extends Configured implements Tool {
       scheduler.shutDown();
     }
     return 0;
+  }
+
+  private String getSentinelPath(String optionValue, String configKey,
+      String defaultValue) {
+    return optionValue == null ? getConf().getTrimmed(configKey, defaultValue)
+        : optionValue;
   }
 
   /**

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/DistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/DistCpProcedure.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.tools.fedbalance;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.AclStatus;
@@ -91,6 +92,14 @@ public class DistCpProcedure extends BalanceProcedure {
   private boolean useMountReadOnly;
   /* The threshold of diff entries. */
   private int diffThreshold;
+  /* Whether to stop after the initial DistCp job succeeds. */
+  private boolean stopAfterInitialCopy;
+  /* Whether to stop when a small diff cannot move to final copy. */
+  private boolean stopOnSmallDiff;
+  /* Sentinel path that gates leaving the incremental DistCp stage. */
+  private String timeWindowSentinelPath;
+  /* Sentinel path that allows force-closing open files. */
+  private String forceCloseSentinelPath;
 
   private FsPermission fPerm; // the permission of the src.
   private AclStatus acl; // the acl of the src.
@@ -145,8 +154,36 @@ public class DistCpProcedure extends BalanceProcedure {
     this.forceCloseOpenFiles = context.getForceCloseOpenFiles();
     this.useMountReadOnly = context.getUseMountReadOnly();
     this.diffThreshold = context.getDiffThreshold();
+    this.stopAfterInitialCopy = context.getStopAfterInitialCopy();
+    this.stopOnSmallDiff = context.getStopOnSmallDiff();
+    this.timeWindowSentinelPath = context.getTimeWindowSentinelPath();
+    this.forceCloseSentinelPath = context.getForceCloseSentinelPath();
     srcFs = (DistributedFileSystem) context.getSrc().getFileSystem(conf);
     dstFs = (DistributedFileSystem) context.getDst().getFileSystem(conf);
+    if (context.getStartFromIncremental()) {
+      validateStartFromIncremental();
+      this.stage = Stage.DIFF_DISTCP;
+    }
+  }
+
+  /**
+   * Check the preconditions that a prior successful initial DistCp copy
+   * normally establishes, since starting from the incremental stage skips
+   * PRE_CHECK/INIT_DISTCP entirely.
+   */
+  private void validateStartFromIncremental() throws IOException {
+    if (!dstFs.exists(dst)) {
+      throw new IOException("Cannot start from the incremental DistCp stage: "
+          + dst + " does not exist. -startFromIncremental requires a prior "
+          + "successful initial DistCp copy.");
+    }
+    Path snapshotPath = new Path(src,
+        HdfsConstants.DOT_SNAPSHOT_DIR_SEPARATOR + CURRENT_SNAPSHOT_NAME);
+    if (!srcFs.exists(snapshotPath)) {
+      throw new IOException("Cannot start from the incremental DistCp stage: "
+          + snapshotPath + " does not exist. -startFromIncremental requires "
+          + "a prior successful initial DistCp copy.");
+    }
   }
 
   @Override
@@ -204,6 +241,10 @@ public class DistCpProcedure extends BalanceProcedure {
         jobId = null; // unset jobId because the job is done.
         if (job.isSuccessful()) {
           updateStage(Stage.DIFF_DISTCP);
+          if (stopAfterInitialCopy) {
+            throw new FedBalancePauseException(
+                "Stopping after initial copy as requested.");
+          }
           return;
         } else {
           LOG.warn("DistCp failed. Failure={}", job.getFailureInfo());
@@ -395,14 +436,57 @@ public class DistCpProcedure extends BalanceProcedure {
   @VisibleForTesting
   boolean diffDistCpStageDone() throws IOException, RetryException {
     int diffSize = getDiffSize();
-    if (diffSize <= diffThreshold) {
-      if (forceCloseOpenFiles || !verifyOpenFiles()) {
-        return true;
-      } else {
-        throw new RetryException();
-      }
+    if (diffSize > diffThreshold) {
+      return false;
     }
-    return false;
+    // Waiting for the scheduled time window is a normal, expected wait, not a
+    // stuck condition, so it always retries regardless of stopOnSmallDiff.
+    if (!inTimeWindow()) {
+      throw new RetryException();
+    }
+    if (shouldForceCloseOpenFiles() || !verifyOpenFiles()) {
+      return true;
+    }
+    if (stopOnSmallDiff) {
+      throw new FedBalancePauseException("Stopping because the diff size is "
+          + "no greater than the threshold but there are still open files "
+          + "that cannot be closed.");
+    }
+    throw new RetryException();
+  }
+
+  private boolean shouldForceCloseOpenFiles() throws IOException {
+    return forceCloseOpenFiles || sentinelExists(forceCloseSentinelPath);
+  }
+
+  private boolean inTimeWindow() throws IOException {
+    if (timeWindowSentinelPath == null || timeWindowSentinelPath.isEmpty()) {
+      return true;
+    }
+    return sentinelExists(timeWindowSentinelPath);
+  }
+
+  /**
+   * Whether the sentinel path exists. Treats a transient failure to resolve
+   * or check the sentinel path the same as "not present yet" so a temporary
+   * problem with the sentinel's filesystem doesn't hard-fail the job.
+   */
+  private boolean sentinelExists(String sentinelPath) {
+    if (sentinelPath == null || sentinelPath.isEmpty()) {
+      return false;
+    }
+    Path sentinel = new Path(sentinelPath);
+    boolean exists;
+    try {
+      FileSystem fileSystem = sentinel.getFileSystem(conf);
+      exists = fileSystem.exists(sentinel);
+    } catch (IOException e) {
+      LOG.warn("Failed to check FedBalance sentinel path={}, will retry.",
+          sentinel, e);
+      return false;
+    }
+    LOG.info("FedBalance sentinel path={} exists={}", sentinel, exists);
+    return exists;
   }
 
   /**
@@ -564,6 +648,11 @@ public class DistCpProcedure extends BalanceProcedure {
     bandWidth = context.getBandwidthLimit();
     forceCloseOpenFiles = context.getForceCloseOpenFiles();
     useMountReadOnly = context.getUseMountReadOnly();
+    diffThreshold = context.getDiffThreshold();
+    stopAfterInitialCopy = context.getStopAfterInitialCopy();
+    stopOnSmallDiff = context.getStopOnSmallDiff();
+    timeWindowSentinelPath = context.getTimeWindowSentinelPath();
+    forceCloseSentinelPath = context.getForceCloseSentinelPath();
     this.client = new JobClient(conf);
   }
 

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalance.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalance.java
@@ -38,9 +38,18 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.FORCE_CLOSE_SENTINEL_PATH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.FORCE_CLOSE_SENTINEL_PATH_DEFAULT;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TIME_WINDOW_SENTINEL_PATH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TIME_WINDOW_SENTINEL_PATH_DEFAULT;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.FORCE_CLOSE_OPEN;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.FORCE_CLOSE_SENTINEL;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.MAP;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.BANDWIDTH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.START_FROM_INCREMENTAL;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.STOP_AFTER_INITIAL_COPY;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.STOP_ON_SMALL_DIFF;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.TIME_WINDOW_SENTINEL;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.TRASH;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.DELAY_DURATION;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceOptions.CLI_OPTIONS;
@@ -83,6 +92,16 @@ public class FedBalance extends Configured implements Tool {
     private long delayDuration = TimeUnit.SECONDS.toMillis(1);
     /* Specify the threshold of diff entries. */
     private int diffThreshold = 0;
+    /* Whether to stop after the initial DistCp job succeeds. */
+    private boolean stopAfterInitialCopy = false;
+    /* Whether to start from the incremental DistCp stage. */
+    private boolean startFromIncremental = false;
+    /* Whether to stop when a small diff cannot move to final copy. */
+    private boolean stopOnSmallDiff = false;
+    /* Sentinel path that gates leaving the incremental DistCp stage. */
+    private String timeWindowSentinelPath;
+    /* Sentinel path that allows force-closing open files. */
+    private String forceCloseSentinelPath;
     /* The source input. This specifies the source path. */
     private final String inputSrc;
     /* The dst input. This specifies the dst path. */
@@ -148,6 +167,52 @@ public class FedBalance extends Configured implements Tool {
     }
 
     /**
+     * Specify whether to stop after the initial DistCp job succeeds.
+     * @param value true if stopping after initial copy.
+     */
+    public Builder setStopAfterInitialCopy(boolean value) {
+      this.stopAfterInitialCopy = value;
+      return this;
+    }
+
+    /**
+     * Specify whether to start from the incremental DistCp stage.
+     * @param value true if starting from the incremental DistCp stage.
+     */
+    public Builder setStartFromIncremental(boolean value) {
+      this.startFromIncremental = value;
+      return this;
+    }
+
+    /**
+     * Specify whether to stop when a small diff cannot move to final copy.
+     * @param value true if stopping on small diff.
+     */
+    public Builder setStopOnSmallDiff(boolean value) {
+      this.stopOnSmallDiff = value;
+      return this;
+    }
+
+    /**
+     * Specify the sentinel path that gates leaving the incremental DistCp
+     * stage.
+     * @param value the sentinel path.
+     */
+    public Builder setTimeWindowSentinelPath(String value) {
+      this.timeWindowSentinelPath = value;
+      return this;
+    }
+
+    /**
+     * Specify the sentinel path that allows force-closing open files.
+     * @param value the sentinel path.
+     */
+    public Builder setForceCloseSentinelPath(String value) {
+      this.forceCloseSentinelPath = value;
+      return this;
+    }
+
+    /**
      * Build the balance job.
      */
     public BalanceJob build() throws IOException {
@@ -164,7 +229,15 @@ public class FedBalance extends Configured implements Tool {
       context = new FedBalanceContext.Builder(src, dst, NO_MOUNT, getConf())
           .setForceCloseOpenFiles(forceCloseOpen).setUseMountReadOnly(false)
           .setMapNum(map).setBandwidthLimit(bandwidth).setTrash(trashOpt)
-          .setDiffThreshold(diffThreshold).build();
+          .setDiffThreshold(diffThreshold)
+          .setStopAfterInitialCopy(stopAfterInitialCopy)
+          .setStartFromIncremental(startFromIncremental)
+          .setStopOnSmallDiff(stopOnSmallDiff)
+          .setTimeWindowSentinelPath(getSentinelPath(timeWindowSentinelPath,
+              TIME_WINDOW_SENTINEL_PATH, TIME_WINDOW_SENTINEL_PATH_DEFAULT))
+          .setForceCloseSentinelPath(getSentinelPath(forceCloseSentinelPath,
+              FORCE_CLOSE_SENTINEL_PATH, FORCE_CLOSE_SENTINEL_PATH_DEFAULT))
+          .build();
 
       LOG.info(context.toString());
       // Construct the balance job.
@@ -268,6 +341,23 @@ public class FedBalance extends Configured implements Tool {
       builder.setDiffThreshold(Integer.parseInt(
           command.getOptionValue(DIFF_THRESHOLD.getOpt())));
     }
+    if (command.hasOption(STOP_AFTER_INITIAL_COPY.getOpt())) {
+      builder.setStopAfterInitialCopy(true);
+    }
+    if (command.hasOption(START_FROM_INCREMENTAL.getOpt())) {
+      builder.setStartFromIncremental(true);
+    }
+    if (command.hasOption(STOP_ON_SMALL_DIFF.getOpt())) {
+      builder.setStopOnSmallDiff(true);
+    }
+    if (command.hasOption(TIME_WINDOW_SENTINEL.getOpt())) {
+      builder.setTimeWindowSentinelPath(command.getOptionValue(
+          TIME_WINDOW_SENTINEL.getOpt()));
+    }
+    if (command.hasOption(FORCE_CLOSE_SENTINEL.getOpt())) {
+      builder.setForceCloseSentinelPath(command.getOptionValue(
+          FORCE_CLOSE_SENTINEL.getOpt()));
+    }
     if (command.hasOption(TRASH.getOpt())) {
       String val = command.getOptionValue(TRASH.getOpt());
       if (val.equalsIgnoreCase("skip")) {
@@ -298,6 +388,12 @@ public class FedBalance extends Configured implements Tool {
       scheduler.shutDown();
     }
     return 0;
+  }
+
+  private String getSentinelPath(String optionValue, String configKey,
+      String defaultValue) {
+    return optionValue == null ? getConf().getTrimmed(configKey, defaultValue)
+        : optionValue;
   }
 
   private void printUsage() {

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
@@ -44,6 +44,24 @@ public final class FedBalanceConfigs {
       "hdfs.fedbalance.procedure.scheduler.journal.uri";
   public static final String JOB_PREFIX = "JOB-";
   public static final String TMP_TAIL = ".tmp";
+  /**
+   * Sentinel path that gates leaving the incremental DistCp stage.
+   */
+  public static final String TIME_WINDOW_SENTINEL_PATH =
+      "hdfs.fedbalance.time.window.sentinel.path";
+  /**
+   * Default value for {@link #TIME_WINDOW_SENTINEL_PATH}.
+   */
+  public static final String TIME_WINDOW_SENTINEL_PATH_DEFAULT = "";
+  /**
+   * Sentinel path that allows force-closing open files.
+   */
+  public static final String FORCE_CLOSE_SENTINEL_PATH =
+      "hdfs.fedbalance.force.close.sentinel.path";
+  /**
+   * Default value for {@link #FORCE_CLOSE_SENTINEL_PATH}.
+   */
+  public static final String FORCE_CLOSE_SENTINEL_PATH_DEFAULT = "";
 
   private FedBalanceConfigs(){}
 }

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceContext.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceContext.java
@@ -56,6 +56,16 @@ public class FedBalanceContext implements Writable {
   private long delayDuration;
   /* The threshold of diff entries. */
   private int diffThreshold;
+  /* Whether to stop after the initial DistCp job succeeds. */
+  private boolean stopAfterInitialCopy;
+  /* Whether to start from the incremental DistCp stage. */
+  private boolean startFromIncremental;
+  /* Whether to stop when a small diff cannot move to final copy. */
+  private boolean stopOnSmallDiff;
+  /* Sentinel path that gates leaving the incremental DistCp stage. */
+  private String timeWindowSentinelPath;
+  /* Sentinel path that allows force-closing open files. */
+  private String forceCloseSentinelPath;
 
   private Configuration conf;
 
@@ -97,6 +107,51 @@ public class FedBalanceContext implements Writable {
     return diffThreshold;
   }
 
+  /**
+   * Get whether the job should stop after the initial copy.
+   *
+   * @return true if the job should stop after the initial copy.
+   */
+  public boolean getStopAfterInitialCopy() {
+    return stopAfterInitialCopy;
+  }
+
+  /**
+   * Get whether the job should start from the incremental DistCp stage.
+   *
+   * @return true if the job should start from the incremental DistCp stage.
+   */
+  public boolean getStartFromIncremental() {
+    return startFromIncremental;
+  }
+
+  /**
+   * Get whether the job should stop on a small diff that cannot finish.
+   *
+   * @return true if the job should stop on a small diff that cannot finish.
+   */
+  public boolean getStopOnSmallDiff() {
+    return stopOnSmallDiff;
+  }
+
+  /**
+   * Get the sentinel path that gates leaving the incremental DistCp stage.
+   *
+   * @return sentinel path, or null if disabled.
+   */
+  public String getTimeWindowSentinelPath() {
+    return timeWindowSentinelPath;
+  }
+
+  /**
+   * Get the sentinel path that allows force-closing open files.
+   *
+   * @return sentinel path, or null if disabled.
+   */
+  public String getForceCloseSentinelPath() {
+    return forceCloseSentinelPath;
+  }
+
   public TrashOption getTrashOpt() {
     return trashOpt;
   }
@@ -114,6 +169,13 @@ public class FedBalanceContext implements Writable {
     out.writeInt(trashOpt.ordinal());
     out.writeLong(delayDuration);
     out.writeInt(diffThreshold);
+    out.writeBoolean(stopAfterInitialCopy);
+    out.writeBoolean(startFromIncremental);
+    out.writeBoolean(stopOnSmallDiff);
+    Text.writeString(out, timeWindowSentinelPath == null ? ""
+        : timeWindowSentinelPath);
+    Text.writeString(out, forceCloseSentinelPath == null ? ""
+        : forceCloseSentinelPath);
   }
 
   @Override
@@ -130,6 +192,15 @@ public class FedBalanceContext implements Writable {
     trashOpt = TrashOption.values()[in.readInt()];
     delayDuration = in.readLong();
     diffThreshold = in.readInt();
+    stopAfterInitialCopy = in.readBoolean();
+    startFromIncremental = in.readBoolean();
+    stopOnSmallDiff = in.readBoolean();
+    timeWindowSentinelPath = emptyToNull(Text.readString(in));
+    forceCloseSentinelPath = emptyToNull(Text.readString(in));
+  }
+
+  private static String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 
   @Override
@@ -155,6 +226,11 @@ public class FedBalanceContext implements Writable {
         .append(trashOpt, bc.trashOpt)
         .append(delayDuration, bc.delayDuration)
         .append(diffThreshold, bc.diffThreshold)
+        .append(stopAfterInitialCopy, bc.stopAfterInitialCopy)
+        .append(startFromIncremental, bc.startFromIncremental)
+        .append(stopOnSmallDiff, bc.stopOnSmallDiff)
+        .append(timeWindowSentinelPath, bc.timeWindowSentinelPath)
+        .append(forceCloseSentinelPath, bc.forceCloseSentinelPath)
         .isEquals();
   }
 
@@ -171,6 +247,11 @@ public class FedBalanceContext implements Writable {
         .append(trashOpt)
         .append(delayDuration)
         .append(diffThreshold)
+        .append(stopAfterInitialCopy)
+        .append(startFromIncremental)
+        .append(stopOnSmallDiff)
+        .append(timeWindowSentinelPath)
+        .append(forceCloseSentinelPath)
         .build();
   }
 
@@ -204,6 +285,16 @@ public class FedBalanceContext implements Writable {
       break;
     }
     builder.append(" Delay duration is ").append(delayDuration).append("ms.");
+    builder.append(" Stop after initial copy is ")
+        .append(stopAfterInitialCopy).append(".");
+    builder.append(" Start from incremental stage is ")
+        .append(startFromIncremental).append(".");
+    builder.append(" Stop on small diff is ").append(stopOnSmallDiff)
+        .append(".");
+    builder.append(" Time window sentinel path is ")
+        .append(timeWindowSentinelPath).append(".");
+    builder.append(" Force close sentinel path is ")
+        .append(forceCloseSentinelPath).append(".");
     return builder.toString();
   }
 
@@ -219,6 +310,11 @@ public class FedBalanceContext implements Writable {
     private TrashOption trashOpt;
     private long delayDuration;
     private int diffThreshold;
+    private boolean stopAfterInitialCopy;
+    private boolean startFromIncremental;
+    private boolean stopOnSmallDiff;
+    private String timeWindowSentinelPath;
+    private String forceCloseSentinelPath;
 
     /**
      * This class helps building the FedBalanceContext.
@@ -306,6 +402,57 @@ public class FedBalanceContext implements Writable {
     }
 
     /**
+     * Specify whether to stop after the initial DistCp job succeeds.
+     * @param value true if stopping after initial copy.
+     * @return the builder.
+     */
+    public Builder setStopAfterInitialCopy(boolean value) {
+      this.stopAfterInitialCopy = value;
+      return this;
+    }
+
+    /**
+     * Specify whether to start from the incremental DistCp stage.
+     * @param value true if starting from the incremental DistCp stage.
+     * @return the builder.
+     */
+    public Builder setStartFromIncremental(boolean value) {
+      this.startFromIncremental = value;
+      return this;
+    }
+
+    /**
+     * Specify whether to stop when a small diff cannot move to final copy.
+     * @param value true if stopping on small diff.
+     * @return the builder.
+     */
+    public Builder setStopOnSmallDiff(boolean value) {
+      this.stopOnSmallDiff = value;
+      return this;
+    }
+
+    /**
+     * Specify the sentinel path that gates leaving the incremental DistCp
+     * stage.
+     * @param value the sentinel path.
+     * @return the builder.
+     */
+    public Builder setTimeWindowSentinelPath(String value) {
+      this.timeWindowSentinelPath = emptyToNull(value);
+      return this;
+    }
+
+    /**
+     * Specify the sentinel path that allows force-closing open files.
+     * @param value the sentinel path.
+     * @return the builder.
+     */
+    public Builder setForceCloseSentinelPath(String value) {
+      this.forceCloseSentinelPath = emptyToNull(value);
+      return this;
+    }
+
+    /**
      * Build the FedBalanceContext.
      *
      * @return the FedBalanceContext obj.
@@ -323,6 +470,11 @@ public class FedBalanceContext implements Writable {
       context.trashOpt = this.trashOpt;
       context.delayDuration = this.delayDuration;
       context.diffThreshold = this.diffThreshold;
+      context.stopAfterInitialCopy = this.stopAfterInitialCopy;
+      context.startFromIncremental = this.startFromIncremental;
+      context.stopOnSmallDiff = this.stopOnSmallDiff;
+      context.timeWindowSentinelPath = this.timeWindowSentinelPath;
+      context.forceCloseSentinelPath = this.forceCloseSentinelPath;
       return context;
     }
   }

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceOptions.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceOptions.java
@@ -82,6 +82,46 @@ public final class FedBalanceOptions {
           + " used. If the trash is disabled in the server side, the default"
           + " trash interval 60 minutes is used.");
 
+  /**
+   * Stop the FedBalance job after the initial DistCp job succeeds.
+   */
+  public final static Option STOP_AFTER_INITIAL_COPY =
+      new Option("stopAfterInitialCopy", false,
+          "Stop the FedBalance job after the initial DistCp job succeeds.");
+
+  /**
+   * Start the FedBalance job from the incremental DistCp stage.
+   */
+  public final static Option START_FROM_INCREMENTAL =
+      new Option("startFromIncremental", false,
+          "Start the FedBalance job from the incremental DistCp stage.");
+
+  /**
+   * Stop instead of retrying when the diff size is small enough but final
+   * copy conditions are not satisfied.
+   */
+  public final static Option STOP_ON_SMALL_DIFF =
+      new Option("stopOnSmallDiff", false,
+          "Stop when the diff size is no greater than the threshold but "
+              + "final copy conditions are not satisfied.");
+
+  /**
+   * A sentinel path that must exist before FedBalance can leave the
+   * incremental DistCp stage.
+   */
+  public final static Option TIME_WINDOW_SENTINEL =
+      new Option("timeWindowSentinel", true,
+          "A sentinel path that must exist before FedBalance can leave the "
+              + "incremental DistCp stage.");
+
+  /**
+   * A sentinel path that makes FedBalance treat open files as force closeable.
+   */
+  public final static Option FORCE_CLOSE_SENTINEL =
+      new Option("forceCloseSentinel", true,
+          "A sentinel path that makes FedBalance treat open files as force "
+              + "closeable.");
+
   public final static Options CLI_OPTIONS = new Options();
 
   static {
@@ -90,5 +130,10 @@ public final class FedBalanceOptions {
     CLI_OPTIONS.addOption(BANDWIDTH);
     CLI_OPTIONS.addOption(DELAY_DURATION);
     CLI_OPTIONS.addOption(TRASH);
+    CLI_OPTIONS.addOption(STOP_AFTER_INITIAL_COPY);
+    CLI_OPTIONS.addOption(START_FROM_INCREMENTAL);
+    CLI_OPTIONS.addOption(STOP_ON_SMALL_DIFF);
+    CLI_OPTIONS.addOption(TIME_WINDOW_SENTINEL);
+    CLI_OPTIONS.addOption(FORCE_CLOSE_SENTINEL);
   }
 }

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalancePauseException.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalancePauseException.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools.fedbalance;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a FedBalance job stops itself on purpose, e.g. because
+ * -stopAfterInitialCopy or -stopOnSmallDiff was requested. The job still
+ * surfaces through BalanceJob#getError() like any other failure, but callers
+ * can check for this type to tell an intentional pause apart from a genuine
+ * DistCp failure.
+ */
+public class FedBalancePauseException extends IOException {
+
+  /**
+   * Create a pause exception.
+   *
+   * @param message detail message.
+   */
+  public FedBalancePauseException(String message) {
+    super(message);
+  }
+}

--- a/hadoop-tools/hadoop-federation-balance/src/main/resources/hdfs-fedbalance-default.xml
+++ b/hadoop-tools/hadoop-federation-balance/src/main/resources/hdfs-fedbalance-default.xml
@@ -38,4 +38,23 @@
         </description>
     </property>
 
+    <property>
+        <name>hdfs.fedbalance.time.window.sentinel.path</name>
+        <value></value>
+        <description>
+            A sentinel path that must exist before FedBalance can leave the
+            incremental DistCp stage. An empty value disables this gate.
+        </description>
+    </property>
+
+    <property>
+        <name>hdfs.fedbalance.force.close.sentinel.path</name>
+        <value></value>
+        <description>
+            A sentinel path that makes FedBalance treat open files as force
+            closeable while checking whether the incremental DistCp stage can
+            finish. An empty value disables this gate.
+        </description>
+    </property>
+
 </configuration>

--- a/hadoop-tools/hadoop-federation-balance/src/site/markdown/HDFSFederationBalance.md
+++ b/hadoop-tools/hadoop-federation-balance/src/site/markdown/HDFSFederationBalance.md
@@ -100,6 +100,11 @@ Command `submit` has the following options:
 | -delay | Specify the delayed duration(millie seconds) when the job needs to retry. | 1000 |
 | -moveToTrash | This options has 3 values: `trash` (move the source path to trash), `delete` (delete the source path directly) and `skip` (skip both trash and deletion). By default the server side trash interval is used. If the trash is disabled in the server side, the default trash interval 60 minutes is used. | trash |
 | -diffThreshold | Specify the threshold of the diff entries that used in incremental copy stage. If the diff entries size is no greater than the threshold and the open files check is satisfied(no open files or force close all open files), the fedBalance will go to the final round of distcp. Setting to 0 means waiting until there is no diff.| 0 |
+| -stopAfterInitialCopy | Stop the FedBalance job after the initial DistCp job succeeds. A later job can use `-startFromIncremental` to continue from the incremental copy stage. | Disabled |
+| -startFromIncremental | Start the FedBalance job from the incremental DistCp stage. This is intended for controlled recovery after the initial copy and source snapshot already exist. | Disabled |
+| -stopOnSmallDiff | Stop instead of retrying when the diff size is no greater than the threshold but final copy conditions are not satisfied. | Disabled |
+| -timeWindowSentinel | A sentinel path that must exist before FedBalance can leave the incremental DistCp stage. | Disabled |
+| -forceCloseSentinel | A sentinel path that makes FedBalance treat open files as force closeable while checking whether the incremental DistCp stage can finish. | Disabled |
 
 ### Configuration Options
 --------------------
@@ -110,6 +115,8 @@ Set configuration options at hdfs-fedbalance-site.xml.
 | ------------------------------ | ------------------------------------ | ------- |
 | hdfs.fedbalance.procedure.work.thread.num | The worker threads number of the BalanceProcedureScheduler. BalanceProcedureScheduler is responsible for scheduling a balance job, including submit, run, delay and recover. | 10 |
 | hdfs.fedbalance.procedure.scheduler.journal.uri | The uri of the journal, the journal file is used for handling the job persistence and recover. | hdfs://localhost:8020/tmp/procedure |
+| hdfs.fedbalance.time.window.sentinel.path | A sentinel path that must exist before FedBalance can leave the incremental DistCp stage. An empty value disables this gate. | empty |
+| hdfs.fedbalance.force.close.sentinel.path | A sentinel path that makes FedBalance treat open files as force closeable while checking whether the incremental DistCp stage can finish. An empty value disables this gate. | empty |
 
 Architecture of HDFS Federation Balance
 ----------------------

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
@@ -201,6 +201,144 @@ public class TestDistCpProcedure {
   }
 
   @Test
+  public void testStopAfterInitialCopyAndStartFromIncremental()
+      throws Exception {
+    String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
+    DistributedFileSystem fs =
+        (DistributedFileSystem) FileSystem.get(URI.create(nnUri), conf);
+    createFiles(fs, testRoot, srcfiles);
+    Path src = new Path(testRoot, SRCDAT);
+    Path dst = new Path(testRoot, DSTDAT);
+
+    FedBalanceContext context = new FedBalanceContext.Builder(src, dst, MOUNT,
+        conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setStopAfterInitialCopy(true)
+        .build();
+    DistCpProcedure dcProcedure =
+        new DistCpProcedure("distcp-procedure", null, 1000, context);
+    intercept(IOException.class, "Stopping after initial copy",
+        () -> executeProcedure(dcProcedure, Stage.DIFF_DISTCP,
+            () -> dcProcedure.initDistCp()));
+    assertEquals(Stage.DIFF_DISTCP, dcProcedure.getStage());
+    assertTrue(fs.exists(dst));
+
+    FedBalanceContext restartContext =
+        new FedBalanceContext.Builder(src, dst, MOUNT, conf)
+            .setMapNum(10)
+            .setBandwidthLimit(1)
+            .setTrash(TrashOption.TRASH)
+            .setDelayDuration(1000)
+            .setStartFromIncremental(true)
+            .build();
+    DistCpProcedure restartedProcedure =
+        new DistCpProcedure("distcp-procedure", null, 1000, restartContext);
+    assertEquals(Stage.DIFF_DISTCP, restartedProcedure.getStage());
+    cleanup(fs, new Path(testRoot));
+  }
+
+  @Test
+  public void testDiffStageSentinels() throws Exception {
+    String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
+    DistributedFileSystem fs =
+        (DistributedFileSystem) FileSystem.get(URI.create(nnUri), conf);
+    createFiles(fs, testRoot, srcfiles);
+    Path src = new Path(testRoot, SRCDAT);
+    Path dst = new Path(testRoot, DSTDAT);
+    Path timeWindowSentinel = new Path(testRoot, "time-window-sentinel");
+
+    FedBalanceContext context = new FedBalanceContext.Builder(src, dst, MOUNT,
+        conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setDiffThreshold(10)
+        .setStopOnSmallDiff(true)
+        .setTimeWindowSentinelPath(timeWindowSentinel.toString())
+        .build();
+    DistCpProcedure dcProcedure =
+        new DistCpProcedure("distcp-procedure", null, 1000, context);
+    executeProcedure(dcProcedure, Stage.DIFF_DISTCP,
+        () -> dcProcedure.initDistCp());
+    // Outside the time window, diffDistCpStageDone() should keep retrying
+    // rather than hard-stop, even though stopOnSmallDiff is set.
+    intercept(RetryException.class, () -> dcProcedure.diffDistCpStageDone());
+    fs.create(timeWindowSentinel).close();
+    assertTrue(dcProcedure.diffDistCpStageDone());
+    cleanup(fs, new Path(testRoot));
+  }
+
+  @Test
+  public void testStopOnSmallDiffWithOpenFiles() throws Exception {
+    String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
+    DistributedFileSystem fs =
+        (DistributedFileSystem) FileSystem.get(URI.create(nnUri), conf);
+    createFiles(fs, testRoot, srcfiles);
+    Path src = new Path(testRoot, SRCDAT);
+    Path dst = new Path(testRoot, DSTDAT);
+
+    FedBalanceContext context = new FedBalanceContext.Builder(src, dst, MOUNT,
+        conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setDiffThreshold(10)
+        .setStopOnSmallDiff(true)
+        .build();
+    DistCpProcedure dcProcedure =
+        new DistCpProcedure("distcp-procedure", null, 1000, context);
+    executeProcedure(dcProcedure, Stage.DIFF_DISTCP,
+        () -> dcProcedure.initDistCp());
+    OutputStream out = fs.append(new Path(src, "a"));
+    try {
+      intercept(IOException.class, "there are still open files",
+          () -> dcProcedure.diffDistCpStageDone());
+    } finally {
+      out.close();
+    }
+    cleanup(fs, new Path(testRoot));
+  }
+
+  @Test
+  public void testForceCloseSentinel() throws Exception {
+    String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
+    DistributedFileSystem fs =
+        (DistributedFileSystem) FileSystem.get(URI.create(nnUri), conf);
+    createFiles(fs, testRoot, srcfiles);
+    Path src = new Path(testRoot, SRCDAT);
+    Path dst = new Path(testRoot, DSTDAT);
+    Path forceCloseSentinel = new Path(testRoot, "force-close-sentinel");
+
+    FedBalanceContext context = new FedBalanceContext.Builder(src, dst, MOUNT,
+        conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setDiffThreshold(10)
+        .setForceCloseSentinelPath(forceCloseSentinel.toString())
+        .build();
+    DistCpProcedure dcProcedure =
+        new DistCpProcedure("distcp-procedure", null, 1000, context);
+    executeProcedure(dcProcedure, Stage.DIFF_DISTCP,
+        () -> dcProcedure.initDistCp());
+    OutputStream out = fs.append(new Path(src, "a"));
+    try {
+      intercept(RetryException.class, () -> dcProcedure.diffDistCpStageDone());
+      fs.create(forceCloseSentinel).close();
+      assertTrue(dcProcedure.diffDistCpStageDone());
+    } finally {
+      out.close();
+    }
+    cleanup(fs, new Path(testRoot));
+  }
+
+  @Test
   public void testDiffDistCp() throws Exception {
     String testRoot = nnUri + "/user/foo/testdir." + getMethodName();
     DistributedFileSystem fs =

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestFedBalance.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestFedBalance.java
@@ -18,11 +18,23 @@
 package org.apache.hadoop.tools.fedbalance;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.FORCE_CLOSE_SENTINEL_PATH;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TIME_WINDOW_SENTINEL_PATH;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TrashOption;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.WORK_THREAD_NUM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestFedBalance {
   @Test
@@ -30,5 +42,55 @@ public class TestFedBalance {
     Configuration conf = FedBalance.getDefaultConf();
     assertNotNull(conf.get(SCHEDULER_JOURNAL_URI));
     assertNotNull(conf.get(WORK_THREAD_NUM));
+    assertEquals("", conf.getTrimmed(TIME_WINDOW_SENTINEL_PATH, ""));
+    assertEquals("", conf.getTrimmed(FORCE_CLOSE_SENTINEL_PATH, ""));
+  }
+
+  @Test
+  public void testFedBalanceOptionsRegistered() {
+    assertTrue(FedBalanceOptions.CLI_OPTIONS.hasOption(
+        FedBalanceOptions.STOP_AFTER_INITIAL_COPY.getOpt()));
+    assertTrue(FedBalanceOptions.CLI_OPTIONS.hasOption(
+        FedBalanceOptions.START_FROM_INCREMENTAL.getOpt()));
+    assertTrue(FedBalanceOptions.CLI_OPTIONS.hasOption(
+        FedBalanceOptions.STOP_ON_SMALL_DIFF.getOpt()));
+    assertTrue(FedBalanceOptions.CLI_OPTIONS.hasOption(
+        FedBalanceOptions.TIME_WINDOW_SENTINEL.getOpt()));
+    assertTrue(FedBalanceOptions.CLI_OPTIONS.hasOption(
+        FedBalanceOptions.FORCE_CLOSE_SENTINEL.getOpt()));
+  }
+
+  @Test
+  public void testFedBalanceContextOperationalControlSerialization()
+      throws IOException {
+    Configuration conf = new Configuration(false);
+    FedBalanceContext context = new FedBalanceContext.Builder(
+        new Path("hdfs://src.example.com/src"),
+        new Path("hdfs://dst.example.com/dst"), FedBalance.NO_MOUNT, conf)
+        .setMapNum(10)
+        .setBandwidthLimit(1)
+        .setTrash(TrashOption.TRASH)
+        .setDelayDuration(1000)
+        .setStopAfterInitialCopy(true)
+        .setStartFromIncremental(true)
+        .setStopOnSmallDiff(true)
+        .setTimeWindowSentinelPath("hdfs://nn/sentinel/time")
+        .setForceCloseSentinelPath("hdfs://nn/sentinel/force")
+        .build();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    context.write(new DataOutputStream(out));
+
+    FedBalanceContext recovered = new FedBalanceContext();
+    recovered.readFields(new DataInputStream(
+        new ByteArrayInputStream(out.toByteArray())));
+
+    assertTrue(recovered.getStopAfterInitialCopy());
+    assertTrue(recovered.getStartFromIncremental());
+    assertTrue(recovered.getStopOnSmallDiff());
+    assertEquals("hdfs://nn/sentinel/time",
+        recovered.getTimeWindowSentinelPath());
+    assertEquals("hdfs://nn/sentinel/force",
+        recovered.getForceCloseSentinelPath());
   }
 }


### PR DESCRIPTION
### Description of PR

Large FedBalance jobs may need operator-controlled stop and resume points, especially around the initial copy, incremental copy, and final cutover window.

This issue proposes adding optional operational control switches for FedBalance. All new controls are disabled by default and do not change the existing default behavior.

Proposed controls:
- Stop after the initial DistCp succeeds.
- Start a later job from the incremental DistCp stage after validating the required prior-copy state.
- Stop instead of retrying forever when the diff is small enough but final-copy conditions are blocked by open files.
- Gate leaving the incremental DistCp stage on a time-window sentinel path.
- Allow a sentinel path to make open files force-closeable.

These controls make long-running FedBalance migrations easier to operate while preserving the current default behavior.

### How was this patch tested?

Ran FedBalance unit tests locally and validated on a production cluster.

### AI Tooling

Contains content generated by Codex.