### PR TITLE
HDFS-17944. Validate short-circuit streams cache size

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -841,6 +841,8 @@ public class DfsClientConf {
       shortCircuitStreamsCacheSize = conf.getInt(
           Read.ShortCircuit.STREAMS_CACHE_SIZE_KEY,
           Read.ShortCircuit.STREAMS_CACHE_SIZE_DEFAULT);
+      Preconditions.checkArgument(shortCircuitStreamsCacheSize >= 0,
+          Read.ShortCircuit.STREAMS_CACHE_SIZE_KEY + " can't be negative.");
       shortCircuitStreamsCacheExpiryMs = conf.getLong(
           Read.ShortCircuit.STREAMS_CACHE_EXPIRY_MS_KEY,
           Read.ShortCircuit.STREAMS_CACHE_EXPIRY_MS_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/client/impl/TestDfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/client/impl/TestDfsClientConf.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.client.impl;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestDfsClientConf {
+
+  @Test
+  public void testNegativeShortCircuitStreamsCacheSize() {
+    Configuration conf = new Configuration();
+    conf.setInt(
+        HdfsClientConfigKeys.Read.ShortCircuit.STREAMS_CACHE_SIZE_KEY, -1);
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class, () -> new DfsClientConf(conf));
+    assertEquals(
+        HdfsClientConfigKeys.Read.ShortCircuit.STREAMS_CACHE_SIZE_KEY
+            + " can't be negative.",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testZeroShortCircuitStreamsCacheSize() {
+    Configuration conf = new Configuration();
+    conf.setInt(
+        HdfsClientConfigKeys.Read.ShortCircuit.STREAMS_CACHE_SIZE_KEY, 0);
+
+    DfsClientConf dfsClientConf = new DfsClientConf(conf);
+    assertEquals(0, dfsClientConf.getShortCircuitConf()
+        .getShortCircuitStreamsCacheSize());
+  }
+}


### PR DESCRIPTION
### Description of PR

JIRA: [HDFS-17944](https://issues.apache.org/jira/browse/HDFS-17944)

`dfs.client.read.shortcircuit.streams.cache.size=-1` currently passes
`DfsClientConf` parsing and is rejected only when a new
`ShortCircuitCache` is built. This exposes the internal `maxTotalSize`
parameter in the error, while reuse of an existing `ClientContext` can
avoid that late validation entirely.

This PR:

- validates that the configured streams cache size is non-negative while
  building `DfsClientConf`;
- reports the public configuration key in the exception;
- adds client-module tests for the invalid `-1` boundary and the valid `0`
  boundary.

Zero remains valid and keeps its existing cache-retention semantics. The
change does not modify public APIs, protocols, dependencies,
`hdfs-default.xml`, or the defensive validation in `ShortCircuitCache`.

Source and attribution: the issue comes from HDFS-17944. The implementation
was independently written against the current `trunk`. Its error style is
consistent with merged [HDFS-17943 / PR #8603](https://github.com/apache/hadoop/pull/8603),
and the existing zero boundary was confirmed from merged
[HDFS-16653 / PR #5568](https://github.com/apache/hadoop/pull/5568).
Open [PR #7215](https://github.com/apache/hadoop/pull/7215) also touches
`DfsClientConf.java`, but only for lease renewal configuration; no code or
text from that unmerged PR was reused.

### How was this patch tested?

On Windows x86_64 with JDK 21.0.11 and the repository Maven Wrapper:

```powershell
.\mvnw.cmd --batch-mode --no-transfer-progress `
  -pl :hadoop-hdfs-client -am "-P=-native-win" `
  "-Dtest=TestDfsClientConf" `
  "-Dsurefire.failIfNoSpecifiedTests=false" `
  "-DskipShade" "-DskipDocs" test
```

Result: `BUILD SUCCESS`; 10 reactor modules succeeded; 2 tests ran with
0 failures, 0 errors, and 0 skips.

```powershell
.\mvnw.cmd --batch-mode --no-transfer-progress `
  -pl :hadoop-hdfs -am "-P=-native-win" `
  "-Dtest=TestShortCircuitCache#testInvalidConfiguration" `
  "-Dsurefire.failIfNoSpecifiedTests=false" `
  "-DskipShade" "-DskipDocs" test
```

Result: `BUILD SUCCESS`; 12 reactor modules succeeded; 1 test ran with
0 failures, 0 errors, and 0 skips. Bash tests were skipped because `bats`
was not installed; the targeted Java test completed successfully.

```powershell
.\mvnw.cmd --batch-mode --no-transfer-progress `
  -pl :hadoop-hdfs-client -am "-P=-native-win" `
  "-DskipTests" "-DskipShade" "-DskipDocs" checkstyle:check
```

Result: exit code 0. The new test has no Checkstyle violations.
`DfsClientConf.java` retains a pre-existing `MethodLength` warning at line
171; the production change is at line 844 and introduces no new violation.

A full repository build was not run.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: N/A; this HDFS client change does not affect an object storage connector.
- [x] New dependencies: N/A; this PR adds no dependencies.
- [x] License and notice updates: N/A; this PR does not change distributed dependencies or licensing content.

### AI Tooling

- [x] Contains content generated by Codex
- [x] My use of AI contributions follows the [ASF legal policy](https://www.apache.org/legal/generative-tooling.html).
