### PR TITLE
ABFS: disable external entity resolution when parsing Blob endpoint XML

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
 import org.apache.hadoop.fs.azurebfs.utils.ListUtils;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+import org.apache.hadoop.util.XMLUtils;
 
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
@@ -1711,7 +1712,7 @@ public class AbfsBlobClient extends AbfsClient {
     // Convert the input stream to a Document object
 
     try {
-      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      DocumentBuilderFactory factory = XMLUtils.newSecureDocumentBuilderFactory();
       Document doc = factory.newDocumentBuilder().parse(stream);
 
       // Find the CommittedBlocks element and extract the list of block IDs
@@ -1977,9 +1978,9 @@ public class AbfsBlobClient extends AbfsClient {
   }
 
   private final ThreadLocal<SAXParser> saxParserThreadLocal = ThreadLocal.withInitial(() -> {
-    SAXParserFactory factory = SAXParserFactory.newInstance();
-    factory.setNamespaceAware(true);
     try {
+      SAXParserFactory factory = XMLUtils.newSecureSAXParserFactory();
+      factory.setNamespaceAware(true);
       return factory.newSAXParser();
     } catch (SAXException e) {
       throw new RuntimeException("Unable to create SAXParser", e);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsBlobClientXmlParsing.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsBlobClientXmlParsing.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests that the XML returned by the Blob endpoint is parsed without resolving
+ * external entities.
+ */
+public class TestAbfsBlobClientXmlParsing {
+
+  @TempDir
+  private File tempDir;
+
+  private static final String SECRET = "top-secret-block-id";
+
+  private String blockListWithExternalEntity(final File secretFile) {
+    return "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<!DOCTYPE BlockList ["
+        + "<!ENTITY xxe SYSTEM \"" + secretFile.toURI() + "\">"
+        + "]>"
+        + "<BlockList><CommittedBlocks>"
+        + "<Block><Name>&xxe;</Name><Size>1</Size></Block>"
+        + "</CommittedBlocks></BlockList>";
+  }
+
+  @Test
+  public void testParseBlockListResponseRejectsExternalEntity() throws Exception {
+    File secretFile = new File(tempDir, "secret.txt");
+    Files.write(secretFile.toPath(), SECRET.getBytes(StandardCharsets.UTF_8));
+
+    AbfsBlobClient client = Mockito.mock(AbfsBlobClient.class);
+    Mockito.doCallRealMethod().when(client).parseBlockListResponse(Mockito.any());
+
+    InputStream stream = new ByteArrayInputStream(
+        blockListWithExternalEntity(secretFile).getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> client.parseBlockListResponse(stream))
+        .describedAs("A DOCTYPE in a block list response must be rejected")
+        .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  public void testParseBlockListResponseWithoutDoctype() throws Exception {
+    AbfsBlobClient client = Mockito.mock(AbfsBlobClient.class);
+    Mockito.doCallRealMethod().when(client).parseBlockListResponse(Mockito.any());
+
+    String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<BlockList><CommittedBlocks>"
+        + "<Block><Name>block-1</Name><Size>1</Size></Block>"
+        + "<Block><Name>block-2</Name><Size>2</Size></Block>"
+        + "</CommittedBlocks></BlockList>";
+
+    List<String> blockIds = client.parseBlockListResponse(
+        new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(blockIds)
+        .describedAs("Block ids parsed from a well formed block list")
+        .containsExactly("block-1", "block-2");
+  }
+}


### PR DESCRIPTION
### Description of PR

**Blob endpoint XML responses are parsed with external entities enabled**

`parseBlockListResponse` creates its `DocumentBuilderFactory` via `newInstance()`, and the `saxParserThreadLocal` behind `parseListPathResults` and `parseListContainersResponse` does the same with `SAXParserFactory`. Neither disables DOCTYPE or external entity resolution, so XML coming back from the Blob endpoint on GetBlockList, ListBlobs and ListContainers is parsed with entity resolution on, and a response carrying `<!ENTITY xxe SYSTEM "file:///...">` has the entity resolved client side, with the contents landing in block ids and listing entries. Both now use the secure factories hadoop-common already exposes in `XMLUtils` for exactly this.

I do not have a JIRA id for this yet, so the title does not carry one. Happy to file one and rename if you would like it tracked that way.

### How was this patch tested?

New unit test `TestAbfsBlobClientXmlParsing` under hadoop-azure. It feeds `parseBlockListResponse` a block list response whose block name is an external entity pointing at a temp file: before the change the parse succeeds and hands back the file contents as a block id, after it the parse raises `IOException`. A second case parses a well formed block list and checks the ids still come through, so valid responses are unaffected.

Ran locally on JDK 11:

- `mvn test -pl hadoop-tools/hadoop-azure -Dtest='TestAbfsBlobClientXmlParsing,TestBlobListXmlParser,TestListActionTaker,TestAbfsClient,TestAbfsHttpOperation'` — 11 tests, all pass
- `mvn install -DskipTests` from the root — BUILD SUCCESS
- `mvn checkstyle:check -pl hadoop-tools/hadoop-azure` — nothing new on the two touched files

The ABFS ITest suites need a live storage account, which I do not have, so they have not been run. That is the one gap I would ask a reviewer with an endpoint to cover.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

No new dependencies; `XMLUtils` is already reachable from hadoop-azure through the hadoop-common provided dependency.

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

Contains content generated by Claude Code.
