### PR TITLE
HADOOP-19945. Update to commons-configuration2 2.15.0, commons-lang3 3.20.0 and commons-io 2.22.0 to fix CVE-2026-45205

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -284,7 +284,7 @@ commons-cli:commons-cli:1.9.0
 commons-codec:commons-codec:1.15
 org.apache.commons:commons-collections4:4.4
 commons-daemon:commons-daemon:1.0.13
-commons-io:commons-io:2.16.1
+commons-io:commons-io:2.22.0
 commons-net:commons-net:3.9.0
 de.ruedigermoeller:fst:2.50
 io.grpc:grpc-alts:1.70.0
@@ -367,10 +367,10 @@ net.java.dev.jna:jna:5.2.0
 net.minidev:accessors-smart:1.21
 org.apache.avro:avro:1.12.1
 org.apache.commons:commons-compress:1.26.1
-org.apache.commons:commons-configuration2:2.10.1
+org.apache.commons:commons-configuration2:2.15.0
 org.apache.commons:commons-csv:1.9.0
 org.apache.commons:commons-digester:1.8.1
-org.apache.commons:commons-lang3:3.18.0
+org.apache.commons:commons-lang3:3.20.0
 org.apache.commons:commons-math3:3.6.1
 org.apache.commons:commons-text:1.14.0
 org.apache.commons:commons-validator:1.6

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -132,8 +132,8 @@
     <commons-collections4.version>4.4</commons-collections4.version>
     <commons-compress.version>1.26.1</commons-compress.version>
     <commons-csv.version>1.9.0</commons-csv.version>
-    <commons-io.version>2.16.1</commons-io.version>
-    <commons-lang3.version>3.18.0</commons-lang3.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-logging.version>1.3.0</commons-logging.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-net.version>3.9.0</commons-net.version>
@@ -1239,7 +1239,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
-        <version>2.10.1</version>
+        <version>2.15.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Update commons-lang3 and commons-io along with commons-configuration2 because commons-configuration2 2.15.0 is built against newer related Commons library versions.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19945

Updates commons-configuration2 along with related Apache Commons dependencies commons-lang3 and commons-io. The related dependency bumps are included because updating only commons-configuration2 caused the shaded client CI check to fail in https://github.com/apache/hadoop/pull/8505. commons-configuration2 2.15.0 declares newer related Commons versions, so this keeps Hadoop's managed dependency set aligned. Also updates LICENSE-binary accordingly.

### How was this patch tested?

CI build

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html