### PR TITLE
HDFS-17946. Several HDFS client integer configs report raw NumberForm…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -1531,11 +1531,16 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     String valueString = getTrimmed(name);
     if (valueString == null)
       return defaultValue;
-    String hexString = getHexDigits(valueString);
-    if (hexString != null) {
-      return Integer.parseInt(hexString, 16);
+    try {
+      String hexString = getHexDigits(valueString);
+      if (hexString != null) {
+        return Integer.parseInt(hexString, 16);
+      }
+      return Integer.parseInt(valueString);
+    } catch (NumberFormatException e) {
+      throw new NumberFormatException("Failed to parse value of " + name
+          + ", got \"" + valueString + "\", expect a valid integer.");
     }
-    return Integer.parseInt(valueString);
   }
   
   /**
@@ -1552,7 +1557,13 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     String[] strings = getTrimmedStrings(name);
     int[] ints = new int[strings.length];
     for (int i = 0; i < strings.length; i++) {
-      ints[i] = Integer.parseInt(strings[i]);
+      try {
+        ints[i] = Integer.parseInt(strings[i]);
+      } catch (NumberFormatException e) {
+        throw new NumberFormatException("Failed to parse value of " + name
+            + "[" + i + "], got \"" + strings[i]
+            + "\", expect a valid integer.");
+      }
     }
     return ints;
   }
@@ -1584,11 +1595,16 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     String valueString = getTrimmed(name);
     if (valueString == null)
       return defaultValue;
-    String hexString = getHexDigits(valueString);
-    if (hexString != null) {
-      return Long.parseLong(hexString, 16);
+    try {
+      String hexString = getHexDigits(valueString);
+      if (hexString != null) {
+        return Long.parseLong(hexString, 16);
+      }
+      return Long.parseLong(valueString);
+    } catch (NumberFormatException e) {
+      throw new NumberFormatException("Failed to parse value of " + name
+          + ", got \"" + valueString + "\", expect a valid long.");
     }
-    return Long.parseLong(valueString);
   }
 
   /**
@@ -1656,7 +1672,12 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     String valueString = getTrimmed(name);
     if (valueString == null)
       return defaultValue;
-    return Float.parseFloat(valueString);
+    try {
+      return Float.parseFloat(valueString);
+    } catch (NumberFormatException e) {
+      throw new NumberFormatException("Failed to parse value of " + name
+          + ", got \"" + valueString + "\", expect a valid float.");
+    }
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
@@ -2763,4 +2763,72 @@ public class TestConfiguration {
 
     assertFalse(exceptionOccurred.get(), "ConcurrentModificationException occurred");
   }
+
+  @Test
+  public void testGetIntOutOfRange() {
+    Configuration conf = new Configuration();
+    final String key = "test.get.int.key";
+    final String outOfRangeValue = "-4294967296";
+    conf.set(key, outOfRangeValue);
+    try {
+      conf.getInt(key, 0);
+      fail("should have thrown NumberFormatException");
+    } catch (NumberFormatException e) {
+      assertTrue(e.getMessage().contains(key),
+          "Exception message should contain the config key");
+      assertTrue(e.getMessage().contains(outOfRangeValue),
+          "Exception message should contain the invalid value");
+    }
+  }
+
+  @Test
+  public void testGetIntsOutOfRange() {
+    Configuration conf = new Configuration();
+    final String key = "test.get.ints.key";
+    final String outOfRangeValue = "1,-4294967296,3";
+    conf.set(key, outOfRangeValue);
+    try {
+      conf.getInts(key);
+      fail("should have thrown NumberFormatException");
+    } catch (NumberFormatException e) {
+      assertTrue(e.getMessage().contains(key),
+          "Exception message should contain the config key");
+      assertTrue(e.getMessage().contains("-4294967296"),
+          "Exception message should contain the invalid value");
+    }
+  }
+
+  @Test
+  public void testGetLongOutOfRange() {
+    Configuration conf = new Configuration();
+    final String key = "test.get.long.key";
+    final String outOfRangeValue = "99999999999999999999";
+    conf.set(key, outOfRangeValue);
+    try {
+      conf.getLong(key, 0L);
+      fail("should have thrown NumberFormatException");
+    } catch (NumberFormatException e) {
+      assertTrue(e.getMessage().contains(key),
+          "Exception message should contain the config key");
+      assertTrue(e.getMessage().contains(outOfRangeValue),
+          "Exception message should contain the invalid value");
+    }
+  }
+
+  @Test
+  public void testGetFloatOutOfRange() {
+    Configuration conf = new Configuration();
+    final String key = "test.get.float.key";
+    final String invalidValue = "not_a_float";
+    conf.set(key, invalidValue);
+    try {
+      conf.getFloat(key, 0.0f);
+      fail("should have thrown NumberFormatException");
+    } catch (NumberFormatException e) {
+      assertTrue(e.getMessage().contains(key),
+          "Exception message should contain the config key");
+      assertTrue(e.getMessage().contains(invalidValue),
+          "Exception message should contain the invalid value");
+    }
+  }
 }


### PR DESCRIPTION
### Description of PR

This PR fixes [HDFS-17946](https://issues.apache.org/jira/browse/HDFS-17946).

When several HDFS client integer configuration values are set to out-of-range
values (e.g. `-4294967296`, which exceeds the `int` range of
`-2147483648 ~ 2147483647`), the underlying `Configuration` class throws a raw
`NumberFormatException` without identifying the offending config key:

```
Failed to initialize filesystem hdfs://127.0.0.1:9000:
java.lang.NumberFormatException: For input string: "-4294967296"
```

This makes it hard for users to figure out which property is misconfigured.
The fix wraps the `Integer.parseInt` / `Long.parseLong` / `Float.parseFloat`
calls in `Configuration.getInt`, `Configuration.getInts`,
`Configuration.getLong` and `Configuration.getFloat` with a `try`/`catch` so
that the thrown `NumberFormatException` includes the config key name and the
invalid value, e.g.:

```
NumberFormatException: Failed to parse value of dfs.client.block.write.retries,
got "-4294967296", expect a valid integer.
```

### Affected configs (from HDFS-17946)

* `dfs.client.block.write.retries`
* `dfs.client.pipeline.recovery.max-retries`
* `dfs.client.retry.max.attempts`
* `dfs.client.congestion.backoff.mean.time`

### Changes

* `hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java`
  * `getInt(String, int)` – wrap parsing in `try`/`catch`
  * `getInts(String)` – wrap parsing in `try`/`catch` (includes array index)
  * `getLong(String, long)` – wrap parsing in `try`/`catch`
  * `getFloat(String, float)` – wrap parsing in `try`/`catch`
* `hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java`
  * Added `testGetIntOutOfRange`, `testGetIntsOutOfRange`,
    `testGetLongOutOfRange`, `testGetFloatOutOfRange` covering the new
    behavior and the exact value `-4294967296` reported in the JIRA.

