### PR TITLE
HADOOP-18814. Direct class cast causes ClassCastException in TestRPC#testReaderExceptions

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1943,8 +1943,12 @@ public class TestRPC extends TestRpcBase {
           proxy.ping(null, newEmptyRequest());
           fail(reqName + " didn't fail");
         } catch (ServiceException e) {
-          RemoteException re = (RemoteException)e.getCause();
-          assertEquals(expectedIOE, re.unwrapRemoteException(), reqName);
+          if (e.getCause() instanceof RemoteException) {
+            RemoteException re = (RemoteException)e.getCause();
+            assertEquals(expectedIOE, re.unwrapRemoteException(), reqName);
+          } else {
+            throw e;
+          }
         }
         // check authorizations to ensure new connection when expected,
         // then conclusively determine if connections are disconnected


### PR DESCRIPTION
### Description of PR
This PR fixes HADOOP-18814.

`TestRPC#testReaderExceptions` directly casts `e.getCause()` to `RemoteException` without first checking its type:

```java
RemoteException re = (RemoteException)e.getCause();
```

If the root cause is not a `RemoteException` (e.g. when `hadoop.security.authentication` is set to `kerberos`, where the
cause can be a plain `IOException` such as an authentication failure), this direct cast throws a `ClassCastException`, hiding the actual underlying exception and making the test failure confusing to debug.

This PR adds a check for the cause's type before casting. If it is not a `RemoteException`, the original exception is rethrown so the real cause is surfaced instead of a misleading `ClassCastException`.

This continues the work started in #6076 by @teamconfx, which had already received a green CI run (checkstyle, unit tests, and test4tests all passed) but went stale due to inactivity.

### How was this patch tested?
- `mvn -pl hadoop-common-project/hadoop-common test -Dtest=TestRPC#testReaderExceptions` passes.

Note: per the JIRA's reproduction steps, the original `ClassCastException` only manifests when `hadoop.security.authentication` is set to `kerberos`. Setting up a local Kerberos environment was out of scope for this fix; the change here is a minimal, low-risk defensive check matching the fix originally proposed and CI-validated in #6076.

### AI Tooling
Contains content generated by Claude (Anthropic). Used to help investigate the issue and draft the fix.