### PR TITLE
HADOOP-19851. Point S3A GCS docs to the hadoop-gcp connector

### DIFF
--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
@@ -517,10 +517,10 @@ at [ECS Test Drive](https://portal.ecstestdrive.com/) were
 
 ## Google Cloud Storage through the S3A connector
 
-It *is* possible to connect to google cloud storage through the S3A connector.
-However, Google provide their own [Cloud Storage connector](https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage).
-That is a well maintained Hadoop filesystem client which uses their XML API,
-And except for some very unusual cases, that is the connector to use.
+It *is* possible to connect to Google Cloud Storage through the S3A connector.
+However, Hadoop provides its own
+[Google Cloud Storage connector](../../../hadoop-gcp/tools/hadoop-gcp/Configuration.html)
+in the `hadoop-gcp` module. Except for unusual cases, use this `gs:` connector.
 
 When interacting with a GCS container through the S3A connector may make sense
 * The installation doesn't have the gcs-connector JAR.


### PR DESCRIPTION
### Description of PR

This PR updates the S3A third-party-store documentation for Google Cloud
Storage to point users to Hadoop's `hadoop-gcp` `gs:` connector configuration
page instead of the external Dataproc connector page.

The existing S3A compatibility scenarios, configuration, limitations, and test
guidance remain unchanged. This is a documentation-only change: it does not
modify Java code, dependencies, public APIs, configuration defaults or
examples, endpoints, regions, or runtime behavior.

Jira: https://issues.apache.org/jira/browse/HADOOP-19851

HADOOP-19851 supplied the problem statement and requested direction. PR #8058
was reviewed only because it also changes this Markdown file; no unmerged code,
commit, or wording from that PR was reused. This patch was authored
independently against the current `trunk` baseline.

Contains content generated by Codex

### How was this patch tested?

Environment: Windows x86_64, Eclipse Temurin 17.0.19, and the project Maven
Wrapper with Maven 3.9.15.

1. Installed the reactor artifacts required by the two affected site modules:

   ```powershell
   .\mvnw.cmd --batch-mode --no-transfer-progress install `
     -pl ":hadoop-aws,:hadoop-gcp" -am "-P=-native-win" `
     "-DskipTests" "-DskipShade" "-DskipDocs"
   ```

   All 36 reactor projects completed successfully. This command skipped tests
   and was used only to prepare local site artifacts.

2. Ran the targeted site build twice, as required by `BUILDING.txt`:

   ```powershell
   .\mvnw.cmd --batch-mode --no-transfer-progress site site:stage `
     -pl ":hadoop-aws,:hadoop-gcp" "-Preleasedocs,docs" `
     "-DstagingDirectory=<temporary-directory>" "-DgenerateReports=false"
   ```

   Both runs completed with `BUILD SUCCESS`. The generated
   `third_party_stores.html` contained
   `../../../hadoop-gcp/tools/hadoop-gcp/Configuration.html`; resolving that
   href from the generated source page matched the generated
   `Configuration.html` file, which existed. The new `gs:` guidance was present
   and the old Dataproc connector link was absent.

3. Ran Apache Yetus 0.14.1 from an isolated baseline worktree:

   ```text
   dev-support/bin/test-patch --branch=799ef577... \
     --basedir=<isolated-worktree> --patch-dir=<temporary-directory> \
     --git-offline --build-native=false --java-home=<JDK-17> <patch-file>
   ```

   Yetus reported `+1 overall`. The Hadoop personality classified the pure
   Markdown patch as `nobuild`, so this did not run Java compilation or tests.

4. `git diff --check upstream/trunk...HEAD` completed without errors.

The root-reactor aggregate site was not completed because the local environment
did not contain every artifact required by the full reactor; one Maven Central
request was also reset. The two affected modules' generated pages and their
cross-module href were verified directly. Java tests and object-store
integration tests are not applicable because the final diff changes no code,
configuration, endpoint, region, or runtime semantics.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
      N/A: this patch changes documentation guidance only and does not change an object-store endpoint or runtime behavior.
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
      N/A: no dependencies are added.
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
      N/A: the change adds no dependency or third-party material requiring a license or notice update.

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
