### PR TITLE
HDFS-17943. Fix malformed error message for negative dfs.domain.socket.disable.interval.seconds

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -866,7 +866,8 @@ public class DfsClientConf {
           DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_KEY,
           DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_DEFAULT);
       Preconditions.checkArgument(domainSocketDisableIntervalSeconds >= 0,
-          DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_KEY + "can't be negative.");
+          DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_KEY
+              + " can't be negative.");
 
       keyProviderCacheExpiryMs = conf.getLong(
           DFS_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_MS,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/client/impl/TestDfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/client/impl/TestDfsClientConf.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.client.impl;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link DfsClientConf}.
+ */
+public class TestDfsClientConf {
+
+  @Test
+  public void testNegativeDomainSocketDisableIntervalErrorMessage() {
+    Configuration conf = new Configuration();
+    conf.setLong(DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_KEY, -1);
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new DfsClientConf(conf));
+    assertEquals(DFS_DOMAIN_SOCKET_DISABLE_INTERVAL_SECOND_KEY
+        + " can't be negative.", e.getMessage());
+  }
+}


### PR DESCRIPTION
### Description of PR

This PR fixes [HDFS-17943](https://issues.apache.org/jira/browse/HDFS-17943).

When `dfs.domain.socket.disable.interval.seconds` is set to a negative value, the client fails with a malformed error message — a space is missing between the configuration key and the rest of the message:

```
java.lang.IllegalArgumentException: dfs.domain.socket.disable.interval.secondscan't be negative.
```

This change adds the missing space in the `Preconditions.checkArgument` message in `DfsClientConf.ShortCircuitConf`, so the message now reads:

```
dfs.domain.socket.disable.interval.seconds can't be negative.
```

### How was this patch tested?

Added `TestDfsClientConf#testNegativeDomainSocketDisableIntervalErrorMessage`, which sets the config to `-1` and asserts that constructing `DfsClientConf` throws `IllegalArgumentException` with the corrected message. The test fails on trunk (reproducing the malformed message) and passes with this change:

```
mvn -pl hadoop-hdfs-project/hadoop-hdfs-client test -Dtest=TestDfsClientConf
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`checkstyle` reports no new violations for the touched files.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by Claude Code.

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
