### PR TITLE
YARN-11967. Addendum: don't enable pmem/vmem checks in DistributedShellBaseTest

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/DistributedShellBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/DistributedShellBaseTest.java
@@ -524,13 +524,21 @@ public abstract class DistributedShellBaseTest {
     conf.setBoolean(YarnConfiguration.NODE_LABELS_ENABLED, true);
     conf.set("mapreduce.jobhistory.address",
         "0.0.0.0:" + ServerSocketUtil.getPort(10021, 10));
-    // Enable ContainersMonitorImpl
+    // Enable ContainersMonitorImpl so that resource utilization is tracked
+    // (needed by opportunistic container allocation below). Do NOT enable the
+    // polling-based pmem/vmem checks: these tests are not exercising memory
+    // enforcement, and their containers can legitimately exceed the tiny
+    // MIN_ALLOCATION_MB limit. Before YARN-11967 these checks were silently
+    // skipped because strictMemoryEnforcement defaulted to true; now that
+    // strictMemoryEnforcement requires yarn.nodemanager.resource.memory.enabled
+    // as well (default false), the polling check would actually run and kill
+    // the containers, breaking these tests. Keep the checks disabled here.
     conf.set(YarnConfiguration.NM_CONTAINER_MON_RESOURCE_CALCULATOR,
         LinuxResourceCalculatorPlugin.class.getName());
     conf.set(YarnConfiguration.NM_CONTAINER_MON_PROCESS_TREE,
         ProcfsBasedProcessTree.class.getName());
-    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, false);
     conf.setBoolean(
         YarnConfiguration.YARN_MINICLUSTER_CONTROL_RESOURCE_MONITORING, true);
     conf.setBoolean(YarnConfiguration.RM_SYSTEM_METRICS_PUBLISHER_ENABLED,


### PR DESCRIPTION
### Description of PR
Follow-up / addendum to #8573 (YARN-11967).

After #8573, `strictMemoryEnforcement` defaults to `false` — it now requires **both** `yarn.nodemanager.resource.memory.enabled` (default `false`) and `yarn.nodemanager.resource.memory.enforced` (default `true`). As a result, `ContainersMonitorImpl#checkLimit()` no longer takes the strict-only early-return path by default and the polling-based pmem/vmem check actually runs.

`DistributedShellBaseTest#setupInternal` enables the polling checks:

```java
conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, true);
conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, true);
```

Historically these settings were **silent no-ops**, because strict enforcement was on by default and `checkLimit()` short-circuited before reaching the polling logic. After YARN-11967 they take effect, and MiniYARNCluster containers running under the tiny `MIN_ALLOCATION_MB` limit get killed for exceeding pmem/vmem, which is what @pan3793 observed on trunk after the merge.

### Fix
Disable the polling pmem/vmem checks in the base test config. `ContainersMonitorImpl` itself is still enabled (governed by `NM_CONTAINER_MONITOR_ENABLED`, default `true`), so resource-utilization tracking used by the opportunistic-container setup below is preserved. These tests do not exercise memory enforcement (no `KILLED_EXCEEDED_PMEM` / `KILLED_EXCEEDED_VMEM` assertions anywhere in the module).

### Why the fix is safe
- `isContainerMonitorEnabled()` reads only `NM_CONTAINER_MONITOR_ENABLED` — it does not depend on the pmem/vmem check flags, so `ContainersMonitorImpl` remains active and reports utilization for opportunistic scheduling.
- The DistributedShell tests never asserted on memory-kill behaviour; the flags were effectively unused before this change.
- Same-file behaviour is otherwise unchanged (comment updated to explain the rationale).

### How was this patch tested?
Only Linux CI can reproduce the original failure (macOS has no `/proc`, so `ProcfsBasedProcessTree` cannot sample memory locally). Relying on GHA to validate on `apache/hadoop` trunk.

### For code changes:
- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

cc @pan3793 @Hexiaoqiao
