### PR TITLE
HADOOP-19577. Improve error message when the path contains double slash without a preceding authority or bucket name.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -820,8 +820,42 @@ public abstract class FileSystem extends Configured
           return;
       }
     }
-    throw new IllegalArgumentException("Wrong FS: " + path +
-                                       ", expected: " + this.getUri());
+    throw new IllegalArgumentException(getWrongFsErrorMsg(path));
+  }
+
+  /**
+   * Build the "Wrong FS" error message thrown by {@link #checkPath(Path)},
+   * appending a diagnostic hint when the path's URI has an unexpectedly
+   * missing authority component while this FileSystem has one.
+   *
+   * <p>This situation is typically caused by a stray {@code "//"} in the
+   * input, which {@link java.net.URI} reinterprets as an authority
+   * delimiter (see HADOOP-8087). For example, {@code "scheme:////file"}
+   * parses to a URI with a {@code null} authority, and joining
+   * {@code "scheme://host/"} with a child path beginning with {@code "//"}
+   * promotes the child's leading segment into the authority position and
+   * silently drops the intended host. In either case, the resulting
+   * {@code Path.toString()} no longer contains the host/bucket the caller
+   * supplied, which makes the plain "Wrong FS" message misleading.
+   *
+   * @param path the path that failed the check
+   * @return an error message suitable for {@link IllegalArgumentException}
+   */
+  private String getWrongFsErrorMsg(Path path) {
+    StringBuilder msg = new StringBuilder("Wrong FS: ")
+        .append(path).append(", expected: ").append(this.getUri());
+    URI pathUri = path.toUri();
+    URI fsUri = this.getUri();
+    if (pathUri.getScheme() != null
+        && pathUri.getAuthority() == null
+        && fsUri.getAuthority() != null) {
+      msg.append(" (the path's URI has no authority; this is often caused"
+          + " by a stray '//' in the input, e.g. 'scheme:////file' or a"
+          + " child path beginning with '//', which java.net.URI treats"
+          + " as an authority delimiter and drops the intended"
+          + " host/bucket - see HADOOP-8087)");
+    }
+    return msg.toString();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemCanonicalization.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemCanonicalization.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
@@ -289,11 +290,42 @@ public class TestFileSystemCanonicalization {
       assertEquals(pathAuthority, fqPath.toUri().getAuthority());
     } else {
       assertNotNull(e, "did not fail");
-      assertEquals("Wrong FS: "+rawPath+", expected: "+fs.getUri(),
-          e.getMessage());
+      String expectedPrefix = "Wrong FS: "+rawPath+", expected: "+fs.getUri();
+      assertTrue(e.getMessage().startsWith(expectedPrefix),
+          "expected message to start with '" + expectedPrefix
+              + "' but was: " + e.getMessage());
     }
   }
-    
+
+  /**
+   * When the input path's URI has no authority (typically because a stray
+   * "//" caused java.net.URI to drop it) and this FileSystem does have an
+   * authority, {@link FileSystem#checkPath(Path)} should still report the
+   * primary "Wrong FS" mismatch, and the message should also include a
+   * diagnostic hint explaining the likely cause (HADOOP-19577 / HADOOP-8087).
+   */
+  @Test
+  public void testWrongFsHintOnMissingAuthority() throws Exception {
+    FileSystem fs = getVerifiedFS("myfs://host.a.b:123", "myfs://host.a.b:123");
+    Path rawPath = new Path(URI.create("myfs:////file"));
+    assertEquals(null, rawPath.toUri().getAuthority(),
+        "precondition: rawPath authority should be null");
+    Exception e = null;
+    try {
+      fs.makeQualified(rawPath);
+    } catch (IllegalArgumentException iae) {
+      e = iae;
+    }
+    assertNotNull(e, "did not fail");
+    String msg = e.getMessage();
+    assertTrue(msg.startsWith("Wrong FS: "),
+        "unexpected message: " + msg);
+    assertTrue(msg.contains("HADOOP-8087"),
+        "expected HADOOP-8087 hint in message but was: " + msg);
+    assertTrue(msg.contains("no authority"),
+        "expected 'no authority' hint in message but was: " + msg);
+  }
+
   static class DummyFileSystem extends FileSystem {
     URI uri;
     static int defaultPort = 123;


### PR DESCRIPTION
### Description of PR

When `java.net.URI` reinterprets a stray `//` in a `Path` as the authority delimiter (see HADOOP-8087), the intended host or bucket may be silently dropped. `FileSystem.checkPath` then throws `IllegalArgumentException` with a "Wrong FS" message that no longer contains the caller's input, which makes the cause hard to diagnose.

For example, `new Path("hdfs:////some/file")` parses to a URI with a null authority, and the current message reads `Wrong FS: hdfs:/some/file, expected: hdfs://cluster/` with no clue that a leading double slash was the cause.

This PR appends a short diagnostic hint to the exception message when three conditions all hold: the path URI has a scheme, the path URI's authority is null, and this FileSystem has a non-null authority. The primary `Wrong FS: <path>, expected: <fs-uri>` text is preserved, so existing callers and log parsers keep working. Users hitting the common `scheme:////file` typo now see a message that names the cause and references HADOOP-8087.

The hint is deliberately narrow. Joining a Path with a child that begins with `//`, e.g. `new Path(new Path("s3://bucket/"), "//file")`, promotes the child's first segment to the authority position with a non-null value; that shape is not distinguishable at check time from a plain wrong-host root path (`hdfs://wronghost/`) without false positives. A follow-up in `Path`'s constructors would be the right place to catch that shape, since the original input string is only available there.

### How was this patch tested?

Added a new unit test `testWrongFsHintOnMissingAuthority` in `TestFileSystemCanonicalization` covering the null-authority case. The existing exact-match assertion on the "Wrong FS" message in the same file is relaxed from `assertEquals(...)` to `assertTrue(msg.startsWith(...))` so the primary contract is preserved without over-specifying wording. `mvn -pl hadoop-common-project/hadoop-common test -Dtest=TestFileSystemCanonicalization` passes 17/17 (16 existing + 1 new). Locally validated the message end-to-end with a stub FileSystem driver against the null-authority case, the child-`//` displacement case, and a plain scheme/host mismatch — the hint fires only for the null-authority case.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by Claude.