### PR TITLE
HADOOP-19935. Windows: make preferIPv4Stack overridable, matching hadoop-functions.sh

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-config.cmd
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-config.cmd
@@ -220,6 +220,17 @@ if exist %HADOOP_COMMON_HOME%\bin (
 @rem
 set TOOL_PATH=%HADOOP_HOME%\share\hadoop\tools\lib\*
 
+@rem
+@rem Default the stack preference to IPv4 only when the operator has not set
+@rem HADOOP_OPTS, mirroring ${HADOOP_OPTS:-...} in hadoop-functions.sh. Must run
+@rem before the -Dhadoop.* options below, while HADOOP_OPTS holds only the
+@rem operator's value.
+@rem
+
+if not defined HADOOP_OPTS (
+  set HADOOP_OPTS=-Djava.net.preferIPv4Stack=true
+)
+
 set HADOOP_OPTS=%HADOOP_OPTS% -Dhadoop.log.dir=%HADOOP_LOG_DIR%
 set HADOOP_OPTS=%HADOOP_OPTS% -Dhadoop.log.file=%HADOOP_LOGFILE%
 set HADOOP_OPTS=%HADOOP_OPTS% -Dhadoop.home.dir=%HADOOP_HOME%
@@ -230,12 +241,6 @@ if defined JAVA_LIBRARY_PATH (
   set HADOOP_OPTS=%HADOOP_OPTS% -Djava.library.path=%JAVA_LIBRARY_PATH%
 )
 set HADOOP_OPTS=%HADOOP_OPTS% -Dhadoop.policy.file=%HADOOP_POLICYFILE%
-
-@rem
-@rem Disable ipv6 as it can cause issues
-@rem
-
-set HADOOP_OPTS=%HADOOP_OPTS% -Djava.net.preferIPv4Stack=true
 
 @rem
 @rem put hdfs in classpath if present


### PR DESCRIPTION
### Description of PR

Prompted by [HADOOP-16943](https://issues.apache.org/jira/browse/HADOOP-16943), I noticed that Windows hadoop-config.cmd still disables IPv6.

On Unix the IPv4 pin has been overridable since [HADOOP-9902](https://issues.apache.org/jira/browse/HADOOP-9902): hadoop-functions.sh uses `${HADOOP_OPTS:-"-Djava.net.preferIPv4Stack=true"}`, so setting HADOOP_OPTS selects dual-stack or IPv6. hadoop-config.cmd never matched it. It appended the pin unconditionally, so IPv6 could not be enabled on Windows at all.

Apply the pin only when HADOOP_OPTS is unset, mirroring the Unix default. IPv4 stays the default when HADOOP_OPTS is unset; operators who set it can now choose dual-stack or IPv6.

### How was this patch tested?

n/a. There's no Windows CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html