### PR TITLE
YARN: restrict leveldb conf store log deserialization to known types

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/LeveldbConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/LeveldbConfigurationStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.conf;
 
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.yarn.server.resourcemanager.DBManager;
 import org.slf4j.Logger;
@@ -40,11 +41,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -239,8 +239,10 @@ public class LeveldbConfigurationStore extends YarnConfigurationStore {
       return new LinkedList<>();
     }
 
-    try (ObjectInput input = new ObjectInputStream(
+    try (ValidatingObjectInputStream input = new ValidatingObjectInputStream(
         new ByteArrayInputStream(mutations))) {
+      input.accept(LinkedList.class, LogMutation.class, HashMap.class,
+          String.class);
       return (LinkedList<LogMutation>) input.readObject();
     } catch (ClassNotFoundException e) {
       throw new IOException(e);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestLeveldbConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestLeveldbConfigurationStore.java
@@ -36,10 +36,17 @@ import org.junit.jupiter.api.Test;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
 import java.util.Map;
 
+import static org.fusesource.leveldbjni.JniDBFactory.bytes;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -146,6 +153,48 @@ public class TestLeveldbConfigurationStore extends
     assertEquals("val", ((MutableConfScheduler) rm2.getResourceScheduler())
         .getConfiguration().get("key"));
     rm2.close();
+  }
+
+  /**
+   * A type that is not part of a configuration log. Its readObject hook
+   * records that it ran, standing in for the side effect a gadget chain
+   * would have.
+   */
+  public static class UnexpectedType implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private static boolean deserialized = false;
+
+    private void readObject(ObjectInputStream in)
+        throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      deserialized = true;
+    }
+  }
+
+  /**
+   * The configuration log is read back out of the store as a serialized
+   * object graph, so only the types a LogMutation list is made of may be
+   * instantiated from it.
+   */
+  @Test
+  public void testDeserializationIsNotVulnerable() throws Exception {
+    confStore.initialize(conf, schedConf, rmContext);
+    UnexpectedType.deserialized = false;
+
+    LinkedList<Object> logs = new LinkedList<>();
+    logs.add(new UnexpectedType());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(logs);
+    }
+    ((LeveldbConfigurationStore) confStore).getDB()
+        .put(bytes("log"), baos.toByteArray());
+
+    assertThrows(IOException.class,
+        () -> ((LeveldbConfigurationStore) confStore).getLogs());
+    assertFalse(UnexpectedType.deserialized,
+        "A type outside the configuration log must not be deserialized");
+    confStore.close();
   }
 
   @Override


### PR DESCRIPTION
### Description of PR

JIRA: YARN: restrict leveldb conf store log deserialization to known types

`LeveldbConfigurationStore.deserLogMutations` reads the capacity scheduler configuration log back with a bare `ObjectInputStream`, so whatever sits under the leveldb `log` key decides which `Serializable` types the RM constructs during recovery. `ZKConfigurationStore.deserializeObject` already fences the identical `LinkedList<LogMutation>` graph behind a `ValidatingObjectInputStream` allowlist, and `TestZKConfigurationStore.testDeserializationIsNotVulnerable` pins that with a ysoserial payload, but the leveldb store never got either. This applies the same `accept()` list at the point the bytes are turned back into objects.

`ConfigurationUpdateAssembler.constructKeyValueConfUpdate` builds the updates map with `new HashMap<>()`, so `LinkedList`, `LogMutation`, `HashMap` and `String` cover a real configuration log and valid stores still load unchanged.

### How was this patch tested?

Added `testDeserializationIsNotVulnerable` to `TestLeveldbConfigurationStore`, alongside the existing ZK one. It plants a list holding a type that is not part of a configuration log and asserts the read is rejected and the type is never constructed. Against the unpatched store the payload's `readObject` runs and no exception is raised; with the patch it fails with `InvalidClassException`.

`mvn compile`/`test-compile` and `checkstyle:check` are clean for both files on JDK 17. I could not execute the leveldb suite locally, `leveldbjni` ships no arm64 native and the existing tests in that class already fail the same way on this machine, so I am relying on CI for the run.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
