### PR TITLE
YARN: escape the AM-supplied tracking url in the apps table blocks

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/AppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/AppsBlock.java
@@ -219,7 +219,9 @@ public class AppsBlock extends HtmlBlock {
               ? "Unassigned" :
               Apps.isApplicationFinalState(app.getAppState())
                   ? "History" : "ApplicationMaster";
-      appsTableData.append(trackingURL == null ? "#" : "href='" + trackingURL)
+      appsTableData.append(trackingURL == null ? "#" : "href='"
+          + StringEscapeUtils.escapeEcmaScript(
+              StringEscapeUtils.escapeHtml4(trackingURL)))
         .append("'>").append(trackingUI).append("</a>\"],\n");
 
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestAppsBlock.java
@@ -20,10 +20,16 @@ package org.apache.hadoop.yarn.server.webapp;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.webapp.SubView;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.view.BlockForTest;
@@ -31,7 +37,11 @@ import org.apache.hadoop.yarn.webapp.view.HtmlBlock;
 import org.apache.hadoop.yarn.webapp.view.HtmlBlockForTest;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestAppsBlock {
 
@@ -64,6 +74,54 @@ public class TestAppsBlock {
       // instead of catching it.
       appBlock.render(block);
     });
+  }
+
+  /**
+   * The tracking URL is registered by the application master, so it must be
+   * escaped before it is written into the apps table script block.
+   */
+  @Test
+  public void testTrackingUrlIsEscaped() {
+    String trackingUrl = "http://tracking/\"</script><script>alert(1)</script>";
+
+    ApplicationReport report = mock(ApplicationReport.class);
+    when(report.getApplicationId())
+        .thenReturn(ApplicationId.newInstance(0, 1));
+    when(report.getUser()).thenReturn("user");
+    when(report.getQueue()).thenReturn("default");
+    when(report.getName()).thenReturn("app");
+    when(report.getApplicationType()).thenReturn("type");
+    when(report.getYarnApplicationState())
+        .thenReturn(YarnApplicationState.RUNNING);
+    when(report.getFinalApplicationStatus())
+        .thenReturn(FinalApplicationStatus.UNDEFINED);
+    when(report.getTrackingUrl()).thenReturn(trackingUrl);
+
+    AppsBlock appsBlock = new AppsBlock(null, null) {
+      @Override
+      public String url(String... parts) {
+        return "/app";
+      }
+    };
+    appsBlock.reqAppStates = EnumSet.noneOf(YarnApplicationState.class);
+    appsBlock.appReports = Collections.singletonList(report);
+
+    OutputStream outputStream = new ByteArrayOutputStream();
+    PrintWriter printWriter = new PrintWriter(outputStream);
+    HtmlBlock html = new HtmlBlockForTest();
+    HtmlBlock.Block block = new BlockForTest(html, printWriter, 10, false) {
+      @Override
+      protected void subView(Class<? extends SubView> cls) {
+      }
+    };
+    appsBlock.renderData(block);
+    printWriter.flush();
+
+    String rendered = outputStream.toString();
+    assertFalse(rendered.contains("<script>alert(1)</script>"),
+        "tracking url was not escaped: " + rendered);
+    assertTrue(rendered.contains("&lt;\\/script&gt;&lt;script&gt;"),
+        "tracking url was not escaped: " + rendered);
   }
 
   private static HtmlBlock.Block createBlockToCreateTo(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -220,7 +220,8 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
       String trackingURL =
         !appInfo.isTrackingUrlReady()? "#" : appInfo.getTrackingUrlPretty();
 
-      appsTableData.append(trackingURL).append("'>")
+      appsTableData.append(StringEscapeUtils.escapeEcmaScript(
+          StringEscapeUtils.escapeHtml4(trackingURL))).append("'>")
       .append(appInfo.getTrackingUI()).append("</a>\"],\n");
 
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMAppsBlock.java
@@ -210,7 +210,9 @@ public class RMAppsBlock extends AppsBlock {
               || app.getAppState() == YarnApplicationState.NEW ? "Unassigned"
               : Apps.isApplicationFinalState(app.getAppState()) ?
               "History" : "ApplicationMaster";
-      appsTableData.append(trackingURL == null ? "#" : "href='" + trackingURL)
+      appsTableData.append(trackingURL == null ? "#" : "href='"
+          + StringEscapeUtils.escapeEcmaScript(
+              StringEscapeUtils.escapeHtml4(trackingURL)))
         .append("'>").append(trackingUI).append("</a>\",").append("\"")
         .append(blacklistedNodesCount).append("\"],\n");
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AppsBlock.java
@@ -181,7 +181,8 @@ public class AppsBlock extends RouterBlock {
     StringBuilder appsDataBuilder = new StringBuilder();
     try {
       String percent = String.format("%.1f", app.getProgress() * 100.0F);
-      String trackingURL = app.getTrackingUrl() == null ? "#" : app.getTrackingUrl();
+      String trackingURL =
+          app.getTrackingUrl() == null ? "#" : escape(app.getTrackingUrl());
 
       // AppID numerical value parsed by parseHadoopID in yarn.dt.plugins.js
       appsDataBuilder.append("[\"")


### PR DESCRIPTION
### Description of PR

The apps tables in the RM, ApplicationHistory, FairScheduler and Router web UIs build their rows into a `StringBuilder` and emit the result inside a `<script>` element as `var appsTableData=...`. Every application-supplied column in that array (user, name, type, tags, queue) already goes through `escapeEcmaScript(escapeHtml4(...))`, but the tracking URL is concatenated straight into `href='...'`, and `ApplicationReport.getTrackingUrl()` hands back `RMAppAttemptImpl.originalTrackingUrl` verbatim for an unmanaged AM, so the string a client passes to `registerApplicationMaster` reaches the page unfiltered. A tracking URL holding a quote or a `</script>` closes the attribute or the script element and runs in the browser of anyone listing applications, so the escaping the neighbouring columns already use is applied here too. The Router copy has an `escape()` helper of its own that this one call site was skipping.

### How was this patch tested?

New `TestAppsBlock#testTrackingUrlIsEscaped` renders `AppsBlock` with a report whose tracking URL carries a `</script><script>` payload; it fails on trunk and passes with the change. `TestAppsBlock`, `TestRMWebApp`, `TestRMWebAppFairScheduler`, `TestAppPage` and `TestFederationWebApp` all pass, and checkstyle reports nothing new on the touched files.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
