### PR TITLE
HADOOP-15190. Replace Clover with JaCoCo for code coverage

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -149,9 +149,18 @@ Maven build goals:
  * Run checkstyle            : mvn compile checkstyle:checkstyle
  * Install JAR in M2 cache   : mvn install
  * Deploy JAR to Maven repo  : mvn deploy
- * Run JaCoCo coverage       : mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true
+ * Run JaCoCo coverage       : mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true --fail-at-end
                                (aggregate report: hadoop-coverage/target/site/jacoco-aggregate/index.html;
-                                must be a full-reactor build, not -pl hadoop-coverage)
+                                must be a full-reactor build, not -pl hadoop-coverage.
+                                --fail-at-end keeps the reactor building/testing the modules
+                                that don't depend on a hard-failing one (each writing its
+                                target/jacoco.exec) instead of stopping at the first failure;
+                                hadoop-coverage does not depend on the catalog-webapp war, so
+                                it still runs report-aggregate at the verify phase.
+                                -Dmaven.test.failure.ignore=true only tolerates surefire *test*
+                                failures; a plugin-level hard failure (e.g. the catalog-webapp
+                                jasmine/PhantomJS browser test in a headless container) would
+                                otherwise stop the reactor before the report is produced.)
  * Run Rat                   : mvn apache-rat:check
  * Build javadocs            : mvn javadoc:javadoc
  * Build distribution        : mvn package [-Pdist][-Pdocs][-Psrc][-Pnative][-Dtar][-Preleasedocs][-Pyarn-ui]

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -149,18 +149,8 @@ Maven build goals:
  * Run checkstyle            : mvn compile checkstyle:checkstyle
  * Install JAR in M2 cache   : mvn install
  * Deploy JAR to Maven repo  : mvn deploy
- * Run JaCoCo coverage       : mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true --fail-at-end
-                               (aggregate report: hadoop-coverage/target/site/jacoco-aggregate/index.html;
-                                must be a full-reactor build, not -pl hadoop-coverage.
-                                --fail-at-end keeps the reactor building/testing the modules
-                                that don't depend on a hard-failing one (each writing its
-                                target/jacoco.exec) instead of stopping at the first failure;
-                                hadoop-coverage does not depend on the catalog-webapp war, so
-                                it still runs report-aggregate at the verify phase.
-                                -Dmaven.test.failure.ignore=true only tolerates surefire *test*
-                                failures; a plugin-level hard failure (e.g. the catalog-webapp
-                                jasmine/PhantomJS browser test in a headless container) would
-                                otherwise stop the reactor before the report is produced.)
+ * Run JaCoCo coverage       : mvn verify -Djacoco.skip=false -Dmaven.test.failure.ignore=true --fail-at-end
+                               (see 'Special plugins: JaCoCo code coverage' below)
  * Run Rat                   : mvn apache-rat:check
  * Build javadocs            : mvn javadoc:javadoc
  * Build distribution        : mvn package [-Pdist][-Pdocs][-Psrc][-Pnative][-Dtar][-Preleasedocs][-Pyarn-ui]
@@ -270,6 +260,24 @@ Maven build goals:
    of this project for known CVEs (security vulnerabilities against them).
    It will produce a report in target/dependency-check-report.html. To
    invoke, run 'mvn dependency-check:aggregate'.
+
+ Special plugins: JaCoCo code coverage:
+
+   Coverage is opt-in and off by default. Enable it with -Djacoco.skip=false
+   (jacoco.skip is the jacoco-maven-plugin's own skip property); the aggregate
+   report is written to hadoop-coverage/target/site/jacoco-aggregate/index.html.
+
+   It must be a full-reactor build (not -pl hadoop-coverage): report-aggregate
+   only sees modules that are part of the same reactor.
+
+   --fail-at-end keeps the reactor building/testing the modules that do not
+   depend on a hard-failing one (each writing its target/jacoco.exec) instead
+   of stopping at the first failure, so hadoop-coverage still runs
+   report-aggregate at the verify phase. -Dmaven.test.failure.ignore=true only
+   tolerates surefire *test* failures; a plugin-level hard failure (e.g. the
+   catalog-webapp jasmine/PhantomJS browser test, which cannot start a browser
+   in a headless container) would otherwise stop the reactor before the report
+   is produced.
 
  PMDK library build options:
 

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -149,7 +149,9 @@ Maven build goals:
  * Run checkstyle            : mvn compile checkstyle:checkstyle
  * Install JAR in M2 cache   : mvn install
  * Deploy JAR to Maven repo  : mvn deploy
- * Run clover                : mvn test -Pclover
+ * Run JaCoCo coverage       : mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true
+                               (aggregate report: hadoop-coverage/target/site/jacoco-aggregate/index.html;
+                                must be a full-reactor build, not -pl hadoop-coverage)
  * Run Rat                   : mvn apache-rat:check
  * Build javadocs            : mvn javadoc:javadoc
  * Build distribution        : mvn package [-Pdist][-Pdocs][-Psrc][-Pnative][-Dtar][-Preleasedocs][-Pyarn-ui]

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -150,7 +150,6 @@ Maven build goals:
  * Install JAR in M2 cache   : mvn install
  * Deploy JAR to Maven repo  : mvn deploy
  * Run JaCoCo coverage       : mvn verify -Djacoco.skip=false -Dmaven.test.failure.ignore=true --fail-at-end
-                               (see 'Special plugins: JaCoCo code coverage' below)
  * Run Rat                   : mvn apache-rat:check
  * Build javadocs            : mvn javadoc:javadoc
  * Build distribution        : mvn package [-Pdist][-Pdocs][-Psrc][-Pnative][-Dtar][-Preleasedocs][-Pyarn-ui]

--- a/dev-support/bin/check-coverage-modules.sh
+++ b/dev-support/bin/check-coverage-modules.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: check-coverage-modules.sh <repo-root> <coverage-pom>
+#
+# Guards the hadoop-coverage aggregate module against silent drift: every
+# "test-bearing" Maven module (jar packaging with a src/test/java directory)
+# must either be listed as a dependency in hadoop-coverage/pom.xml or be named
+# in dev-support/coverage-modules-allowlist.txt. If a test-bearing module is in
+# neither, its coverage would be silently dropped from the aggregate report, so
+# the build fails with a message telling the developer which module to add and
+# where.
+#
+# The check inspects the source tree (not the Maven reactor), so it behaves the
+# same under a full-reactor build and a partial `-pl` build.
+#
+# Scope and limitations (intentional, to keep the check simple):
+#   - Modules are matched by artifactId only, not by groupId or version. The
+#     check ensures a module is *present* in the aggregate; it does not validate
+#     that its coordinates resolve. A wrong groupId/version is a Maven-resolution
+#     error, surfaced by the build itself, not by this guard.
+#   - "Covered" artifactIds are read from the coverage pom's top-level
+#     <dependencies>. The coverage pom deliberately has no <dependencyManagement>
+#     or plugin-level <dependencies>; if that changes, revisit the awk below.
+#   - <artifactId>/<packaging>/<parent> tags are assumed to sit on a single line
+#     each (the Hadoop pom convention); a multi-line element would be misparsed.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <repo-root> <coverage-pom>" >&2
+  exit 2
+fi
+
+repo_root="$1"
+coverage_pom="$2"
+allowlist="${repo_root}/dev-support/coverage-modules-allowlist.txt"
+
+if [[ ! -f "${coverage_pom}" ]]; then
+  echo "check-coverage-modules: coverage pom not found: ${coverage_pom}" >&2
+  exit 2
+fi
+
+# Print a module's own artifactId: the first <artifactId> after </parent>.
+# Hadoop poms always declare <parent> before the module's own coordinates, and
+# <dependencies> come afterwards, so the first match is the module itself.
+module_artifact_id() {
+  awk '
+    /<\/parent>/ { seen_parent = 1; next }
+    seen_parent && match($0, /<artifactId>[^<]+<\/artifactId>/) {
+      s = substr($0, RSTART, RLENGTH)
+      gsub(/<\/?artifactId>/, "", s)
+      gsub(/[[:space:]]/, "", s)
+      print s
+      exit
+    }
+  ' "$1"
+}
+
+# Print a module's packaging (defaults to "jar" when absent). A <parent> block
+# never carries a <packaging>, so the first match is the module's own.
+module_packaging() {
+  local pkg
+  pkg="$(grep -oE '<packaging>[^<]+</packaging>' "$1" | head -1 \
+         | sed -E 's#</?packaging>##g' | tr -d '[:space:]' || true)"
+  echo "${pkg:-jar}"
+}
+
+# Test-bearing modules: jar packaging AND a src/test/java directory.
+test_bearing_file="$(mktemp)"
+covered_file="$(mktemp)"
+allowed_file="$(mktemp)"
+trap 'rm -f "${test_bearing_file}" "${covered_file}" "${allowed_file}"' EXIT
+
+while IFS= read -r pom; do
+  dir="$(dirname "${pom}")"
+  [[ -d "${dir}/src/test/java" ]] || continue
+  [[ "$(module_packaging "${pom}")" == "jar" ]] || continue
+  aid="$(module_artifact_id "${pom}")"
+  [[ -n "${aid}" ]] && echo "${aid}"
+done < <(find "${repo_root}" -name pom.xml -not -path '*/target/*') \
+  | sort -u > "${test_bearing_file}"
+
+# Sanity check: finding zero test-bearing modules means the tree was not scanned
+# (wrong repo-root, relocated script). Fail loudly rather than pass vacuously.
+if [[ ! -s "${test_bearing_file}" ]]; then
+  echo "check-coverage-modules: no test-bearing modules found under" \
+       "'${repo_root}' -- wrong repo root?" >&2
+  exit 2
+fi
+
+# Covered modules: org.apache.hadoop artifactIds inside the coverage pom's
+# top-level <dependencies> block.
+awk '/<dependencies>/{d=1} /<\/dependencies>/{d=0} d' "${coverage_pom}" \
+  | grep -oE '<artifactId>[^<]+</artifactId>' \
+  | sed -E 's#</?artifactId>##g; s/[[:space:]]//g' \
+  | sort -u > "${covered_file}"
+
+# Allowlist: intentionally-excluded test-bearing modules (ignore blanks/comments).
+if [[ -f "${allowlist}" ]]; then
+  grep -vE '^[[:space:]]*(#|$)' "${allowlist}" | sed 's/[[:space:]]//g' \
+    | sort -u > "${allowed_file}"
+else
+  : > "${allowed_file}"
+fi
+
+# Missing = test-bearing modules that are neither covered nor allowlisted.
+missing="$(comm -23 "${test_bearing_file}" \
+             <(sort -u "${covered_file}" "${allowed_file}"))"
+
+# Non-fatal hygiene warning: allowlist entries that are no longer test-bearing.
+stale="$(comm -13 "${test_bearing_file}" "${allowed_file}")"
+if [[ -n "${stale}" ]]; then
+  echo "check-coverage-modules: WARNING: stale allowlist entries (no longer a" \
+       "test-bearing jar module); consider removing from" \
+       "dev-support/coverage-modules-allowlist.txt:" >&2
+  while IFS= read -r module; do echo "  - ${module}" >&2; done <<< "${stale}"
+fi
+
+if [[ -n "${missing}" ]]; then
+  echo "" >&2
+  echo "check-coverage-modules: FAILED" >&2
+  echo "The following test-bearing modules are missing from the coverage" \
+       "aggregate:" >&2
+  while IFS= read -r module; do echo "  - ${module}" >&2; done <<< "${missing}"
+  echo "" >&2
+  echo "Add each as a <dependency> in hadoop-coverage/pom.xml so its coverage" >&2
+  echo "is aggregated, or, if it is intentionally excluded, add it to" >&2
+  echo "dev-support/coverage-modules-allowlist.txt (with a reason)." >&2
+  exit 1
+fi
+
+count="$(wc -l < "${test_bearing_file}" | tr -d ' ')"
+echo "check-coverage-modules: OK (${count} test-bearing modules accounted for)"

--- a/dev-support/coverage-modules-allowlist.txt
+++ b/dev-support/coverage-modules-allowlist.txt
@@ -1,0 +1,21 @@
+# Modules that ARE test-bearing (jar packaging with a src/test/java directory)
+# but are deliberately excluded from the hadoop-coverage aggregate report.
+#
+# Every other test-bearing module MUST be listed as a <dependency> in
+# hadoop-coverage/pom.xml, or the build fails. See:
+#   dev-support/bin/check-coverage-modules.sh
+#
+# Non-test-bearing modules (dist/assembly, shaded client jars, native-only,
+# stub/alias, benchmark, war/ui) do NOT need to be listed here: the guard only
+# considers jar modules that have a src/test/java directory.
+#
+# Format: one artifactId per line; blank lines and lines starting with # ignored.
+
+# Example code, already excluded from coverage via the **/examples/** class
+# pattern in hadoop-project/pom.xml (jacoco prepare-agent) and the matching
+# exclude in hadoop-coverage/pom.xml (report-aggregate).
+hadoop-mapreduce-examples
+
+# Test-only module (no main classes of its own); it exercises the shaded client
+# jars rather than contributing coverage for its own code.
+hadoop-client-integration-tests

--- a/hadoop-cloud-storage-project/hadoop-bos/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-bos/pom.xml
@@ -262,7 +262,7 @@
             <configuration>
               <forkCount>${testsThreadCount}</forkCount>
               <reuseForks>false</reuseForks>
-              <argLine>${maven-surefire-plugin.argLine}</argLine>
+              <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
               <systemPropertyVariables>
                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>

--- a/hadoop-cloud-storage-project/hadoop-gcp/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-gcp/pom.xml
@@ -88,7 +88,7 @@
               <forkCount>${testsThreadCount}</forkCount>
               <reuseForks>false</reuseForks>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+              <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
               <systemPropertyVariables>
                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>
@@ -111,7 +111,7 @@
                 <configuration>
                   <forkCount>${testsThreadCount}</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.gs.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <trimStackTrace>false</trimStackTrace>
                   <systemPropertyVariables>

--- a/hadoop-cloud-storage-project/hadoop-tos/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-tos/pom.xml
@@ -159,7 +159,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${maven-surefire-plugin.argLine} -Xmx2048m</argLine>
+          <argLine>${maven-surefire-plugin.argLine} @{argLine} -Xmx2048m</argLine>
           <parallel>classes</parallel>
           <threadCount>1</threadCount>
           <perCoreThreadCount>true</perCoreThreadCount>
@@ -208,7 +208,7 @@
                         <configuration>
                             <forkCount>${testsThreadCount}</forkCount>
                             <reuseForks>false</reuseForks>
-                            <argLine>${maven-surefire-plugin.argLine}</argLine>
+                            <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
                             <systemPropertyVariables>
                                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -1019,7 +1019,7 @@
             <configuration>
               <forkCount>${testsThreadCount}</forkCount>
               <reuseForks>false</reuseForks>
-              <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+              <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
               <systemPropertyVariables>
                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>

--- a/hadoop-common-project/hadoop-registry/pom.xml
+++ b/hadoop-common-project/hadoop-registry/pom.xml
@@ -253,7 +253,7 @@
       <configuration>
         <reuseForks>false</reuseForks>
         <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
-        <argLine>${maven-surefire-plugin.argLine} -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError</argLine>
+        <argLine>${maven-surefire-plugin.argLine} @{argLine} -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError</argLine>
         <environmentVariables>
           <!-- HADOOP_HOME required for tests on Windows to find winutils -->
           <HADOOP_HOME>${hadoop.common.build.dir}</HADOOP_HOME>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hadoop</groupId>
+    <artifactId>hadoop-main</artifactId>
+    <version>3.6.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <groupId>org.apache.hadoop</groupId>
+  <artifactId>hadoop-coverage</artifactId>
+  <version>3.6.0-SNAPSHOT</version>
+  <description>Hadoop JaCoCo Aggregate Coverage</description>
+  <name>Hadoop JaCoCo Aggregate Coverage</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- Coverage-only helper module; never publish it to a Maven repository. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.install.skip>true</maven.install.skip>
+  </properties>
+
+  <!--
+    This module collects JaCoCo exec data from all sub-modules and produces
+    an aggregate HTML/XML coverage report under target/site/jacoco-aggregate/.
+
+    The report-aggregate goal only sees sibling modules that are part of the
+    same Maven reactor, so it must be run over the full project (not with
+    "-pl hadoop-coverage", which would leave every other module out of the
+    reactor and produce an empty report). Run tests and the report in a
+    single reactor pass:
+
+      mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true
+
+    hadoop-coverage builds last (it depends on every module), so the aggregate
+    report is generated after all tests have run. -Dmaven.test.failure.ignore=true
+    lets the report be produced even when some tests fail.
+
+    The aggregate report will be at:
+      hadoop-coverage/target/site/jacoco-aggregate/index.html
+  -->
+
+  <dependencies>
+    <!-- hadoop-common-project -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-kms</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-nfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-registry</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- hadoop-hdfs-project -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-nfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-rbf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-httpfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- hadoop-yarn-project -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-registry</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-csi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-applications-distributedshell</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-applications-unmanaged-am-launcher</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-nodemanager</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timeline-pluginstorage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-router</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-sharedcachemanager</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-globalpolicygenerator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-services-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- hadoop-mapreduce-project -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-app</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-hs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-hs-plugins</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- hadoop-tools -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-streaming</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-distcp</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-archives</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-archive-logs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-rumen</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-datajoin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-extras</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-gridmix</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-resourceestimator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-sls</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-federation-balance</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-azure</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-azure-datalake</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aliyun</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-kafka</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- hadoop-cloud-storage-project -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-cos</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-gcp</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-huaweicloud</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-tos</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Additional test-bearing modules so their coverage is included.
+         Only jar-packaged modules may be listed here: a plain dependency on a
+         war module (e.g. hadoop-yarn-applications-catalog-webapp) resolves to a
+         non-existent jar artifact and breaks this module's build. -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-nativetask</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-uploader</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-fs2img</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-compat-bench</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-dynamometer-blockgen</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-dynamometer-infra</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-dynamometer-workload</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-documentstore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-hbase-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-hbase-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-hbase-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-applications-mawo-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-services-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <configuration>
+              <skip>${hadoop.skip-jacoco}</skip>
+              <excludes>
+                <exclude>**/generated/**/*.class</exclude>
+                <exclude>**/examples/**/*.class</exclude>
+                <exclude>**/hamlet/*.class</exclude>
+                <exclude>**/proto/*.class</exclude>
+                <exclude>**/protobuf/*.class</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -26,8 +26,8 @@
   <groupId>org.apache.hadoop</groupId>
   <artifactId>hadoop-coverage</artifactId>
   <version>3.6.0-SNAPSHOT</version>
-  <description>Hadoop JaCoCo Aggregate Coverage</description>
-  <name>Hadoop JaCoCo Aggregate Coverage</name>
+  <description>Hadoop Aggregate Code Coverage</description>
+  <name>Hadoop Aggregate Code Coverage</name>
   <packaging>pom</packaging>
 
   <properties>
@@ -419,7 +419,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
+      <groupId>org.apache.hadoop.applications.mawo</groupId>
       <artifactId>hadoop-yarn-applications-mawo-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -432,6 +432,34 @@
 
   <build>
     <plugins>
+      <!--
+        Guard against silent drift of the dependency list above: every
+        test-bearing module must be aggregated here (or explicitly allowlisted),
+        otherwise its coverage is silently dropped from the report. This check
+        runs regardless of hadoop.skip-jacoco, since list correctness is
+        independent of whether coverage data is collected.
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check-coverage-modules</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${shell-executable}</executable>
+              <arguments>
+                <argument>${project.basedir}/../dev-support/bin/check-coverage-modules.sh</argument>
+                <argument>${project.basedir}/..</argument>
+                <argument>${project.basedir}/pom.xml</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -435,9 +435,10 @@
       <!--
         Guard against silent drift of the dependency list above: every
         test-bearing module must be aggregated here (or explicitly allowlisted),
-        otherwise its coverage is silently dropped from the report. This check
-        runs regardless of hadoop.skip-jacoco, since list correctness is
-        independent of whether coverage data is collected.
+        otherwise its coverage is silently dropped from the report. This module
+        is only in the reactor when coverage is requested (-Dhadoop.skip-jacoco=false;
+        see the "coverage" profile in the root pom), so the check runs on every
+        coverage build, at the validate phase before report-aggregate.
       -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -452,7 +452,7 @@
             <configuration>
               <executable>${shell-executable}</executable>
               <arguments>
-                <argument>${project.basedir}/../dev-support/bin/check-coverage-modules.sh</argument>
+                <argument>${project.basedir}/src/test/resources/check-coverage-modules.sh</argument>
                 <argument>${project.basedir}/..</argument>
                 <argument>${project.basedir}/pom.xml</argument>
               </arguments>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -34,6 +34,10 @@
     <!-- Coverage-only helper module; never publish it to a Maven repository. -->
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.install.skip>true</maven.install.skip>
+    <!-- This module's parent is hadoop-main, not hadoop-project, so it does not
+         inherit hadoop-project's plugin version management. Pin the one plugin
+         it uses (exec-maven-plugin, for the module-list guard below) here. -->
+    <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
   </properties>
 
   <!--
@@ -443,6 +447,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>check-coverage-modules</id>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -339,6 +339,11 @@
     <!-- hadoop-cloud-storage-project -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-bos</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-cos</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -46,7 +46,7 @@
     reactor and produce an empty report). Run tests and the report in a
     single reactor pass:
 
-      mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true
+      mvn verify -Djacoco.skip=false -Dmaven.test.failure.ignore=true
 
     hadoop-coverage builds last (it depends on every module), so the aggregate
     report is generated after all tests have run. -Dmaven.test.failure.ignore=true
@@ -436,7 +436,7 @@
         Guard against silent drift of the dependency list above: every
         test-bearing module must be aggregated here (or explicitly allowlisted),
         otherwise its coverage is silently dropped from the report. This module
-        is only in the reactor when coverage is requested (-Dhadoop.skip-jacoco=false;
+        is only in the reactor when coverage is requested (-Djacoco.skip=false;
         see the "coverage" profile in the root pom), so the check runs on every
         coverage build, at the validate phase before report-aggregate.
       -->
@@ -472,7 +472,6 @@
               <goal>report-aggregate</goal>
             </goals>
             <configuration>
-              <skip>${hadoop.skip-jacoco}</skip>
               <excludes>
                 <exclude>**/generated/**/*.class</exclude>
                 <exclude>**/examples/**/*.class</exclude>

--- a/hadoop-coverage/pom.xml
+++ b/hadoop-coverage/pom.xml
@@ -442,12 +442,14 @@
   <build>
     <plugins>
       <!--
-        Guard against silent drift of the dependency list above: every
-        test-bearing module must be aggregated here (or explicitly allowlisted),
-        otherwise its coverage is silently dropped from the report. This module
-        is only in the reactor when coverage is requested (-Djacoco.skip=false;
-        see the "coverage" profile in the root pom), so the check runs on every
-        coverage build, at the validate phase before report-aggregate.
+        Guard against two silent coverage gaps: (1) every test-bearing module
+        must be aggregated here (or explicitly allowlisted), and (2) any module
+        that overrides the Surefire/Failsafe <argLine> must keep the @{argLine}
+        token, or JaCoCo does not instrument it. Either gap fails the build.
+        This module is only in the reactor when coverage is requested
+        (-Djacoco.skip=false; see the "coverage" profile in the root pom), so the
+        check runs on every coverage build, at the validate phase before
+        report-aggregate.
       -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/hadoop-coverage/src/test/resources/check-coverage-modules.sh
+++ b/hadoop-coverage/src/test/resources/check-coverage-modules.sh
@@ -20,8 +20,9 @@
 # Guards the hadoop-coverage aggregate module against silent drift: every
 # "test-bearing" Maven module (jar packaging with a src/test/java directory)
 # must either be listed as a dependency in hadoop-coverage/pom.xml or be named
-# in dev-support/coverage-modules-allowlist.txt. If a test-bearing module is in
-# neither, its coverage would be silently dropped from the aggregate report, so
+# in the coverage-modules-allowlist.txt sitting next to this script. If a
+# test-bearing module is in neither, its coverage would be silently dropped from
+# the aggregate report, so
 # the build fails with a message telling the developer which module to add and
 # where.
 #
@@ -48,7 +49,10 @@ fi
 
 repo_root="$1"
 coverage_pom="$2"
-allowlist="${repo_root}/dev-support/coverage-modules-allowlist.txt"
+# The allowlist lives next to this script so the two move together; locate it
+# relative to the script rather than the repo root.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+allowlist="${script_dir}/coverage-modules-allowlist.txt"
 
 if [[ ! -f "${coverage_pom}" ]]; then
   echo "check-coverage-modules: coverage pom not found: ${coverage_pom}" >&2
@@ -127,7 +131,7 @@ stale="$(comm -13 "${test_bearing_file}" "${allowed_file}")"
 if [[ -n "${stale}" ]]; then
   echo "check-coverage-modules: WARNING: stale allowlist entries (no longer a" \
        "test-bearing jar module); consider removing from" \
-       "dev-support/coverage-modules-allowlist.txt:" >&2
+       "hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt:" >&2
   while IFS= read -r module; do echo "  - ${module}" >&2; done <<< "${stale}"
 fi
 
@@ -140,7 +144,8 @@ if [[ -n "${missing}" ]]; then
   echo "" >&2
   echo "Add each as a <dependency> in hadoop-coverage/pom.xml so its coverage" >&2
   echo "is aggregated, or, if it is intentionally excluded, add it to" >&2
-  echo "dev-support/coverage-modules-allowlist.txt (with a reason)." >&2
+  echo "hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt" >&2
+  echo "(with a reason)." >&2
   exit 1
 fi
 

--- a/hadoop-coverage/src/test/resources/check-coverage-modules.sh
+++ b/hadoop-coverage/src/test/resources/check-coverage-modules.sh
@@ -17,14 +17,20 @@
 
 # Usage: check-coverage-modules.sh <repo-root> <coverage-pom>
 #
-# Guards the hadoop-coverage aggregate module against silent drift: every
-# "test-bearing" Maven module (jar packaging with a src/test/java directory)
-# must either be listed as a dependency in hadoop-coverage/pom.xml or be named
-# in the coverage-modules-allowlist.txt sitting next to this script. If a
-# test-bearing module is in neither, its coverage would be silently dropped from
-# the aggregate report, so
-# the build fails with a message telling the developer which module to add and
-# where.
+# Guards the hadoop-coverage aggregate module against two silent coverage gaps:
+#
+#   1. Missing module: every "test-bearing" Maven module (jar packaging with a
+#      src/test/java directory) must either be a <dependency> in
+#      hadoop-coverage/pom.xml or be named in the coverage-modules-allowlist.txt
+#      sitting next to this script. A test-bearing module in neither is silently
+#      dropped from the aggregate report.
+#
+#   2. Dropped instrumentation: a test-bearing module that overrides the
+#      Surefire/Failsafe <argLine> must keep the @{argLine} token. A module-level
+#      <argLine> fully replaces the inherited one, so omitting @{argLine} detaches
+#      the JaCoCo agent and the module reports empty coverage with no error.
+#
+# Either problem fails the build with a message telling the developer what to fix.
 #
 # The check inspects the source tree (not the Maven reactor), so it behaves the
 # same under a full-reactor build and a partial `-pl` build.
@@ -37,8 +43,9 @@
 #   - "Covered" artifactIds are read from the coverage pom's top-level
 #     <dependencies>. The coverage pom deliberately has no <dependencyManagement>
 #     or plugin-level <dependencies>; if that changes, revisit the awk below.
-#   - <artifactId>/<packaging>/<parent> tags are assumed to sit on a single line
-#     each (the Hadoop pom convention); a multi-line element would be misparsed.
+#   - <artifactId>/<packaging>/<parent> and <argLine> tags are assumed to sit on
+#     a single line each (the Hadoop pom convention); a multi-line element would
+#     be misparsed.
 
 set -euo pipefail
 
@@ -88,7 +95,8 @@ module_packaging() {
 test_bearing_file="$(mktemp)"
 covered_file="$(mktemp)"
 allowed_file="$(mktemp)"
-trap 'rm -f "${test_bearing_file}" "${covered_file}" "${allowed_file}"' EXIT
+argline_bad_file="$(mktemp)"
+trap 'rm -f "${test_bearing_file}" "${covered_file}" "${allowed_file}" "${argline_bad_file}"' EXIT
 
 while IFS= read -r pom; do
   dir="$(dirname "${pom}")"
@@ -122,6 +130,26 @@ else
   : > "${allowed_file}"
 fi
 
+# Instrumentation check: a module-level <argLine> fully replaces the inherited
+# Surefire/Failsafe argLine, so a test-bearing module that overrides <argLine>
+# but omits the @{argLine} token silently detaches the JaCoCo agent and reports
+# empty coverage. Flag any such module; allowlisted (excluded) modules are skipped
+# since they are not aggregated anyway.
+while IFS= read -r pom; do
+  dir="$(dirname "${pom}")"
+  [[ -d "${dir}/src/test/java" ]] || continue
+  [[ "$(module_packaging "${pom}")" == "jar" ]] || continue
+  grep -q '<argLine>' "${pom}" || continue
+  # Offending if any <argLine> override lacks the @{argLine} token.
+  if grep '<argLine>' "${pom}" | grep -Fqv '@{argLine}'; then
+    aid="$(module_artifact_id "${pom}")"
+    [[ -n "${aid}" ]] && echo "${aid}"
+  fi
+done < <(find "${repo_root}" -name pom.xml -not -path '*/target/*') \
+  | sort -u > "${argline_bad_file}"
+
+argline_missing="$(comm -23 "${argline_bad_file}" "${allowed_file}")"
+
 # Missing = test-bearing modules that are neither covered nor allowlisted.
 missing="$(comm -23 "${test_bearing_file}" \
              <(sort -u "${covered_file}" "${allowed_file}"))"
@@ -135,6 +163,8 @@ if [[ -n "${stale}" ]]; then
   while IFS= read -r module; do echo "  - ${module}" >&2; done <<< "${stale}"
 fi
 
+failed=0
+
 if [[ -n "${missing}" ]]; then
   echo "" >&2
   echo "check-coverage-modules: FAILED" >&2
@@ -146,8 +176,28 @@ if [[ -n "${missing}" ]]; then
   echo "is aggregated, or, if it is intentionally excluded, add it to" >&2
   echo "hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt" >&2
   echo "(with a reason)." >&2
+  failed=1
+fi
+
+if [[ -n "${argline_missing}" ]]; then
+  echo "" >&2
+  echo "check-coverage-modules: FAILED" >&2
+  echo "The following test-bearing modules override the Surefire/Failsafe" \
+       "<argLine> without the @{argLine} token, so JaCoCo cannot instrument" \
+       "them and their coverage is silently empty:" >&2
+  while IFS= read -r module; do echo "  - ${module}" >&2; done <<< "${argline_missing}"
+  echo "" >&2
+  echo "Append @{argLine} to each module's <argLine>, e.g." >&2
+  echo "  <argLine>\${maven-surefire-plugin.argLine} @{argLine}</argLine>" >&2
+  echo "or, if the module is intentionally excluded from coverage, add it to" >&2
+  echo "hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt." >&2
+  failed=1
+fi
+
+if [[ "${failed}" -ne 0 ]]; then
   exit 1
 fi
 
 count="$(wc -l < "${test_bearing_file}" | tr -d ' ')"
-echo "check-coverage-modules: OK (${count} test-bearing modules accounted for)"
+echo "check-coverage-modules: OK (${count} test-bearing modules accounted for," \
+     "all instrumented)"

--- a/hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt
+++ b/hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt
@@ -16,6 +16,8 @@
 
 # Modules that ARE test-bearing (jar packaging with a src/test/java directory)
 # but are deliberately excluded from the hadoop-coverage aggregate report.
+# Modules listed here are also exempt from the guard's <argLine>/@{argLine}
+# instrumentation check, since they are not aggregated.
 #
 # Every other test-bearing module MUST be listed as a <dependency> in
 # hadoop-coverage/pom.xml, or the build fails. See:

--- a/hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt
+++ b/hadoop-coverage/src/test/resources/coverage-modules-allowlist.txt
@@ -1,9 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Modules that ARE test-bearing (jar packaging with a src/test/java directory)
 # but are deliberately excluded from the hadoop-coverage aggregate report.
 #
 # Every other test-bearing module MUST be listed as a <dependency> in
 # hadoop-coverage/pom.xml, or the build fails. See:
-#   dev-support/bin/check-coverage-modules.sh
+#   hadoop-coverage/src/test/resources/check-coverage-modules.sh
 #
 # Non-test-bearing modules (dist/assembly, shaded client jars, native-only,
 # stub/alias, benchmark, war/ui) do NOT need to be listed here: the guard only

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-examples/test-libhdfs.sh
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-examples/test-libhdfs.sh
@@ -24,7 +24,6 @@
 # c) LIBHDFS_BUILD_DIR - optional; the location of the hdfs_test
 # executable. Defaults to the parent directory.
 # d) OS_NAME - used to choose how to locate libjvm.so
-# e) CLOVER_JAR - optional; the location of the Clover code coverage tool's jar.
 #
 
 if [ "x$HADOOP_HOME" == "x" ]; then
@@ -58,9 +57,6 @@ echo "Found HDFS test jar at $HDFS_TEST_JAR"
 # CLASSPATH initially contains $HDFS_TEST_CONF_DIR
 CLASSPATH="${HDFS_TEST_CONF_DIR}"
 CLASSPATH=${CLASSPATH}:$JAVA_HOME/lib/tools.jar
-
-# add Clover jar file needed for code coverage runs
-CLASSPATH=${CLASSPATH}:${CLOVER_JAR};
 
 # so that filenames w/ spaces are handled correctly in loops below
 IFS=$'\n'

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -372,7 +372,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <configuration>
               <forkCount>${testsThreadCount}</forkCount>
               <reuseForks>false</reuseForks>
-              <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+              <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
               <systemPropertyVariables>
                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>

--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -508,7 +508,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <configuration>
               <forkCount>${testsThreadCount}</forkCount>
               <reuseForks>false</reuseForks>
-              <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+              <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
               <systemPropertyVariables>
                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/pom.xml
@@ -151,23 +151,6 @@
 
   </dependencies>
 
- <profiles>
-  <profile>
-    <id>clover</id>
-    <activation>
-      <activeByDefault>false</activeByDefault>
-      <property>
-        <name>clover</name>
-      </property>
-    </activation>
-    <dependencies>
-      <dependency>
-        <groupId>com.cenqua.clover</groupId>
-        <artifactId>clover</artifactId>
-      </dependency>
-    </dependencies>
-  </profile>
-</profiles>
   <build>
     <plugins>
       <plugin>

--- a/hadoop-maven-plugins/pom.xml
+++ b/hadoop-maven-plugins/pom.xml
@@ -119,17 +119,6 @@
           </execution>
         </executions>
       </plugin>
-      <!--
-      Skip Clover instrumentation for this module to prevent error finding Clover
-      classes during plugin execution when running a build with Clover enabled.
-      -->
-      <plugin>
-        <groupId>org.openclover</groupId>
-        <artifactId>clover-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2368,14 +2368,14 @@
           <version>${avro.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>${exec-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${exec-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -206,7 +206,6 @@
     <maven-pdf-plugin.version>1.2</maven-pdf-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
-    <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
@@ -2371,11 +2370,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>${exec-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -204,6 +204,7 @@
     <maven-pdf-plugin.version>1.2</maven-pdf-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
+    <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
@@ -2365,6 +2366,11 @@
           <groupId>org.apache.avro</groupId>
           <artifactId>avro-maven-plugin</artifactId>
           <version>${avro.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${exec-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -185,8 +185,6 @@
       --add-opens=java.base/sun.security.x509=ALL-UNNAMED
       --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
-    <!-- Skip JaCoCo instrumentation by default; enable with -Dhadoop.skip-jacoco=false -->
-    <hadoop.skip-jacoco>true</hadoop.skip-jacoco>
 
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -Xss4m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
@@ -2315,6 +2313,8 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
+            <!-- @{argLine} injects the JaCoCo agent when coverage is enabled;
+                 see the maven-surefire-plugin configuration below for details. -->
             <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
           </configuration>
         </plugin>
@@ -2588,6 +2588,15 @@
         <configuration>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>${surefire.fork.timeout}</forkedProcessTimeoutInSeconds>
+          <!-- @{argLine} is Surefire's late (deferred) property substitution: it
+               is replaced at test-run time with the value of the "argLine"
+               property. jacoco:prepare-agent sets that property to the
+               -javaagent:...jacocoagent.jar=... option when coverage is enabled
+               (see jacoco-maven-plugin above), so the agent is injected into the
+               forked test JVM. When coverage is off (jacoco.skip=true, the
+               default) prepare-agent is skipped, argLine is unset, and @{argLine}
+               resolves to empty. ${maven-surefire-plugin.argLine} is our own
+               static JVM args, kept separate. -->
           <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
           <environmentVariables>
             <HADOOP_COMMON_HOME>${hadoop.common.build.dir}</HADOOP_COMMON_HOME>
@@ -2634,7 +2643,8 @@
               <goal>prepare-agent</goal>
             </goals>
             <configuration>
-              <skip>${hadoop.skip-jacoco}</skip>
+              <!-- skip is inherited from the jacoco.skip property (default true
+                   in the root pom); no explicit <skip> needed here. -->
               <!-- Exclude generated/example classes from instrumentation so
                    the agent does not spend time weaving them in every forked
                    test JVM. These are also filtered from the coverage numbers

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -185,6 +185,9 @@
       --add-opens=java.base/sun.security.x509=ALL-UNNAMED
       --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
+    <!-- Skip JaCoCo instrumentation by default; enable with -Dhadoop.skip-jacoco=false -->
+    <hadoop.skip-jacoco>true</hadoop.skip-jacoco>
+
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -Xss4m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
@@ -2313,7 +2316,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
-            <argLine>${maven-surefire-plugin.argLine}</argLine>
+            <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -2591,7 +2594,7 @@
         <configuration>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>${surefire.fork.timeout}</forkedProcessTimeoutInSeconds>
-          <argLine>${maven-surefire-plugin.argLine}</argLine>
+          <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
           <environmentVariables>
             <HADOOP_COMMON_HOME>${hadoop.common.build.dir}</HADOOP_COMMON_HOME>
             <!-- HADOOP_HOME required for tests on Windows to find winutils -->
@@ -2626,6 +2629,33 @@
             <exclude>**/Test*$*.java</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <skip>${hadoop.skip-jacoco}</skip>
+              <!-- Exclude generated/example classes from instrumentation so
+                   the agent does not spend time weaving them in every forked
+                   test JVM. These are also filtered from the coverage numbers
+                   in the report-aggregate configuration (hadoop-coverage/pom.xml);
+                   keep the two exclude lists in sync. -->
+              <excludes>
+                <exclude>**/generated/**/*.class</exclude>
+                <exclude>**/examples/**/*.class</exclude>
+                <exclude>**/hamlet/*.class</exclude>
+                <exclude>**/proto/*.class</exclude>
+                <exclude>**/protobuf/*.class</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -107,7 +107,7 @@
             <configuration>
               <forkCount>${testsThreadCount}</forkCount>
               <reuseForks>false</reuseForks>
-              <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+              <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
               <systemPropertyVariables>
                 <testsThreadCount>${testsThreadCount}</testsThreadCount>
                 <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>
@@ -138,7 +138,7 @@
                 <configuration>
                   <forkCount>${testsThreadCount}</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.s3a.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <systemPropertyVariables>
                     <!-- Tell tests that they are being executed in parallel -->

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -386,7 +386,7 @@
                 <configuration>
                   <forkCount>${testsThreadCount}</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.azure.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <systemPropertyVariables>
                     <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>
@@ -423,7 +423,7 @@
                   <reuseForks>true</reuseForks>
                   <parallel>both</parallel>
                   <threadCount>${testsThreadCount}</threadCount>
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.azure.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <systemPropertyVariables>
                     <!-- Tell tests that they are being executed in parallel -->
@@ -472,7 +472,7 @@
                   <forkCount>${testsThreadCount}</forkCount>
                   <reuseForks>false</reuseForks>
                   <!--NOTICE: hadoop contract tests methods can not be ran in parallel-->
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.azure.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <systemPropertyVariables>
                     <!-- Tell tests that they are being executed in parallel -->
@@ -569,7 +569,7 @@
                 <configuration>
                   <forkCount>${testsThreadCount}</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.azure.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <systemPropertyVariables>
                     <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>
@@ -603,7 +603,7 @@
                 <configuration>
                   <forkCount>${testsThreadCount}</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                  <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                   <forkedProcessTimeoutInSeconds>${fs.azure.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <systemPropertyVariables>
                     <!-- Tell tests that they are being executed in parallel -->

--- a/hadoop-tools/hadoop-distcp/pom.xml
+++ b/hadoop-tools/hadoop-distcp/pom.xml
@@ -152,7 +152,7 @@
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
-          <argLine>${maven-surefire-plugin.argLine} -Xmx1024m</argLine>
+          <argLine>${maven-surefire-plugin.argLine} @{argLine} -Xmx1024m</argLine>
           <includes>
             <include>**/Test*.java</include>
           </includes>

--- a/hadoop-tools/hadoop-federation-balance/pom.xml
+++ b/hadoop-tools/hadoop-federation-balance/pom.xml
@@ -162,7 +162,7 @@
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
-          <argLine>${maven-surefire-plugin.argLine} -Xmx1024m</argLine>
+          <argLine>${maven-surefire-plugin.argLine} @{argLine} -Xmx1024m</argLine>
           <includes>
             <include>**/Test*.java</include>
           </includes>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -560,7 +560,7 @@
               <configuration>
                 <forkCount>${testsThreadCount}</forkCount>
                 <reuseForks>false</reuseForks>
-                <argLine>${maven-surefire-plugin.argLine} -DminiClusterDedicatedDirs=true</argLine>
+                <argLine>${maven-surefire-plugin.argLine} @{argLine} -DminiClusterDedicatedDirs=true</argLine>
                 <systemPropertyVariables>
                   <testsThreadCount>${testsThreadCount}</testsThreadCount>
                   <test.build.data>${test.build.data}/${surefire.forkNumber}</test.build.data>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/pom.xml
@@ -41,21 +41,4 @@
     <module>hadoop-yarn-applications-mawo</module>
   </modules>
 
- <profiles>
-  <profile>
-    <id>clover</id>
-    <activation>
-      <activeByDefault>false</activeByDefault>
-      <property>
-        <name>clover</name>
-      </property>
-    </activation>
-    <dependencies>
-      <dependency>
-        <groupId>com.cenqua.clover</groupId>
-        <artifactId>clover</artifactId>
-      </dependency>
-    </dependencies>
-  </profile>
-</profiles>
 </project>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -443,13 +443,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.openclover</groupId>
-        <artifactId>clover-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,17 +23,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
   <name>Apache Hadoop Main</name>
   <packaging>pom</packaging>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.cenqua.clover</groupId>
-        <artifactId>clover</artifactId>
-        <!-- Use the version needed by maven-clover-plugin -->
-        <version>3.0.2</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <distributionManagement>
     <repository>
       <id>${distMgmtStagingId}</id>
@@ -85,6 +74,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <!-- required as child projects with different version can't use ${project.version} -->
     <hadoop.version>3.6.0-SNAPSHOT</hadoop.version>
 
+    <!-- Skip JaCoCo instrumentation/reporting by default; enable with
+         -Dhadoop.skip-jacoco=false. Defined here (not only in hadoop-project)
+         so modules that inherit directly from hadoop-main, such as
+         hadoop-coverage, resolve the property too. -->
+    <hadoop.skip-jacoco>true</hadoop.skip-jacoco>
+
     <docker.image>apache/hadoop:${project.version}</docker.image>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
@@ -113,7 +108,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <wagon-ssh.version>2.4</wagon-ssh.version>
-    <clover-maven-plugin.version>4.4.1</clover-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-bundle-plugin.version>2.5.0</maven-bundle-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -165,6 +160,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <module>hadoop-build-tools</module>
     <module>hadoop-cloud-storage-project</module>
     <module>hadoop-dist</module>
+    <module>hadoop-coverage</module>
   </modules>
 
   <build>
@@ -489,9 +485,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.openclover</groupId>
-          <artifactId>clover-maven-plugin</artifactId>
-          <version>${clover-maven-plugin.version}</version>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -868,78 +864,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                 <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>clover</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>clover</name>
-        </property>
-      </activation>
-      <properties>
-        <cloverDatabase>${project.build.directory}/clover/hadoop-coverage.db</cloverDatabase>
-        <!-- NB: This additional parametrization is made in order
-             to be able to re-define these properties with "-Dk=v" maven options.
-             By some reason the expressions declared in clover
-             docs like "${maven.clover.generateHtml}" do not work in that way.
-             However, the below properties are confirmed to work: e.g.
-             -DcloverGenHtml=false switches off the Html generation.
-             The default values provided here exactly correspond to Clover defaults, so
-             the behavior is 100% backwards compatible. -->
-        <cloverAlwaysReport>true</cloverAlwaysReport>
-        <cloverGenHtml>true</cloverGenHtml>
-        <cloverGenXml>true</cloverGenXml>
-        <cloverGenHistorical>false</cloverGenHistorical>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.openclover</groupId>
-            <artifactId>clover-maven-plugin</artifactId>
-            <configuration>
-              <includesAllSourceRoots>false</includesAllSourceRoots>
-              <includesTestSourceRoots>true</includesTestSourceRoots>
-              <cloverDatabase>${cloverDatabase}</cloverDatabase>
-              <targetPercentage>50%</targetPercentage>
-              <outputDirectory>${project.build.directory}/clover</outputDirectory>
-              <alwaysReport>${cloverAlwaysReport}</alwaysReport>
-              <generateHtml>${cloverGenHtml}</generateHtml>
-              <generateXml>${cloverGenXml}</generateXml>
-              <generateHistorical>${cloverGenHistorical}</generateHistorical>
-              <excludes>
-                <exclude>**/examples/**/*.java</exclude>
-                <exclude>**/hamlet/*.java</exclude>
-                <exclude>**/ha/proto/*.java</exclude>
-                <exclude>**/protocol/proto/*.java</exclude>
-                <exclude>**/compiler/generated/*.java</exclude>
-                <exclude>**/protobuf/*.java</exclude>
-                <exclude>**/v2/proto/*.java</exclude>
-                <exclude>**/yarn/proto/*.java</exclude>
-                <exclude>**/security/proto/*.java</exclude>
-                <exclude>**/tools/proto/*.java</exclude>
-                <exclude>**/hs/proto/*.java</exclude>
-              </excludes>
-            </configuration>
-            <executions>
-              <execution>
-                <id>clover-setup</id>
-                <phase>process-sources</phase>
-                <goals>
-                  <goal>setup</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>clover</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>clover</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <wagon-ssh.version>2.4</wagon-ssh.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+    <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <maven-bundle-plugin.version>2.5.0</maven-bundle-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -488,6 +489,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${exec-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <wagon-ssh.version>2.4</wagon-ssh.version>
-    <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-bundle-plugin.version>2.5.0</maven-bundle-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
@@ -489,11 +488,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco-maven-plugin.version}</version>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>${exec-maven-plugin.version}</version>
-        </plugin>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <hadoop.version>3.6.0-SNAPSHOT</hadoop.version>
 
     <!-- Skip JaCoCo instrumentation/reporting by default; enable with
-         -Dhadoop.skip-jacoco=false. Defined here (not only in hadoop-project)
-         so modules that inherit directly from hadoop-main, such as
-         hadoop-coverage, resolve the property too. -->
-    <hadoop.skip-jacoco>true</hadoop.skip-jacoco>
+         -Djacoco.skip=false. jacoco.skip is the jacoco-maven-plugin's own skip
+         property; we only set its default here. Defined in hadoop-main (not
+         only in hadoop-project) so modules that inherit directly from
+         hadoop-main, such as hadoop-coverage, resolve it too. -->
+    <jacoco.skip>true</jacoco.skip>
 
     <docker.image>apache/hadoop:${project.version}</docker.image>
 
@@ -108,8 +109,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <wagon-ssh.version>2.4</wagon-ssh.version>
-    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-bundle-plugin.version>2.5.0</maven-bundle-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -488,11 +489,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco-maven-plugin.version}</version>
-        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
+        </plugin>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -775,17 +776,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
 
   <profiles>
     <!-- The coverage aggregate module joins the reactor only when coverage is
-         explicitly requested (-Dhadoop.skip-jacoco=false). Keeping it out of the
+         explicitly requested (-Djacoco.skip=false). Keeping it out of the
          unconditional <modules> means normal install/site/deploy/package builds
          neither resolve its (reactor-wide) dependency list nor run its guard,
          so the default build is unaffected and coverage stays opt-in. The
-         documented coverage command already passes -Dhadoop.skip-jacoco=false,
+         documented coverage command already passes -Djacoco.skip=false,
          so it still builds as a full reactor that includes hadoop-coverage. -->
     <profile>
       <id>coverage</id>
       <activation>
         <property>
-          <name>hadoop.skip-jacoco</name>
+          <name>jacoco.skip</name>
           <value>false</value>
         </property>
       </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <module>hadoop-build-tools</module>
     <module>hadoop-cloud-storage-project</module>
     <module>hadoop-dist</module>
-    <module>hadoop-coverage</module>
   </modules>
 
   <build>
@@ -775,6 +774,25 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
   </reporting>
 
   <profiles>
+    <!-- The coverage aggregate module joins the reactor only when coverage is
+         explicitly requested (-Dhadoop.skip-jacoco=false). Keeping it out of the
+         unconditional <modules> means normal install/site/deploy/package builds
+         neither resolve its (reactor-wide) dependency list nor run its guard,
+         so the default build is unaffected and coverage stays opt-in. The
+         documented coverage command already passes -Dhadoop.skip-jacoco=false,
+         so it still builds as a full reactor that includes hadoop-coverage. -->
+    <profile>
+      <id>coverage</id>
+      <activation>
+        <property>
+          <name>hadoop.skip-jacoco</name>
+          <value>false</value>
+        </property>
+      </activation>
+      <modules>
+        <module>hadoop-coverage</module>
+      </modules>
+    </profile>
     <profile>
       <id>src</id>
       <activation>


### PR DESCRIPTION
Trunk supports Java 17 (https://github.com/apache/hadoop-release-support). OpenClover (the open-sourced fork of Atlassian Clover) is incompatible with Java 17+ because it relies on source-level instrumentation via a javac annotation processor that triggers split-package violations in the module system.  JaCoCo uses bytecode instrumentation via a Java agent and has no such constraint.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Changes:
- pom.xml: remove com.cenqua.clover dependency management, replace clover-maven-plugin in pluginManagement with jacoco-maven-plugin 0.8.15, add the hadoop-coverage aggregate module, drop the <profile id="clover"> block entirely, and declare
  hadoop.skip-jacoco=true here so modules that inherit directly from hadoop-main (e.g. hadoop-coverage) resolve the property too
- hadoop-project/pom.xml: add hadoop.skip-jacoco=true property (opt-in by default), append @{argLine} to the surefire and failsafe argLines so the JaCoCo agent is injected into every forked test JVM, and wire in jacoco:prepare-agent with excludes for generated/proto/example classes so they are not instrumented
- per-module poms that override the surefire argLine (hadoop-common, hadoop-hdfs, hadoop-hdfs-rbf, hadoop-registry, hadoop-aws, hadoop-azure, hadoop-distcp, hadoop-federation-balance, hadoop-gcp,
  hadoop-tos, hadoop-yarn-applications-catalog-webapp): append @{argLine} so instrumentation is not dropped
- hadoop-coverage/pom.xml (new): aggregate module that depends on the test-bearing modules and runs jacoco:report-aggregate at the verify phase to produce a combined HTML/XML report under
  hadoop-coverage/target/site/jacoco-aggregate/; deploy and install are skipped so this coverage-only pom is never published
- hadoop-maven-plugins/pom.xml, hadoop-yarn-server-nodemanager/pom.xml: remove stale clover skip
  overrides that are no longer needed
- test-libhdfs.sh, hadoop-mapreduce-client-jobclient/pom.xml, hadoop-yarn-applications/pom.xml: drop remaining clover references

report-aggregate only sees modules within the same Maven reactor, so the report must be produced by a single full-reactor build (not with -pl hadoop-coverage, which would leave the other modules out of the
reactor and yield an empty report):

  mvn verify -Dhadoop.skip-jacoco=false -Dmaven.test.failure.ignore=true

The aggregate report lands at hadoop-coverage/target/site/jacoco-aggregate/index.html.

Generated-by: Claude Code

### How was this patch tested?
Run on my local computer coverage report for hadoop_nfs and also an aggregate coverage report.
Screenshots provided on the Jira as attachments. 

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html