### PR TITLE
YARN-11969. Make catalog-webapp jasmine browser tests skippable independently of -DskipTests

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -220,6 +220,9 @@ Maven build goals:
 
   * Use -DskipTests to skip tests when running the following Maven goals:
     'package',  'install', 'deploy' or 'verify'
+  * Use -DskipJasmineTests=true to skip only the browser-driven jasmine tests in
+    hadoop-yarn-applications-catalog-webapp (e.g. on a headless machine with no
+    browser) while still running the module's other tests.
   * -Dtest=<TESTCLASSNAME>,<TESTCLASSNAME#METHODNAME>,....
   * -Dtest.exclude=<TESTCLASSNAME>
   * -Dtest.exclude.pattern=**/<TESTCLASSNAME1>.java,**/<TESTCLASSNAME2>.java

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -37,12 +37,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <javascript.test>*Spec</javascript.test>
-        <!-- Skip the browser-driven jasmine tests independently of -DskipTests.
-             Defaults to ${skipTests} so normal builds are unchanged; a headless CI
-             run (no PhantomJS browser available) can pass -DskipJasmineTests=true to
-             avoid the hard build failure while still compiling and covering the
-             module's Java/JS. -->
-        <skipJasmineTests>${skipTests}</skipJasmineTests>
     </properties>
 
   <dependencies>
@@ -490,7 +484,14 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <skipJasmineTests>${skipJasmineTests}</skipJasmineTests>
+                    <!-- No explicit skipJasmineTests element: the plugin already
+                         binds skipTests, maven.test.skip and skipJasmineTests to the
+                         matching command-line properties and skips when any is true.
+                         Setting the element here would override those bindings, so
+                         -DskipJasmineTests would be ignored. Omitting it lets
+                         -DskipTests skip jasmine (as before) while -DskipJasmineTests=true
+                         skips only the browser-driven specs (e.g. on a headless box
+                         with no PhantomJS) without disabling the module's other tests. -->
                     <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
                     <webDriverCapabilities>
                         <capability>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -484,14 +484,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <!-- No explicit skipJasmineTests element: the plugin already
-                         binds skipTests, maven.test.skip and skipJasmineTests to the
-                         matching command-line properties and skips when any is true.
-                         Setting the element here would override those bindings, so
-                         -DskipJasmineTests would be ignored. Omitting it lets
-                         -DskipTests skip jasmine (as before) while -DskipJasmineTests=true
-                         skips only the browser-driven specs (e.g. on a headless box
-                         with no PhantomJS) without disabling the module's other tests. -->
+                    <!-- Jasmine tests are skipped if any one of -Dmaven.test.skip=true,
+                         -DskipTests, -DskipJasmineTests=true is set. Don't declare
+                         skipJasmineTests here: it would override those command-line flags. -->
                     <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
                     <webDriverCapabilities>
                         <capability>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -37,6 +37,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <javascript.test>*Spec</javascript.test>
+        <!-- Skip the browser-driven jasmine tests independently of -DskipTests.
+             Defaults to ${skipTests} so normal builds are unchanged; a headless CI
+             run (no PhantomJS browser available) can pass -DskipJasmineTests=true to
+             avoid the hard build failure while still compiling and covering the
+             module's Java/JS. -->
+        <skipJasmineTests>${skipTests}</skipJasmineTests>
     </properties>
 
   <dependencies>
@@ -484,7 +490,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <skipJasmineTests>${skipTests}</skipJasmineTests>
+                    <skipJasmineTests>${skipJasmineTests}</skipJasmineTests>
                     <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
                     <webDriverCapabilities>
                         <capability>


### PR DESCRIPTION
### Description of PR
`hadoop-yarn-applications-catalog-webapp` runs a `jasmine-maven-plugin` test that
drives a PhantomJS browser. In headless build environments PhantomJS cannot start,
and the plugin fails with `UnreachableBrowserException`. Because this is a
plugin-execution failure rather than a Surefire test failure,
`-Dmaven.test.failure.ignore=true` does not suppress it and it fails the build.

The module's jasmine config previously hardcoded its skip flag to `${skipTests}`,
so the only way to avoid the browser test was `-DskipTests`, which skips every test
in the module.

This PR introduces a `skipJasmineTests` property (default `${skipTests}`) and binds
the plugin's `<skipJasmineTests>` to it. Default behavior is unchanged; a headless
build can pass `-DskipJasmineTests=true` to skip only the browser-driven tests while
still compiling and covering the rest of the module.

Build-config change only; no production code affected.

### How was this patch tested?
Single-file change to the catalog-webapp `pom.xml`. Verified property resolution
with `mvn help:evaluate`:

- No flag: resolves to `${skipTests}` — same value the plugin received before.
- `-DskipTests`: resolves to `true` (jasmine skipped, as before).
- `-DskipJasmineTests=true`: resolves to `true` (jasmine skipped independently).

### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html