### PR TITLE
HADOOP-19942. Upgrade to BouncyCastle 1.85 due to security issues

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -605,9 +605,9 @@ com.microsoft.azure:azure-cosmosdb-gateway:2.4.5
 com.microsoft.azure:azure-data-lake-store-sdk:2.3.9
 com.microsoft.azure:azure-keyvault-core:1.0.0
 com.microsoft.sqlserver:mssql-jdbc:6.2.1.jre7
-org.bouncycastle:bcpkix-jdk18on:1.84
-org.bouncycastle:bcprov-jdk18on:1.84
-org.bouncycastle:bcutil-jdk18on:1.84
+org.bouncycastle:bcpkix-jdk18on:1.85
+org.bouncycastle:bcprov-jdk18on:1.85
+org.bouncycastle:bcutil-jdk18on:1.85
 org.checkerframework:checker-qual:3.8.0
 org.codehaus.mojo:animal-sniffer-annotations:1.24
 org.jruby.jcodings:jcodings:1.0.13

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -120,7 +120,7 @@
     <guava.version>33.4.8-jre</guava.version>
     <guice.version>5.1.0</guice.version>
 
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0.AM27</apacheds.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

https://github.com/bcgit/bc-java/issues/2355
https://issues.apache.org/jira/browse/HADOOP-19942

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html