### PR TITLE
YARN-11682: Legacy auto created queue in absolute mode has zero capacity after creation during app recovery.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ManagedParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ManagedParentQueue.java
@@ -262,6 +262,26 @@ public class ManagedParentQueue extends AbstractManagedParentQueue {
     }
   }
 
+/**
+ * Recomputes leaf queue template capacities in ABSOLUTE_RESOURCE mode.
+ * This handles the case where a queue is recreated during RM recovery
+ * before any NodeManager has registered, causing the initial capacity
+ * to be computed as 0. The periodic queue management policy recalculates
+ * the template once cluster resources become available. No operation for other
+ * queue modes.
+ */
+  public void updateTemplateCapacitiesForAbsoluteResource() {
+    writeLock.lock();
+    try {
+      if (this.capacityConfigType.equals(
+          CapacityConfigType.ABSOLUTE_RESOURCE)) {
+        updateQueueCapacities(getLeafQueueTemplate().getQueueCapacities());
+      }
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
   protected void validate(final CSQueue newlyParsedQueue) throws IOException {
     // Sanity check
     if (!(newlyParsedQueue instanceof ManagedParentQueue) || !newlyParsedQueue

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/queuemanagement/GuaranteedOrZeroCapacityOverTimePolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/queuemanagement/GuaranteedOrZeroCapacityOverTimePolicy.java
@@ -52,6 +52,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler
+    .capacity.AbstractCSQueue.CapacityConfigType.ABSOLUTE_RESOURCE;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler
     .capacity.CSQueueUtils.EPSILON;
 
 /**
@@ -309,6 +311,15 @@ public class GuaranteedOrZeroCapacityOverTimePolicy
   @Override
   public List<QueueManagementChange> computeQueueManagementChanges()
       throws SchedulerDynamicEditException {
+
+    // Recompute the leaf queue template capacities from the current cluster
+    // resource for ABSOLUTE_RESOURCE mode. The template fraction is otherwise
+    // computed only at reinitialize; if a leaf queue was auto-created
+    // while the cluster resource was zero  during RM recovery before any
+    // NodeManager registered the fraction stays 0 and the queue never regains
+    // capacity. This refresh lets the template pick up the real capacity once
+    // NodeManagers register. No operation unless it is ABSOLUTE_RESOURCE.
+    managedParentQueue.updateTemplateCapacitiesForAbsoluteResource();
 
     // Update template absolute capacities as the capacities could have changed
     // in weight mode
@@ -716,8 +727,18 @@ public class GuaranteedOrZeroCapacityOverTimePolicy
             getAbsoluteCapacity(nodeLabel) - parentQueueState.
             getAbsoluteActivatedChildQueueCapacity(nodeLabel) + EPSILON;
 
-        if (availableCapacity >= leafQueueTemplateCapacities
-            .getAbsoluteCapacity(nodeLabel)) {
+        // In ABSOLUTE_RESOURCE mode, don't activate a leaf queue while the cluster
+        // resource is 0 during RM recovery before NodeManagers register.
+        // Otherwise, it gets initialized with zero capacity and never updates.
+        // Create it deactivated instead, and let the monitor activate it once
+        // cluster resources are available. Percentage and weight modes are unaffected.
+        boolean deferActivationUntilClusterResource =
+            managedParentQueue.getCapacityConfigType() == ABSOLUTE_RESOURCE
+                && managedParentQueue.getQueueContext().getClusterResource()
+                    .getMemorySize() <= 0;
+
+        if (!deferActivationUntilClusterResource && availableCapacity
+            >= leafQueueTemplateCapacities.getAbsoluteCapacity(nodeLabel)) {
           updateCapacityFromTemplate(capacities, nodeLabel);
           activate(leafQueue, nodeLabel);
         } else{

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAbsoluteResourceWithAutoQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAbsoluteResourceWithAutoQueue.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 import static org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager.NO_LABEL;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueueUtils.EPSILON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -337,5 +338,64 @@ public class TestAbsoluteResourceWithAutoQueue
     assertNotNull(autoCreatedLeafQueue, "Auto Creation of Queue failed");
     ManagedParentQueue parentQueue = (ManagedParentQueue) cs.getQueue(QUEUED);
     assertEquals(parentQueue, autoCreatedLeafQueue.getParent());
+  }
+
+  @Test
+  @Timeout(value = 20)
+  public void testAutoCreatedLeafQueueRecoversCapacityAfterNodeRegisters()
+      throws Exception {
+    try {
+      CapacitySchedulerConfiguration csConf =
+          setupSimpleQueueConfiguration(false);
+      setupMinMaxResourceConfiguration(csConf);
+      csConf.setClass(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class,
+          ResourceScheduler.class);
+      csConf.setOverrideWithQueueMappings(true);
+      setupGroupQueueMappings(QUEUED, csConf, "%user");
+
+      mockRM = new MockRM(csConf);
+      cs = (CapacityScheduler) mockRM.getResourceScheduler();
+      mockRM.start();
+      cs.start();
+
+      submitApp(mockRM, cs.getQueue(QUEUED), TEST_GROUPUSER, TEST_GROUPUSER, 1,
+          1);
+
+      AutoCreatedLeafQueue autoCreatedLeafQueue =
+          (AutoCreatedLeafQueue) cs.getQueue(TEST_GROUPUSER);
+      ManagedParentQueue parentQueue = (ManagedParentQueue) cs.getQueue(QUEUED);
+      assertNotNull(autoCreatedLeafQueue, "Auto Creation of Queue failed");
+      assertEquals(parentQueue, autoCreatedLeafQueue.getParent());
+
+      GuaranteedOrZeroCapacityOverTimePolicy policy =
+          (GuaranteedOrZeroCapacityOverTimePolicy) parentQueue
+              .getAutoCreatedQueueManagementPolicy();
+
+      // With no cluster resource the queue must be created at zero capacity and
+      // must NOT be activated - activating it here is exactly what strands it at
+      // zero capacity for the lifetime of the queue.
+      assertEquals(0.0f, autoCreatedLeafQueue.getCapacity(), EPSILON);
+      assertEquals(0.0f, autoCreatedLeafQueue.getAbsoluteCapacity(), EPSILON);
+      assertFalse(policy.isActive(autoCreatedLeafQueue, NO_LABEL),
+              "Queue must not be activated while the cluster resource is zero");
+
+      // A NodeManager registers: the cluster resource becomes available.
+      mockRM.registerNode("127.0.0.1:1234", 250 * GB, 40);
+      mockRM.drainEvents();
+
+      // The queue management monitor runs, which is what
+      // QueueManagementDynamicEditPolicy does on its monitoring interval.
+      List<QueueManagementChange> changes =
+          policy.computeQueueManagementChanges();
+      parentQueue.validateAndApplyQueueManagementChanges(changes);
+
+      validateCapacities(autoCreatedLeafQueue, 0.4f, 0.04f, 1f, 0.6f);
+      assertTrue(policy.isActive(autoCreatedLeafQueue, NO_LABEL),
+              "Queue must be activated once the cluster resource is available");
+      assertEquals(0.04f,
+          policy.getAbsoluteActivatedChildQueueCapacity(NO_LABEL), EPSILON);
+    } finally {
+      cleanupQueue(TEST_GROUPUSER);
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11682: Legacy auto created queue in absolute mode has zero capacity after creation during app recovery.

During recovery of a running app in a legacy auto created queue configured in absolute resource mode, the leaf queue is recreated before any NodeManager has reregistered, so clusterResource is still zero. In absolute mode the leaf queue capacity is derived from configuredMinResource , which update to 0, and the queue is committed at zero capacity. The absolute mode leaf template fraction is only recomputed on init or reinitialize, the queue stays at zero capacity even after NM's register. So this pr recompute the resource for the queues.

### How was this patch tested?
Added a new test method testAutoCreatedLeafQueueRecoversCapacityAfterNodeRegisters.
Manually verrified on a cluster with an absolute mode allocation.
Added a managed parent queue root.dynamic where auto-create was enabled and  RM work preserving recovery enabled to true. Then submitted a long running app to an auto created leaf queue root.dynamic.aqcqueue.
Stopped the NM's. Restarted the RM, the queue root.dynamic.aqcqueue have 0 capacity now.
And then started the NM's. The queue root.dynamic.aqcqueue now is restored to the configured guaranteed capacity(which stayed 0 before the fix). 

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html