### PR TITLE
YARN-11971: Add validation to block adding queue capacity in partition view if the queue does not have the accessible label configured

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/config/__tests__/validation-rules.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/config/__tests__/validation-rules.test.ts
@@ -1200,4 +1200,31 @@ describe('CAPACITY_SUM validation rule', () => {
     // Should skip because absolute capacity doesn't have sum-to-100% requirement
     expect(capacitySumIssues).toHaveLength(0);
   });
+
+  it('blocks removing accessible labels while label partition capacity remains', () => {
+    const config = new Map([
+      [
+        'yarn.scheduler.capacity.root.default.accessible-node-labels.gpu.capacity',
+        '50',
+      ],
+    ]);
+
+    const context: ValidationContext = {
+      queuePath: 'root.default',
+      fieldName: 'accessible-node-labels',
+      fieldValue: 'fpga',
+      config,
+      schedulerData: createMockSchedulerData(),
+      stagedChanges: [],
+      legacyModeEnabled: false,
+    };
+
+    const issues = runFieldValidation(context);
+    const removalIssues = issues.filter(
+      (issue) => issue.rule === 'label-partition-capacity-requires-access',
+    );
+
+    expect(removalIssues).toHaveLength(1);
+    expect(removalIssues[0]?.message).toContain('gpu');
+  });
 });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/config/validation-rules.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/config/validation-rules.ts
@@ -24,6 +24,7 @@ import { AUTO_CREATION_PROPS } from '~/types/constants/auto-creation';
 import type { StagedChange, ValidationIssue, SchedulerInfo } from '~/types';
 import { findQueueByPath, getSiblingQueues } from '~/utils/treeUtils';
 import { isTemplateQueuePath } from '~/utils/templateUtils';
+import { getAccessibleLabelRemovalIssues } from '~/features/queue-management/utils/capacityValidation';
 
 export interface ValidationContext {
   queuePath: string;
@@ -87,6 +88,19 @@ export const QUEUE_VALIDATION_RULES: ValidationRule[] = [
     level: 'error',
     triggers: ['capacity'],
     evaluate: (context) => evaluateWeightModeTransitionFlexibleAQC(context),
+  },
+  {
+    id: 'LABEL_PARTITION_CAPACITY_REQUIRES_ACCESS',
+    description:
+      'Prevents removing a label from accessible-node-labels while label partition capacity remains configured.',
+    level: 'error',
+    triggers: ['accessible-node-labels'],
+    evaluate: (context) =>
+      getAccessibleLabelRemovalIssues(
+        context.queuePath,
+        typeof context.fieldValue === 'string' ? context.fieldValue : '',
+        context.config,
+      ),
   },
 ];
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/components/CapacityEditorDialog.tsx
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/components/CapacityEditorDialog.tsx
@@ -17,7 +17,7 @@
  */
 
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Loader2 } from 'lucide-react';
 import {
   Dialog,
@@ -48,6 +48,7 @@ import {
   parseVectorDraft,
 } from '~/features/queue-management/utils/capacityEditor';
 import { computeRemainingHelper } from '../utils/capacityRemainingHelper';
+import { getLabelPartitionAccessIssues } from '../utils/capacityValidation';
 import { RemainingHelperDisplay } from './RemainingHelperDisplay';
 import { CapacityRowEditor } from './CapacityRowEditor';
 import type { CapacityResourceMode, CapacityRowDraft } from '~/stores/slices/capacityEditorSlice';
@@ -99,6 +100,8 @@ export const CapacityEditorDialog: React.FC = () => {
   const getQueuePartitionCapacities = useSchedulerStore(
     (state) => state.getQueuePartitionCapacities,
   );
+  const hasQueueProperty = useSchedulerStore((state) => state.hasQueueProperty);
+  const getQueuePropertyValue = useSchedulerStore((state) => state.getQueuePropertyValue);
 
   const rows = draftOrder
     .map((queuePath) => drafts[queuePath])
@@ -113,7 +116,21 @@ export const CapacityEditorDialog: React.FC = () => {
     getQueuePartitionCapacities,
   });
 
-  const hasBlockingIssues = validationIssues.some((issue) => issue.severity === 'error');
+  const labelAccessIssues = useMemo(
+    () =>
+      getLabelPartitionAccessIssues(rows, selectedNodeLabel, {
+        hasQueueProperty,
+        getQueuePropertyValue,
+      }),
+    [rows, selectedNodeLabel, hasQueueProperty, getQueuePropertyValue],
+  );
+
+  const allValidationIssues = useMemo(
+    () => [...validationIssues, ...labelAccessIssues],
+    [validationIssues, labelAccessIssues],
+  );
+
+  const hasBlockingIssues = allValidationIssues.some((issue) => issue.severity === 'error');
 
   const handleSave = async (force: boolean) => {
     const success = await saveCapacityDrafts({ force });
@@ -275,10 +292,10 @@ export const CapacityEditorDialog: React.FC = () => {
                 ? `accessible-node-labels.${selectedNodeLabel}.maximum-capacity`
                 : 'maximum-capacity';
 
-              const capacityIssuesForRow = validationIssues.filter(
+              const capacityIssuesForRow = allValidationIssues.filter(
                 (issue) => issue.queuePath === row.queuePath && issue.field === capacityFieldName,
               );
-              const maxIssuesForRow = validationIssues.filter(
+              const maxIssuesForRow = allValidationIssues.filter(
                 (issue) => issue.queuePath === row.queuePath && issue.field === maxFieldName,
               );
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/components/__tests__/CapacityEditorDialog.test.tsx
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/components/__tests__/CapacityEditorDialog.test.tsx
@@ -85,6 +85,8 @@ describe('CapacityEditorDialog', () => {
         saveCapacityDrafts: mockSaveCapacityDrafts,
         getQueuePropertyValue: () => ({ value: '', isStaged: false }),
         getGlobalPropertyValue: () => ({ value: 'false', isStaged: false }),
+        hasQueueProperty: () => true,
+        getQueueAccessibility: () => true,
         getQueuePartitionCapacities: mockGetQueuePartitionCapacities,
         ...overrides,
       };
@@ -649,6 +651,47 @@ describe('CapacityEditorDialog', () => {
 
       expect(
         screen.getByText(/This queue doesn't have access to the gpu label/i),
+      ).toBeInTheDocument();
+    });
+
+    it('should show validation error when label partition capacity is set without access', () => {
+      const draft = createMockDraft({
+        capacityValue: '50',
+        maxCapacityValue: '100',
+      });
+
+      mockStoreState({
+        hasQueueProperty: () => false,
+        getQueuePropertyValue: () => ({ value: '', isStaged: false }),
+        capacityEditor: {
+          isOpen: true,
+          drafts: { [draft.queuePath]: draft },
+          draftOrder: [draft.queuePath],
+          parentQueuePath: 'root',
+          selectedNodeLabel: 'gpu',
+          labelOptions: [
+            { value: '__DEFAULT_PARTITION__', label: 'Default partition' },
+            { value: 'gpu', label: 'gpu' },
+          ],
+          labelsWithoutAccess: new Set(['gpu']),
+          validationIssues: [],
+          isSaving: false,
+          saveError: null,
+          origin: 'property-editor',
+          originQueuePath: draft.queuePath,
+          originQueueName: draft.queueName,
+          originQueueState: null,
+          originInitialCapacity: null,
+          originInitialMaxCapacity: null,
+          originIsNew: false,
+          draftCache: {},
+        },
+      });
+
+      render(<CapacityEditorDialog />);
+
+      expect(
+        screen.getByText(/Add "gpu" to accessible-node-labels before setting label partition capacity/i),
       ).toBeInTheDocument();
     });
   });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.test.ts
@@ -67,8 +67,6 @@ describe('useCapacityEditor', () => {
         originQueuePath: 'root.department.new',
         originQueueName: 'new',
         selectedNodeLabel: 'sales',
-        capacityValue: '10',
-        maxCapacityValue: '50',
         markOriginAsNew: true,
         queueState: 'RUNNING',
       });
@@ -85,5 +83,53 @@ describe('useCapacityEditor', () => {
       originIsNew: true,
       selectedNodeLabel: 'sales',
     });
+  });
+
+  it('ignores capacity prefill when a labeled partition is selected', () => {
+    const { result } = renderHook(() => useCapacityEditor());
+
+    act(() => {
+      result.current.openCapacityEditor({
+        origin: 'add-queue',
+        parentQueuePath: 'root.department',
+        originQueuePath: 'root.department.new',
+        originQueueName: 'new',
+        selectedNodeLabel: 'sales',
+        capacityValue: '10',
+        maxCapacityValue: '50',
+      });
+    });
+
+    expect(openCapacityEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originInitialCapacity: null,
+        originInitialMaxCapacity: null,
+        selectedNodeLabel: 'sales',
+      }),
+    );
+  });
+
+  it('forwards capacity prefill for the default partition', () => {
+    mockStore.selectedNodeLabelFilter = '';
+    const { result } = renderHook(() => useCapacityEditor());
+
+    act(() => {
+      result.current.openCapacityEditor({
+        origin: 'add-queue',
+        parentQueuePath: 'root.department',
+        originQueuePath: 'root.department.new',
+        originQueueName: 'new',
+        capacityValue: '10',
+        maxCapacityValue: '50',
+      });
+    });
+
+    expect(openCapacityEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originInitialCapacity: '10',
+        originInitialMaxCapacity: '50',
+        selectedNodeLabel: '',
+      }),
+    );
   });
 });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.test.ts
@@ -80,8 +80,8 @@ describe('useCapacityEditor', () => {
       originQueuePath: 'root.department.new',
       originQueueName: 'new',
       originQueueState: 'RUNNING',
-      originInitialCapacity: '10',
-      originInitialMaxCapacity: '50',
+      originInitialCapacity: null,
+      originInitialMaxCapacity: null,
       originIsNew: true,
       selectedNodeLabel: 'sales',
     });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.ts
@@ -76,16 +76,18 @@ export const useCapacityEditor = () => {
         originQueueName,
       );
 
+      const resolvedLabel = selectedNodeLabel ?? selectedNodeLabelFilter ?? null;
+
       openCapacityEditorAction({
         origin,
         parentQueuePath,
         originQueuePath: resolvedOriginPath,
         originQueueName,
         originQueueState: queueState,
-        originInitialCapacity: capacityValue,
-        originInitialMaxCapacity: maxCapacityValue,
+        originInitialCapacity: resolvedLabel ? null : capacityValue,
+        originInitialMaxCapacity: resolvedLabel ? null : maxCapacityValue,
         originIsNew: Boolean(markOriginAsNew),
-        selectedNodeLabel: selectedNodeLabel ?? selectedNodeLabelFilter ?? null,
+        selectedNodeLabel: resolvedLabel,
       });
     },
   };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/hooks/useCapacityEditor.ts
@@ -20,6 +20,7 @@
 import { SPECIAL_VALUES } from '~/types';
 import { useSchedulerStore } from '~/stores/schedulerStore';
 import type { CapacityEditorOrigin } from '~/stores/slices/capacityEditorSlice';
+import { a } from 'vitest/dist/chunks/suite.d.FvehnV49.js';
 
 const resolveOriginQueuePath = (
   parentQueuePath: string,
@@ -76,7 +77,7 @@ export const useCapacityEditor = () => {
         originQueueName,
       );
 
-      const resolvedLabel = selectedNodeLabel ?? selectedNodeLabelFilter ?? null;
+      const activeNodeLabel = selectedNodeLabel ?? selectedNodeLabelFilter ?? null;
 
       openCapacityEditorAction({
         origin,
@@ -84,10 +85,10 @@ export const useCapacityEditor = () => {
         originQueuePath: resolvedOriginPath,
         originQueueName,
         originQueueState: queueState,
-        originInitialCapacity: resolvedLabel ? null : capacityValue,
-        originInitialMaxCapacity: resolvedLabel ? null : maxCapacityValue,
+        originInitialCapacity: activeNodeLabel ? null : capacityValue,
+        originInitialMaxCapacity: activeNodeLabel ? null : maxCapacityValue,
         originIsNew: Boolean(markOriginAsNew),
-        selectedNodeLabel: resolvedLabel,
+        selectedNodeLabel: activeNodeLabel,
       });
     },
   };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.test.ts
@@ -20,17 +20,18 @@ import { describe, expect, it } from 'vitest';
 import type { CapacityRowDraft } from '~/stores/slices/capacityEditorSlice';
 import {
   getLabelPartitionAccessIssues,
-  queueListsAccessibleNodeLabel,
+  getAccessibleLabelRemovalIssues,
+  isLabelListedInQueue,
 } from './capacityValidation';
 
-describe('queueListsAccessibleNodeLabel', () => {
+describe('isLabelListedInQueue', () => {
   it('returns false when the queue has no accessible-node-labels property', () => {
     const store = {
       hasQueueProperty: () => false,
       getQueuePropertyValue: () => ({ value: '', isStaged: false }),
     };
 
-    expect(queueListsAccessibleNodeLabel('root.default', 'gpu', store)).toBe(false);
+    expect(isLabelListedInQueue('root.default', 'gpu', store)).toBe(false);
   });
 
   it('returns false when accessible-node-labels is empty', () => {
@@ -39,7 +40,7 @@ describe('queueListsAccessibleNodeLabel', () => {
       getQueuePropertyValue: () => ({ value: '', isStaged: false }),
     };
 
-    expect(queueListsAccessibleNodeLabel('root.default', 'gpu', store)).toBe(false);
+    expect(isLabelListedInQueue('root.default', 'gpu', store)).toBe(false);
   });
 
   it('returns true when the label is listed on the queue', () => {
@@ -48,7 +49,7 @@ describe('queueListsAccessibleNodeLabel', () => {
       getQueuePropertyValue: () => ({ value: 'gpu,label3', isStaged: false }),
     };
 
-    expect(queueListsAccessibleNodeLabel('root.default', 'label3', store)).toBe(true);
+    expect(isLabelListedInQueue('root.default', 'label3', store)).toBe(true);
   });
 
   it('returns true when the queue lists all labels via wildcard', () => {
@@ -57,7 +58,7 @@ describe('queueListsAccessibleNodeLabel', () => {
       getQueuePropertyValue: () => ({ value: '*', isStaged: false }),
     };
 
-    expect(queueListsAccessibleNodeLabel('root.default', 'label3', store)).toBe(true);
+    expect(isLabelListedInQueue('root.default', 'label3', store)).toBe(true);
   });
 });
 
@@ -119,5 +120,41 @@ describe('getLabelPartitionAccessIssues', () => {
     expect(issues).toHaveLength(2);
     expect(issues[0]?.field).toBe('accessible-node-labels.gpu.capacity');
     expect(issues[1]?.field).toBe('accessible-node-labels.gpu.maximum-capacity');
+  });
+});
+
+describe('getAccessibleLabelRemovalIssues', () => {
+  it('blocks removing a label that still has partition capacity configured', () => {
+    const config = new Map<string, string>([
+      [
+        'yarn.scheduler.capacity.root.default.accessible-node-labels.gpu.capacity',
+        '50',
+      ],
+    ]);
+
+    const issues = getAccessibleLabelRemovalIssues('root.default', 'fpga', config);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.field).toBe('accessible-node-labels');
+    expect(issues[0]?.message).toContain('gpu');
+  });
+
+  it('allows removing access when partition capacity is cleared', () => {
+    const issues = getAccessibleLabelRemovalIssues('root.default', 'fpga', new Map());
+
+    expect(issues).toEqual([]);
+  });
+
+  it('allows wildcard access even when partition capacity is configured', () => {
+    const config = new Map<string, string>([
+      [
+        'yarn.scheduler.capacity.root.default.accessible-node-labels.gpu.capacity',
+        '50',
+      ],
+    ]);
+
+    const issues = getAccessibleLabelRemovalIssues('root.default', '*', config);
+
+    expect(issues).toEqual([]);
   });
 });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.test.ts
@@ -110,7 +110,7 @@ describe('getLabelPartitionAccessIssues', () => {
     expect(issues).toEqual([]);
   });
 
-  it('blocks non-empty label partition capacity when the queue does not list the label', () => {
+  it('blocks filling queue-partition capacity when the queue does not have the label', () => {
     const issues = getLabelPartitionAccessIssues(
       [createRow({ capacityValue: '50', maxCapacityValue: '100' })],
       'gpu',
@@ -139,13 +139,13 @@ describe('getAccessibleLabelRemovalIssues', () => {
     expect(issues[0]?.message).toContain('gpu');
   });
 
-  it('allows removing access when partition capacity is cleared', () => {
+  it('allows removing access when queue-partition capacity is not there', () => {
     const issues = getAccessibleLabelRemovalIssues('root.default', 'fpga', new Map());
 
     expect(issues).toEqual([]);
   });
 
-  it('allows wildcard access even when partition capacity is configured', () => {
+  it('allows wildcard access even when queue-partition capacity is configured', () => {
     const config = new Map<string, string>([
       [
         'yarn.scheduler.capacity.root.default.accessible-node-labels.gpu.capacity',

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { CapacityRowDraft } from '~/stores/slices/capacityEditorSlice';
+import {
+  getLabelPartitionAccessIssues,
+  queueListsAccessibleNodeLabel,
+} from './capacityValidation';
+
+describe('queueListsAccessibleNodeLabel', () => {
+  it('returns false when the queue has no accessible-node-labels property', () => {
+    const store = {
+      hasQueueProperty: () => false,
+      getQueuePropertyValue: () => ({ value: '', isStaged: false }),
+    };
+
+    expect(queueListsAccessibleNodeLabel('root.default', 'gpu', store)).toBe(false);
+  });
+
+  it('returns false when accessible-node-labels is empty', () => {
+    const store = {
+      hasQueueProperty: () => true,
+      getQueuePropertyValue: () => ({ value: '', isStaged: false }),
+    };
+
+    expect(queueListsAccessibleNodeLabel('root.default', 'gpu', store)).toBe(false);
+  });
+
+  it('returns true when the label is listed on the queue', () => {
+    const store = {
+      hasQueueProperty: () => true,
+      getQueuePropertyValue: () => ({ value: 'gpu,label3', isStaged: false }),
+    };
+
+    expect(queueListsAccessibleNodeLabel('root.default', 'label3', store)).toBe(true);
+  });
+
+  it('returns true when the queue lists all labels via wildcard', () => {
+    const store = {
+      hasQueueProperty: () => true,
+      getQueuePropertyValue: () => ({ value: '*', isStaged: false }),
+    };
+
+    expect(queueListsAccessibleNodeLabel('root.default', 'label3', store)).toBe(true);
+  });
+});
+
+describe('getLabelPartitionAccessIssues', () => {
+  const createRow = (overrides: Partial<CapacityRowDraft> = {}): CapacityRowDraft => ({
+    queuePath: 'root.default',
+    queueName: 'default',
+    isOrigin: false,
+    isNew: false,
+    hasStagedChange: false,
+    mode: 'simple',
+    baseMode: 'simple',
+    baseCapacityValue: '',
+    baseMaxCapacityValue: '',
+    capacityValue: '',
+    maxCapacityValue: '',
+    vectorCapacity: [],
+    vectorMaxCapacity: [],
+    ...overrides,
+  });
+
+  const queueWithLabel = {
+    hasQueueProperty: () => true,
+    getQueuePropertyValue: () => ({ value: 'gpu,label3', isStaged: false }),
+  };
+
+  const queueWithoutLabel = {
+    hasQueueProperty: () => false,
+    getQueuePropertyValue: () => ({ value: '', isStaged: false }),
+  };
+
+  it('returns no issues for the default partition', () => {
+    const issues = getLabelPartitionAccessIssues(
+      [createRow({ capacityValue: '50' })],
+      null,
+      queueWithoutLabel,
+    );
+
+    expect(issues).toEqual([]);
+  });
+
+  it('returns no issues when the queue lists the label in accessible-node-labels', () => {
+    const issues = getLabelPartitionAccessIssues(
+      [createRow({ capacityValue: '50' })],
+      'gpu',
+      queueWithLabel,
+    );
+
+    expect(issues).toEqual([]);
+  });
+
+  it('blocks non-empty label partition capacity when the queue does not list the label', () => {
+    const issues = getLabelPartitionAccessIssues(
+      [createRow({ capacityValue: '50', maxCapacityValue: '100' })],
+      'gpu',
+      queueWithoutLabel,
+    );
+
+    expect(issues).toHaveLength(2);
+    expect(issues[0]?.field).toBe('accessible-node-labels.gpu.capacity');
+    expect(issues[1]?.field).toBe('accessible-node-labels.gpu.maximum-capacity');
+  });
+});

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.ts
@@ -1,4 +1,22 @@
 /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Capacity validation utilities
  *
  * These functions extract changes from capacity editor drafts
@@ -6,6 +24,7 @@
  */
 
 import type { CapacityRowDraft } from '~/stores/slices/capacityEditorSlice';
+import type { SchedulerStore } from '~/stores/schedulerStore';
 import {
   convertVectorDraftToString,
   DEFAULT_PARTITION_VALUE,
@@ -15,9 +34,161 @@ import { buildPropertyKey } from '~/utils/propertyUtils';
 import { validateQueue } from '~/features/validation/service';
 import type { ValidationIssue, StagedChange, SchedulerInfo } from '~/types';
 
+const ACCESSIBLE_NODE_LABELS_PROPERTY = 'accessible-node-labels';
+const LABEL_PARTITION_ACCESS_RULE = 'label-partition-access';
+
+export type QueuePropertyReader = Pick<SchedulerStore, 'hasQueueProperty' | 'getQueuePropertyValue'>;
+
 export interface DraftCacheEntry {
   drafts: Record<string, CapacityRowDraft>;
   draftOrder: string[];
+}
+
+/**
+ * Returns whether a queue lists the label in its own accessible-node-labels property.
+ * Parent inheritance is intentionally not considered.
+ */
+export function queueListsAccessibleNodeLabel(
+  queuePath: string,
+  label: string,
+  store: QueuePropertyReader,
+): boolean {
+  if (!store.hasQueueProperty(queuePath, ACCESSIBLE_NODE_LABELS_PROPERTY)) {
+    return false;
+  }
+
+  const accessibleLabels = store
+    .getQueuePropertyValue(queuePath, ACCESSIBLE_NODE_LABELS_PROPERTY)
+    .value.trim();
+  if (!accessibleLabels) {
+    return false;
+  }
+
+  const labels = accessibleLabels.split(',').map((entry) => entry.trim());
+  return labels.includes('*') || labels.includes(label);
+}
+
+const getDraftCapacityValues = (draft: CapacityRowDraft) => ({
+  capacityValue:
+    draft.mode === 'vector'
+      ? convertVectorDraftToString(draft.vectorCapacity).trim()
+      : draft.capacityValue.trim(),
+  maxCapacityValue:
+    draft.mode === 'vector'
+      ? convertVectorDraftToString(draft.vectorMaxCapacity).trim()
+      : draft.maxCapacityValue.trim(),
+});
+
+const createLabelPartitionAccessIssue = (
+  queuePath: string,
+  field: string,
+  label: string,
+  propertyLabel: 'capacity' | 'maximum capacity',
+): ValidationIssue => ({
+  queuePath,
+  field,
+  severity: 'error',
+  rule: LABEL_PARTITION_ACCESS_RULE,
+  message: `Add "${label}" to accessible-node-labels before setting label partition ${propertyLabel}.`,
+});
+
+/**
+ * Validates label-partition capacity drafts for queues that do not list the label
+ * in their own accessible-node-labels property.
+ */
+export function getLabelPartitionAccessIssues(
+  rows: CapacityRowDraft[],
+  selectedNodeLabel: string | null,
+  store: QueuePropertyReader,
+): ValidationIssue[] {
+  if (!selectedNodeLabel) {
+    return [];
+  }
+
+  const capacityField = getPropertyNameForLabel(selectedNodeLabel, 'capacity');
+  const maxCapacityField = getPropertyNameForLabel(selectedNodeLabel, 'maximum-capacity');
+  const issues: ValidationIssue[] = [];
+
+  rows.forEach((row) => {
+    if (queueListsAccessibleNodeLabel(row.queuePath, selectedNodeLabel, store)) {
+      return;
+    }
+
+    const { capacityValue, maxCapacityValue } = getDraftCapacityValues(row);
+
+    if (capacityValue) {
+      issues.push(
+        createLabelPartitionAccessIssue(
+          row.queuePath,
+          capacityField,
+          selectedNodeLabel,
+          'capacity',
+        ),
+      );
+    }
+
+    if (maxCapacityValue) {
+      issues.push(
+        createLabelPartitionAccessIssue(
+          row.queuePath,
+          maxCapacityField,
+          selectedNodeLabel,
+          'maximum capacity',
+        ),
+      );
+    }
+  });
+
+  return issues;
+};
+
+const mergeCapacityEditorDraftCache = (
+  draftCache: Record<string, DraftCacheEntry>,
+  currentDrafts: Record<string, CapacityRowDraft>,
+  currentDraftOrder: string[],
+  selectedNodeLabel: string | null,
+): Record<string, DraftCacheEntry> => {
+  const currentCacheKey = selectedNodeLabel ?? DEFAULT_PARTITION_VALUE;
+
+  return {
+    ...draftCache,
+    [currentCacheKey]: {
+      drafts: { ...currentDrafts },
+      draftOrder: [...currentDraftOrder],
+    },
+  };
+};
+
+/** Validates all cached label-partition drafts in the capacity editor. */
+export function getLabelPartitionAccessIssuesForEditor(
+  draftCache: Record<string, DraftCacheEntry>,
+  currentDrafts: Record<string, CapacityRowDraft>,
+  currentDraftOrder: string[],
+  selectedNodeLabel: string | null,
+  store: QueuePropertyReader,
+): ValidationIssue[] {
+  const completeDraftCache = mergeCapacityEditorDraftCache(
+    draftCache,
+    currentDrafts,
+    currentDraftOrder,
+    selectedNodeLabel,
+  );
+
+  const issues: ValidationIssue[] = [];
+
+  Object.entries(completeDraftCache).forEach(([cacheKey, cachedData]) => {
+    if (cacheKey === DEFAULT_PARTITION_VALUE) {
+      return;
+    }
+
+    const rows = cachedData.draftOrder
+      .map((queuePath) => cachedData.drafts[queuePath])
+      .filter((row): row is CapacityRowDraft => Boolean(row));
+
+    issues.push(...getLabelPartitionAccessIssues(rows, cacheKey, store));
+  });
+
+  return issues;
 }
 
 export interface ExtractChangesParams {
@@ -42,17 +213,13 @@ export function extractChangesFromDrafts({
   const normalizeValue = (value: string) => value.trim();
   const changesByQueue = new Map<string, Record<string, string>>();
 
-  // Build a complete cache including the current drafts
-  const currentCacheKey = selectedNodeLabel ?? DEFAULT_PARTITION_VALUE;
-  const completeDraftCache: Record<string, DraftCacheEntry> = {
-    ...draftCache,
-    [currentCacheKey]: {
-      drafts: { ...currentDrafts },
-      draftOrder: [...currentDraftOrder],
-    },
-  };
+  const completeDraftCache = mergeCapacityEditorDraftCache(
+    draftCache,
+    currentDrafts,
+    currentDraftOrder,
+    selectedNodeLabel,
+  );
 
-  // Process all cached labels (including the currently selected one)
   Object.entries(completeDraftCache).forEach(([cacheKey, cachedData]) => {
     const label = cacheKey === DEFAULT_PARTITION_VALUE ? null : cacheKey;
     const capacityProperty = getPropertyNameForLabel(label, 'capacity');

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.ts
@@ -82,7 +82,6 @@ const parseQueueAccessibleNodeLabelsProperty = (
 
 /**
  * Returns whether a queue lists the label in its own accessible-node-labels property.
- * Parent inheritance is intentionally not considered.
  */
 export function isLabelListedInQueue(
   queuePath: string,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/queue-management/utils/capacityValidation.ts
@@ -36,36 +36,123 @@ import type { ValidationIssue, StagedChange, SchedulerInfo } from '~/types';
 
 const ACCESSIBLE_NODE_LABELS_PROPERTY = 'accessible-node-labels';
 const LABEL_PARTITION_ACCESS_RULE = 'label-partition-access';
+const LABEL_PARTITION_CAPACITY_REQUIRES_ACCESS_RULE =
+  'label-partition-capacity-requires-access';
+
+type AccessibleLabelAccess = 'all' | 'none' | Set<string>;
 
 export type QueuePropertyReader = Pick<SchedulerStore, 'hasQueueProperty' | 'getQueuePropertyValue'>;
 
-export interface DraftCacheEntry {
-  drafts: Record<string, CapacityRowDraft>;
-  draftOrder: string[];
-}
+export const parseAccessibleNodeLabels = (value: string): AccessibleLabelAccess => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 'none';
+  }
+  if (trimmed === '*') {
+    return 'all';
+  }
+  return new Set(trimmed.split(',').map((label) => label.trim()).filter(Boolean));
+};
+
+export const isLabelInAccessibleList = (
+  label: string,
+  accessibleLabels: AccessibleLabelAccess,
+): boolean => {
+  if (accessibleLabels === 'all') {
+    return true;
+  }
+  if (accessibleLabels === 'none') {
+    return false;
+  }
+  return accessibleLabels.has(label);
+};
+
+const parseQueueAccessibleNodeLabelsProperty = (
+  queuePath: string,
+  store: QueuePropertyReader,
+): AccessibleLabelAccess | null => {
+  if (!store.hasQueueProperty(queuePath, ACCESSIBLE_NODE_LABELS_PROPERTY)) {
+    return null;
+  }
+
+  return parseAccessibleNodeLabels(
+    store.getQueuePropertyValue(queuePath, ACCESSIBLE_NODE_LABELS_PROPERTY).value,
+  );
+};
 
 /**
  * Returns whether a queue lists the label in its own accessible-node-labels property.
  * Parent inheritance is intentionally not considered.
  */
-export function queueListsAccessibleNodeLabel(
+export function isLabelListedInQueue(
   queuePath: string,
   label: string,
   store: QueuePropertyReader,
 ): boolean {
-  if (!store.hasQueueProperty(queuePath, ACCESSIBLE_NODE_LABELS_PROPERTY)) {
+  const accessibleLabels = parseQueueAccessibleNodeLabelsProperty(queuePath, store);
+  if (accessibleLabels === null) {
     return false;
   }
 
-  const accessibleLabels = store
-    .getQueuePropertyValue(queuePath, ACCESSIBLE_NODE_LABELS_PROPERTY)
-    .value.trim();
-  if (!accessibleLabels) {
-    return false;
-  }
+  return isLabelInAccessibleList(label, accessibleLabels);
+};
 
-  const labels = accessibleLabels.split(',').map((entry) => entry.trim());
-  return labels.includes('*') || labels.includes(label);
+/** Labels with non-empty label-partition capacity configured on the queue. */
+export const getLabelsWithPartitionCapacityConfigured = (
+  queuePath: string,
+  config: Map<string, string>,
+): Set<string> => {
+  const prefix = buildPropertyKey(queuePath, `${ACCESSIBLE_NODE_LABELS_PROPERTY}.`);
+  const labels = new Set<string>();
+
+  config.forEach((value, key) => {
+    if (!key.startsWith(prefix) || !value.trim()) {
+      return;
+    }
+
+    const remainder = key.slice(prefix.length);
+    const match = remainder.match(/^([^.]+)\.(capacity|maximum-capacity)$/);
+    if (match?.[1]) {
+      labels.add(match[1]);
+    }
+  });
+
+  return labels;
+};
+
+/**
+ * Block removing a label from accessible-node-labels while label-partition capacity
+ * for that label remains configured on the queue.
+ */
+export function getAccessibleLabelRemovalIssues(
+  queuePath: string,
+  newAccessibleNodeLabels: string,
+  config: Map<string, string>,
+): ValidationIssue[] {
+  const accessibleLabels = parseAccessibleNodeLabels(newAccessibleNodeLabels);
+  const configuredLabels = getLabelsWithPartitionCapacityConfigured(queuePath, config);
+  const issues: ValidationIssue[] = [];
+
+  configuredLabels.forEach((label) => {
+    if (isLabelInAccessibleList(label, accessibleLabels)) {
+      return;
+    }
+
+    issues.push({
+      queuePath,
+      field: ACCESSIBLE_NODE_LABELS_PROPERTY,
+      severity: 'error',
+      rule: LABEL_PARTITION_CAPACITY_REQUIRES_ACCESS_RULE,
+      message: `Cannot remove "${label}" from accessible-node-labels while label partition capacity is configured. Clear label partition capacity first.`,
+    });
+  });
+
+  return issues;
+}
+
+export interface DraftCacheEntry {
+  drafts: Record<string, CapacityRowDraft>;
+  draftOrder: string[];
 }
 
 const getDraftCapacityValues = (draft: CapacityRowDraft) => ({
@@ -110,7 +197,7 @@ export function getLabelPartitionAccessIssues(
   const issues: ValidationIssue[] = [];
 
   rows.forEach((row) => {
-    if (queueListsAccessibleNodeLabel(row.queuePath, selectedNodeLabel, store)) {
+    if (isLabelListedInQueue(row.queuePath, selectedNodeLabel, store)) {
       return;
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/stores/slices/__tests__/capacityEditorSlice.test.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/stores/slices/__tests__/capacityEditorSlice.test.ts
@@ -766,7 +766,13 @@ describe('capacityEditorSlice', () => {
       vi.mocked(buildCapacityEditorDrafts).mockReturnValue(mockDrafts);
 
       store.setState({
-        getQueuePropertyValue: vi.fn(() => ({ value: '50', isStaged: false })),
+        hasQueueProperty: vi.fn((_queuePath, property) => property === 'accessible-node-labels'),
+        getQueuePropertyValue: vi.fn((queuePath, property) => {
+          if (property === 'accessible-node-labels') {
+            return { value: 'gpu', isStaged: false };
+          }
+          return { value: '50', isStaged: false };
+        }),
         stageQueueChange: vi.fn(),
         stageLabelQueueChange: vi.fn(),
       });
@@ -845,7 +851,13 @@ describe('capacityEditorSlice', () => {
       const stageLabelQueueChange = vi.fn();
 
       store.setState({
-        getQueuePropertyValue: vi.fn(() => ({ value: '50', isStaged: false })),
+        hasQueueProperty: vi.fn((_queuePath, property) => property === 'accessible-node-labels'),
+        getQueuePropertyValue: vi.fn((queuePath, property) => {
+          if (property === 'accessible-node-labels') {
+            return { value: 'gpu', isStaged: false };
+          }
+          return { value: '50', isStaged: false };
+        }),
         stageQueueChange: vi.fn(),
         stageLabelQueueChange,
       });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/stores/slices/capacityEditorSlice.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/stores/slices/capacityEditorSlice.ts
@@ -36,6 +36,7 @@ import {
   extractChangesFromDrafts,
   buildPreviewConfig,
   validateCapacityChanges,
+  getLabelPartitionAccessIssuesForEditor,
 } from '~/features/queue-management/utils/capacityValidation';
 import type { ValidationIssue } from '~/types';
 
@@ -385,6 +386,23 @@ export const createCapacityEditorSlice: StateCreator<
         state.capacityEditor.validationIssues = [];
       });
       return true;
+    }
+
+    const labelAccessIssues = getLabelPartitionAccessIssuesForEditor(
+      draftCache,
+      drafts,
+      draftOrder,
+      selectedNodeLabel,
+      storeSnapshot,
+    );
+
+    if (!force && labelAccessIssues.length > 0) {
+      set((state) => {
+        state.capacityEditor.isSaving = false;
+        state.capacityEditor.saveError = 'Capacity validation failed.';
+        state.capacityEditor.validationIssues = labelAccessIssues;
+      });
+      return false;
     }
 
     // Build preview config and validate

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -212,11 +212,12 @@ public class CapacityScheduler extends
       yarnConf = conf;
   }
 
-  private void validateConf(Configuration conf) {
+  private void validateConf(Configuration conf) throws IOException {
     // validate scheduler memory allocation setting
     CapacitySchedulerConfigValidator.validateMemoryAllocation(conf);
     // validate scheduler vcores allocation setting
     CapacitySchedulerConfigValidator.validateVCores(conf);
+    CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
@@ -161,19 +161,19 @@ public final class CapacitySchedulerConfigValidator {
   }
 
   private static boolean isLabelAccessibleByQueue(
-      CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
+          CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
     QueuePath currentQueue = queue;
     while (currentQueue != null && !currentQueue.isRoot()) {
       String accessibleNodeLabelsKey = getQueuePrefix(currentQueue) + ACCESSIBLE_NODE_LABELS;
       if (conf.get(accessibleNodeLabelsKey) != null) {
         Set<String> accessibleLabels = conf.getAccessibleNodeLabels(currentQueue);
         return accessibleLabels.contains(RMNodeLabelsManager.ANY)
-            || accessibleLabels.contains(label);
+                || accessibleLabels.contains(label);
       }
       currentQueue = currentQueue.getParentObject();
     }
-    // No queue on the path declared accessible-node-labels; treat like root (*).
-    return true;
+    // No queue on the path declared accessible-node-labels; label is not accessible.
+    return false;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
@@ -160,6 +160,10 @@ public final class CapacitySchedulerConfigValidator {
     return maxCapacity != null && !maxCapacity.trim().isEmpty();
   }
 
+  /***
+   * Requires queue in the queue-path to declare accessible-node-labels explicitly. 
+   * The inheritance from root’s implicit * label is not accepted here.
+   */
   private static boolean isLabelAccessibleByQueue(
           CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
     QueuePath currentQueue = queue;
@@ -172,7 +176,7 @@ public final class CapacitySchedulerConfigValidator {
       }
       currentQueue = currentQueue.getParentObject();
     }
-    // No queue on the path declared accessible-node-labels; label is not accessible.
+
     return false;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
@@ -121,8 +121,9 @@ public final class CapacitySchedulerConfigValidator {
   }
 
   /**
-   * Validates that queue's partition capacity could only be configured if the queue is accessible by that label
-   * and vice versa, the label that is accessible by the queue could not be removed if
+   * Validates that queue's partition capacity.
+   * It could only be configured if the queue is accessible by that label and vice versa,
+   * the label that is accessible by the queue could not be removed if
    * it has capacity or max-capacity configured in queue's partition
    *
    * @param conf Capacity Scheduler configuration to validate
@@ -144,7 +145,8 @@ public final class CapacitySchedulerConfigValidator {
           continue;
         }
 
-        throw new IOException("Queue: " + queuePath + " must have accessible-node-labels and its capacity together");
+        throw new IOException("Queue: " + queuePath +
+          " must have accessible-node-labels and its capacity together");
       }
     }
   }
@@ -160,8 +162,8 @@ public final class CapacitySchedulerConfigValidator {
     return maxCapacity != null && !maxCapacity.trim().isEmpty();
   }
 
-  /***
-   * Requires queue in the queue-path to declare accessible-node-labels explicitly. 
+  /**
+   * Requires queue in the queue-path to declare accessible-node-labels explicitly.
    * The inheritance from root’s implicit * label is not accepted here.
    */
   private static boolean isLabelAccessibleByQueue(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
@@ -137,9 +137,9 @@ public final class CapacitySchedulerConfigValidator {
         continue;
       }
 
-      for (String label : csConf.getConfiguredNodeLabels(queue)) { // return NO_LABEL if queue does not have any labels
+      for (String label : csConf.getConfiguredNodeLabels(queue)) {
         if (RMNodeLabelsManager.NO_LABEL.equals(label)
-            || !hasNonEmptyPartitionCapacity(csConf, queue, label)
+            || !hasQueuePartitionCapacity(csConf, queue, label)
             || isLabelAccessibleByQueue(csConf, queue, label)) {
           continue;
         }
@@ -149,7 +149,7 @@ public final class CapacitySchedulerConfigValidator {
     }
   }
 
-  private static boolean hasNonEmptyPartitionCapacity(
+  private static boolean hasQueuePartitionCapacity(
       CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
     String labelPrefix = QueuePrefixes.getNodeLabelPrefix(queue, label);
     String capacity = conf.get(labelPrefix + CAPACITY);
@@ -162,12 +162,18 @@ public final class CapacitySchedulerConfigValidator {
 
   private static boolean isLabelAccessibleByQueue(
       CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
-    Set<String> accessibleLabels = conf.getAccessibleNodeLabels(queue);
-    if (accessibleLabels == null) {
-      return false;
+    QueuePath currentQueue = queue;
+    while (currentQueue != null && !currentQueue.isRoot()) {
+      String accessibleNodeLabelsKey = getQueuePrefix(currentQueue) + ACCESSIBLE_NODE_LABELS;
+      if (conf.get(accessibleNodeLabelsKey) != null) {
+        Set<String> accessibleLabels = conf.getAccessibleNodeLabels(currentQueue);
+        return accessibleLabels.contains(RMNodeLabelsManager.ANY)
+            || accessibleLabels.contains(label);
+      }
+      currentQueue = currentQueue.getParentObject();
     }
-    return accessibleLabels.contains(RMNodeLabelsManager.ANY)
-        || accessibleLabels.contains(label);
+    // No queue on the path declared accessible-node-labels; treat like root (*).
+    return true;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.yarn.api.records.QueueState;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,11 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ACCESSIBLE_NODE_LABELS;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.CAPACITY;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAXIMUM_CAPACITY;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueuePrefixes.getQueuePrefix;
 
 public final class CapacitySchedulerConfigValidator {
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -112,6 +118,56 @@ public final class CapacitySchedulerConfigValidator {
               + "=" + maxVcores + ", min and max should be greater than 0"
               + ", max should be no smaller than min.");
     }
+  }
+
+  /**
+   * Validates that queue's partition capacity could only be configured if the queue is accessible by that label
+   * and vice versa, the label that is accessible by the queue could not be removed if
+   * it has capacity or max-capacity configured in queue's partition
+   *
+   * @param conf Capacity Scheduler configuration to validate
+   * @throws IOException when the above rules have been violated
+   */
+  public static void validateQueueAccessibleLabels(Configuration conf) throws IOException {
+    CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration(conf);
+
+    for (String queuePath : csConf.getConfiguredNodeLabelsByQueue().keySet()) {
+      QueuePath queue = new QueuePath(queuePath);
+      if (queue.isRoot()) {
+        continue;
+      }
+
+      for (String label : csConf.getConfiguredNodeLabels(queue)) { // return NO_LABEL if queue does not have any labels
+        if (RMNodeLabelsManager.NO_LABEL.equals(label)
+            || !hasNonEmptyPartitionCapacity(csConf, queue, label)
+            || isLabelAccessibleByQueue(csConf, queue, label)) {
+          continue;
+        }
+
+        throw new IOException("Queue: " + queuePath + " must have accessible-node-labels and its capacity together");
+      }
+    }
+  }
+
+  private static boolean hasNonEmptyPartitionCapacity(
+      CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
+    String labelPrefix = QueuePrefixes.getNodeLabelPrefix(queue, label);
+    String capacity = conf.get(labelPrefix + CAPACITY);
+    if (capacity != null && !capacity.trim().isEmpty()) {
+      return true;
+    }
+    String maxCapacity = conf.get(labelPrefix + MAXIMUM_CAPACITY);
+    return maxCapacity != null && !maxCapacity.trim().isEmpty();
+  }
+
+  private static boolean isLabelAccessibleByQueue(
+      CapacitySchedulerConfiguration conf, QueuePath queue, String label) {
+    Set<String> accessibleLabels = conf.getAccessibleNodeLabels(queue);
+    if (accessibleLabels == null) {
+      return false;
+    }
+    return accessibleLabels.contains(RMNodeLabelsManager.ANY)
+        || accessibleLabels.contains(label);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerQueueManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerQueueManager.java
@@ -201,6 +201,7 @@ public class CapacitySchedulerQueueManager implements SchedulerQueueManager<
       // Ensure queue hierarchy in the new XML file is proper.
       CapacitySchedulerConfigValidator
               .validateQueueHierarchy(queues, newQueues, newConf);
+      CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(newConf);
     }
 
     // Add new queues and delete OldQeueus only after validation.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAbsoluteResourceConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAbsoluteResourceConfiguration.java
@@ -170,6 +170,11 @@ public class TestAbsoluteResourceConfiguration {
 
   private CapacitySchedulerConfiguration setupLabeledConfiguration(
       CapacitySchedulerConfiguration csConf) {
+    csConf.setAccessibleNodeLabels(QUEUEA_FULL, Set.of(X_LABEL, Y_LABEL));
+    csConf.setAccessibleNodeLabels(QUEUEB_FULL, Set.of(X_LABEL, Y_LABEL));
+    csConf.setAccessibleNodeLabels(QUEUEC_FULL, Set.of(X_LABEL, Y_LABEL));
+    csConf.setAccessibleNodeLabels(QUEUED_FULL, Set.of(X_LABEL, Y_LABEL));
+
     csConf.setMinimumResourceRequirement("", QUEUEA_FULL, Resource.newInstance(20 * GB, 8));
     csConf.setMinimumResourceRequirement("", QUEUEB_FULL, Resource.newInstance(10 * GB, 3));
     csConf.setMinimumResourceRequirement("", QUEUEC_FULL, Resource.newInstance(10 * GB, 2));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
@@ -754,6 +754,14 @@ public class TestApplicationLimits {
     conf.setCapacity(AA2_QUEUE_PATH, 50);
     conf.setCapacity(AA3_QUEUE_PATH, 0);
 
+    conf.setAccessibleNodeLabels(A_QUEUE_PATH, Set.of("x", "y", "z"));
+    conf.setAccessibleNodeLabels(B_QUEUE_PATH, Set.of("x", "y", "z"));
+    conf.setAccessibleNodeLabels(C_QUEUE_PATH, Set.of("y"));
+    conf.setAccessibleNodeLabels(D_QUEUE_PATH, Set.of("y"));
+    conf.setAccessibleNodeLabels(AA1_QUEUE_PATH, Set.of("x", "y"));
+    conf.setAccessibleNodeLabels(AA2_QUEUE_PATH, Set.of("x", "y", "z"));
+    conf.setAccessibleNodeLabels(AA3_QUEUE_PATH, Set.of("z"));
+
     conf.setCapacityByLabel(A_QUEUE_PATH, "y", 25);
     conf.setCapacityByLabel(B_QUEUE_PATH, "y", 50);
     conf.setCapacityByLabel(C_QUEUE_PATH, "y", 25);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
@@ -783,6 +783,22 @@ public class TestCapacitySchedulerConfigValidator {
   }
 
   @Test
+  public void testValidateQueueAccessibleLabelsRejectsAbsoluteMinResourceWithoutAccessibleLabels() {
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath queue = new QueuePath("root.queueC");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"queueC"});
+    conf.setCapacity(queue, 25);
+    conf.setMinimumResourceRequirement("x", queue, Resource.newInstance(10 * 1024, 2));
+    conf.setMaximumResourceRequirement("x", queue, Resource.newInstance(20 * 1024, 4));
+
+    IOException exception = assertThrows(IOException.class, () ->
+        CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf));
+    assertTrue(exception.getMessage().contains(ACCESSIBLE_LABELS_CAPACITY_ERROR));
+    assertTrue(exception.getMessage().contains("root.queueC"));
+  }
+
+  @Test
   public void testValidateQueueAccessibleLabelsRejectsCapacityWithoutAccessibleLabelsProperty() {
     CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
     QueuePath sibling = new QueuePath("root.sibling");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
@@ -774,11 +774,27 @@ public class TestCapacitySchedulerConfigValidator {
         new String[] {"test1"});
     conf.setCapacity(queue, 100);
     conf.setCapacityByLabel(queue, "gpu", 50);
+    conf.setAccessibleNodeLabels(queue, Set.of());
 
     IOException exception = assertThrows(IOException.class, () ->
         CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf));
     assertTrue(exception.getMessage().contains(ACCESSIBLE_LABELS_CAPACITY_ERROR));
     assertTrue(exception.getMessage().contains("root.test1"));
+  }
+
+  @Test
+  public void testValidateQueueAccessibleLabelsAllowsInheritedAccessibleLabel()
+      throws IOException {
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath parent = new QueuePath("root.c");
+    QueuePath template = new QueuePath("root.c.leaf-queue-template");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"c"});
+    conf.setCapacity(parent, 100);
+    conf.setAccessibleNodeLabels(parent, Set.of("gpu"));
+    conf.setCapacityByLabel(template, "gpu", 50);
+
+    CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf);
   }
 
   @Test
@@ -804,6 +820,7 @@ public class TestCapacitySchedulerConfigValidator {
     conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
         new String[] {"test1"});
     conf.setCapacity(queue, 100);
+    conf.setAccessibleNodeLabels(queue, Set.of());
     conf.setMaximumCapacityByLabel(queue, "gpu", 100);
 
     IOException exception = assertThrows(IOException.class, () ->

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.hadoop.yarn.api.records.ResourceInformation.GPU_URI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -734,5 +735,80 @@ public class TestCapacitySchedulerConfigValidator {
     }
 
     return csConf;
+  }
+
+  private static final String ACCESSIBLE_LABELS_CAPACITY_ERROR =
+      "must have accessible-node-labels and its capacity together";
+
+  @Test
+  public void testValidateQueueAccessibleLabelsAllowsListedLabel() throws IOException {
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath queue = new QueuePath("root.test1");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"test1"});
+    conf.setCapacity(queue, 100);
+    conf.setAccessibleNodeLabels(queue, Set.of("gpu"));
+    conf.setCapacityByLabel(queue, "gpu", 50);
+
+    CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf);
+  }
+
+  @Test
+  public void testValidateQueueAccessibleLabelsAllowsWildcardAccess() throws IOException {
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath queue = new QueuePath("root.test1");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"test1"});
+    conf.setCapacity(queue, 100);
+    conf.setAccessibleNodeLabels(queue, Set.of("*"));
+    conf.setCapacityByLabel(queue, "gpu", 50);
+
+    CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf);
+  }
+
+  @Test
+  public void testValidateQueueAccessibleLabelsRejectsUnlistedLabelCapacity(){
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath queue = new QueuePath("root.test1");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"test1"});
+    conf.setCapacity(queue, 100);
+    conf.setCapacityByLabel(queue, "gpu", 50);
+
+    IOException exception = assertThrows(IOException.class, () ->
+        CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf));
+    assertTrue(exception.getMessage().contains(ACCESSIBLE_LABELS_CAPACITY_ERROR));
+    assertTrue(exception.getMessage().contains("root.test1"));
+  }
+
+  @Test
+  public void testValidateQueueAccessibleLabelsRejectsRemovedAccessibleLabel(){
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath queue = new QueuePath("root.test1");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"test1"});
+    conf.setCapacity(queue, 100);
+    conf.setAccessibleNodeLabels(queue, Set.of("cpu"));
+    conf.setCapacityByLabel(queue, "gpu", 50);
+
+    IOException exception = assertThrows(IOException.class, () ->
+        CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf));
+    assertTrue(exception.getMessage().contains(ACCESSIBLE_LABELS_CAPACITY_ERROR));
+    assertTrue(exception.getMessage().contains("root.test1"));
+  }
+
+  @Test
+  public void testValidateQueueAccessibleLabelsRejectsUnlistedMaxCapacity(){
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath queue = new QueuePath("root.test1");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+        new String[] {"test1"});
+    conf.setCapacity(queue, 100);
+    conf.setMaximumCapacityByLabel(queue, "gpu", 100);
+
+    IOException exception = assertThrows(IOException.class, () ->
+        CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf));
+    assertTrue(exception.getMessage().contains(ACCESSIBLE_LABELS_CAPACITY_ERROR));
+    assertTrue(exception.getMessage().contains("root.test1"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfigValidator.java
@@ -783,6 +783,23 @@ public class TestCapacitySchedulerConfigValidator {
   }
 
   @Test
+  public void testValidateQueueAccessibleLabelsRejectsCapacityWithoutAccessibleLabelsProperty() {
+    CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();
+    QueuePath sibling = new QueuePath("root.sibling");
+    conf.setQueues(new QueuePath(CapacitySchedulerConfiguration.ROOT),
+            new String[] {"default", "sibling"});
+    conf.setCapacity(new QueuePath("root.default"), 50);
+    conf.setCapacity(sibling, 50);
+    conf.setCapacityByLabel(sibling, "label3", 100);
+    conf.setMaximumCapacityByLabel(sibling, "label3", 100);
+
+    IOException exception = assertThrows(IOException.class, () ->
+            CapacitySchedulerConfigValidator.validateQueueAccessibleLabels(conf));
+    assertTrue(exception.getMessage().contains(ACCESSIBLE_LABELS_CAPACITY_ERROR));
+    assertTrue(exception.getMessage().contains("root.sibling"));
+  }
+
+  @Test
   public void testValidateQueueAccessibleLabelsAllowsInheritedAccessibleLabel()
       throws IOException {
     CapacitySchedulerConfiguration conf = new CapacitySchedulerConfiguration();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNewQueueAutoCreation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNewQueueAutoCreation.java
@@ -791,6 +791,7 @@ public class TestCapacitySchedulerNewQueueAutoCreation
         "auto queue deletion should be turned off on a3");
 
     // Set the capacity of label TEST
+    csConf.setAccessibleNodeLabels(cQueuePath, Set.of("TEST"));
     csConf.set(AutoCreatedQueueTemplate.getAutoQueueTemplatePrefix(
         cQueuePath) + "accessible-node-labels.TEST.capacity", "6w");
     csConf.setQueues(ROOT, new String[]{"a", "b", "c"});

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNodeLabelUpdate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNodeLabelUpdate.java
@@ -131,10 +131,11 @@ public class TestCapacitySchedulerNodeLabelUpdate {
     conf2.setCapacity(aa3, 20);
     conf2.setCapacity(aa4, 20);
     conf2.setAccessibleNodeLabels(a, ImmutableSet.of("x", "y", "z"));
+    conf2.setAccessibleNodeLabels(b, ImmutableSet.of("x", "y", "z"));
     conf2.setAccessibleNodeLabels(aa1, ImmutableSet.of("x", "y"));
     conf2.setAccessibleNodeLabels(aa2, ImmutableSet.of("y"));
     conf2.setAccessibleNodeLabels(aa3, ImmutableSet.of("x", "y", "z"));
-    conf2.setAccessibleNodeLabels(aa4, ImmutableSet.of("x", "y"));
+    conf2.setAccessibleNodeLabels(aa4, ImmutableSet.of("x", "y", "z"));
     conf2.setCapacityByLabel(a, "x", 50);
     conf2.setCapacityByLabel(a, "y", 50);
     conf2.setCapacityByLabel(a, "z", 50);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CyclicBarrier;
@@ -5248,6 +5249,7 @@ public class TestLeafQueue {
     when(cs.getClusterResource()).thenReturn(
         Resources.createResource(2 * 16 * GB, 2 * 32));
 
+    conf.setAccessibleNodeLabels(new QueuePath(rootChild), Set.of(RMNodeLabelsManager.ANY));
     conf.setCapacityByLabel(ROOT, "test", 100);
     conf.setCapacityByLabel(new QueuePath(rootChild), "test", 100);
     conf.setCapacityByLabel(new QueuePath(rootChild, A), "test", 20);
@@ -5285,6 +5287,7 @@ public class TestLeafQueue {
     CapacitySchedulerConfiguration conf = csConf;
     String rootChild = root.getChildQueues().get(0).getQueuePath();
 
+    conf.setAccessibleNodeLabels(new QueuePath(rootChild), Set.of(RMNodeLabelsManager.ANY));
     conf.setCapacityByLabel(new QueuePath(rootChild), "test", 100);
     conf.setCapacityByLabel(new QueuePath(rootChild, A), "test", 20);
     conf.setCapacityByLabel(new QueuePath(rootChild, B), "test", 40);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestMixedQueueResourceCalculation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestMixedQueueResourceCalculation.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager.NO_LABEL;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ROOT;
@@ -465,6 +466,9 @@ public class TestMixedQueueResourceCalculation extends CapacitySchedulerQueueCal
     mockRM.registerNode("h2:1234", H2_MEMORY, H2_VCORES); // label = y
     mockRM.registerNode("h3:1234", H3_MEMORY, H3_VCORES); // label = y
     mockRM.registerNode("h4:1234", H4_MEMORY, H4_VCORES); // label = z
+
+    csConf.setAccessibleNodeLabels(A, Set.of(RMNodeLabelsManager.ANY));
+    csConf.setAccessibleNodeLabels(B, Set.of(RMNodeLabelsManager.ANY));
 
     csConf.setCapacityVector(A, NO_LABEL, A_VECTOR_NO_LABEL);
     csConf.setCapacityVector(A1, NO_LABEL, A1_VECTOR_NO_LABEL);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServiceAppsNodelabel.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServiceAppsNodelabel.java
@@ -138,6 +138,7 @@ public class TestRMWebServiceAppsNodelabel extends JerseyTestBase {
     config.setCapacityByLabel(root, "X", 100);
     config.setMaximumCapacityByLabel(root, "X", 100);
     // set for default queue
+    config.setAccessibleNodeLabels(defaultQueue, Set.of("X"));
     config.setCapacityByLabel(defaultQueue, "X", 100);
     config.setMaximumCapacityByLabel(defaultQueue, "X", 100);
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

Contains content generated by Cursor.

### Description of PR

Queue capacity could be set in partition view even though the queue does not have access to that label. Leaving the only queue's label capacity in /scheduler-conf endpoint. E.g. 

```
<property>
<name>yarn.scheduler.capacity.root.default.accessible-node-labels.label3.capacity</name>
<value>100</value>
</property>
```
Resulting into a bug when the label is deleted and created a new queue. Detail in the jira ticket description.

Therefore, a new validation is needed to make sure the queue has access to the label before allowing to set capacity in the partition view. Vice versa, the accessible label could not be removed if the queue has capacity in that partition. Both have to be changed at the same time.

Error when user adds queue partition capacity without adding label to the accessible queue:
<img width="969" height="686" alt="Screenshot 2026-08-04 at 14 51 51" src="https://github.com/user-attachments/assets/4a47e8bb-a7b8-48a0-8c7c-71c576c278f7" />

Error when user trying to remove label when the queue has partition capacity:
<img width="1194" height="1036" alt="Screenshot 2026-08-04 at 15 09 23" src="https://github.com/user-attachments/assets/ee7857bd-b181-4feb-ac2f-30137be44de4" />

### How was this patch tested?
Tested locally plus unit tests and work as expected.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html