### PR TITLE
HADOOP-18896. Large `file.bytes-per-checksum` cause NegativeArraySizeException in FSOutputSummer

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.tracing.TraceScope;
+import org.apache.hadoop.util.Preconditions;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -52,6 +53,9 @@ abstract public class FSOutputSummer extends OutputStream implements
   
   protected FSOutputSummer(DataChecksum sum) {
     this.sum = sum;
+    Preconditions.checkArgument(
+            sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS > 0,
+            "Buffer size for FSOutputSummer should be a positive integer.");
     this.buf = new byte[sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS];
     this.checksum = new byte[getChecksumSize() * BUFFER_NUM_CHUNKS];
     this.count = 0;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.tracing.TraceScope;
-import org.apache.hadoop.util.Preconditions;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -53,11 +52,32 @@ abstract public class FSOutputSummer extends OutputStream implements
   
   protected FSOutputSummer(DataChecksum sum) {
     this.sum = sum;
-    Preconditions.checkArgument(
-            sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS > 0,
-            "Buffer size for FSOutputSummer should be a positive integer.");
-    this.buf = new byte[sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS];
-    this.checksum = new byte[getChecksumSize() * BUFFER_NUM_CHUNKS];
+    int bufSize;
+    try {
+      bufSize = Math.multiplyExact(sum.getBytesPerChecksum(), BUFFER_NUM_CHUNKS);
+    } catch (ArithmeticException ae) {
+      throw new IllegalArgumentException(
+          "The calculated buffer array size for FSOutputSummer is too large", ae);
+    }
+    if (bufSize < 0) {
+      throw new IllegalArgumentException(
+          "The calculated buffer array size for FSOutputSummer is negative");
+    }
+    this.buf = new byte[bufSize];
+
+    int checksumBufSize;
+    try {
+      checksumBufSize = Math.multiplyExact(getChecksumSize(), BUFFER_NUM_CHUNKS);
+    } catch (ArithmeticException ae) {
+      throw new IllegalArgumentException(
+          "The calculated checksum buffer array size for FSOutputSummer is too large", ae);
+    }
+    if (checksumBufSize < 0) {
+      throw new IllegalArgumentException(
+          "The calculated checksum buffer array size for FSOutputSummer is negative");
+    }
+    this.checksum = new byte[checksumBufSize];
+
     this.count = 0;
   }
   

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
@@ -59,25 +59,8 @@ abstract public class FSOutputSummer extends OutputStream implements
       throw new IllegalArgumentException(
           "The calculated buffer array size for FSOutputSummer is too large", ae);
     }
-    if (bufSize < 0) {
-      throw new IllegalArgumentException(
-          "The calculated buffer array size for FSOutputSummer is negative");
-    }
     this.buf = new byte[bufSize];
-
-    int checksumBufSize;
-    try {
-      checksumBufSize = Math.multiplyExact(getChecksumSize(), BUFFER_NUM_CHUNKS);
-    } catch (ArithmeticException ae) {
-      throw new IllegalArgumentException(
-          "The calculated checksum buffer array size for FSOutputSummer is too large", ae);
-    }
-    if (checksumBufSize < 0) {
-      throw new IllegalArgumentException(
-          "The calculated checksum buffer array size for FSOutputSummer is negative");
-    }
-    this.checksum = new byte[checksumBufSize];
-
+    this.checksum = new byte[getChecksumSize() * BUFFER_NUM_CHUNKS];
     this.count = 0;
   }
   
@@ -285,7 +268,7 @@ abstract public class FSOutputSummer extends OutputStream implements
   }
 
   protected synchronized void resetChecksumBufSize() {
-    setChecksumBufSize(sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS);
+    setChecksumBufSize(Math.multiplyExact(sum.getBytesPerChecksum(), BUFFER_NUM_CHUNKS));
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFSOutputSummer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFSOutputSummer.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs;
+
+import java.io.IOException;
+
+import org.apache.hadoop.util.DataChecksum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link FSOutputSummer}.
+ */
+public class TestFSOutputSummer {
+
+  /**
+   * A minimal concrete subclass of FSOutputSummer for testing the
+   * constructor in isolation, without needing a real output stream.
+   */
+  private static class DummyFSOutputSummer extends FSOutputSummer {
+    DummyFSOutputSummer(DataChecksum sum) {
+      super(sum);
+    }
+
+    @Override
+    protected void writeChunk(byte[] b, int bOffset, int bLen,
+        byte[] checksum, int checksumOffset, int checksumLen)
+        throws IOException {
+      // no-op for this test
+    }
+
+    @Override
+    protected void checkClosed() throws IOException {
+      // no-op for this test
+    }
+  }
+
+  /**
+   * HADOOP-18896: a large value of file.bytes-per-checksum causes the
+   * buffer size computation (bytesPerChecksum * BUFFER_NUM_CHUNKS) to
+   * overflow a signed int and become negative, which previously caused
+   * a NegativeArraySizeException when allocating the buffer array.
+   * After the fix, the constructor should instead fail fast with an
+   * IllegalArgumentException.
+   */
+  @Test
+  public void testLargeBytesPerChecksumOverflow() {
+    // Chosen so that bytesPerChecksum * 9 (BUFFER_NUM_CHUNKS) overflows
+    // Integer.MAX_VALUE and wraps around to a negative value.
+    final int largeBytesPerChecksum = 238609295;
+    DataChecksum sum = DataChecksum.newDataChecksum(
+        DataChecksum.Type.CRC32, largeBytesPerChecksum);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new DummyFSOutputSummer(sum));
+  }
+}


### PR DESCRIPTION
## Description of PR
This PR fixes HADOOP-18896.

The buffer size in `FSOutputSummer` is computed as `sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS`. When
`file.bytes-per-checksum` is configured to a very large value (e.g. 238609295), this multiplication overflows a signed 32-bit int and wraps around to a negative number, causing a `NegativeArraySizeException` when allocating the internal buffer array.

This PR adds a `Preconditions.checkArgument` check in the `FSOutputSummer` constructor to validate that the computed buffer size is positive, failing fast with a clear `IllegalArgumentException` instead of an obscure `NegativeArraySizeException`.

This continues the work started in #6064 by @teamconfx, which went stale. This PR additionally adds a unit test, as the original PR's `test4tests` check had failed for not including one.

### How was this patch tested?
- Added a new test class `TestFSOutputSummer` in `hadoop-common` with `testLargeBytesPerChecksumOverflow`, using     a minimal concrete subclass of `FSOutputSummer` to verify the constructor fails with `IllegalArgumentException` (rather than `NegativeArraySizeException`) when `bytesPerChecksum * BUFFER_NUM_CHUNKS` overflows.
- Verified the test fails with the original `NegativeArraySizeException` when the fix is reverted, and passes with the fix applied.
- `mvn -pl hadoop-common-project/hadoop-common test -Dtest=TestFSOutputSummer` passes.

Note: the JIRA's original reproduction steps reference an HDFS test (`TestDecommissionWithStriped`), but since the buffer overflow bug lives entirely in `hadoop-common`'s `FSOutputSummer` class, this PR adds a focused unit test in `hadoop-common` instead, avoiding an unnecessary cross-module HDFS test dependency.

### AI Tooling
Contains content generated by Claude (Anthropic). Used to help investigate the root cause, draft the fix, and write/verify the accompanying unit test.