### PR TITLE
HADOOP-19943. Upgrade Apache Mina to 2.0.29 due to CVE-2026-47065

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1164,7 +1164,7 @@
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.0.28</version>
+        <version>2.0.29</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

https://issues.apache.org/jira/browse/HADOOP-19943

This dependency is not listed in LICENSE-binary

See also https://github.com/apache/hadoop/pull/8600

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html