### PR TITLE
HDFS-17951. Fix TestFsVolumeList#testAddRplicaProcessorForAddingReplicaInMap.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -1130,7 +1130,7 @@ public class BlockPoolSlice {
    */
   @VisibleForTesting
   public static int getAddReplicaForkPoolSize() {
-    return addReplicaThreadPool.getPoolSize();
+    return addReplicaThreadPool.getParallelism();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### Description of PR

`TestFsVolumeList#testAddRplicaProcessorForAddingReplicaInMap` fails in some environments with "Fork pool should be initialize with configured pool size ==> expected: <5> but was: <4>".

The test assumes the fork-join pool always holds as many threads as the configured pool size. That assumption is false: `ForkJoinPool` creates worker threads on demand, so `getPoolSize()` depends on the load of the environment and can be lower than the configured parallelism.

What the test can verify deterministically is the pool's configuration. The fix changes the `@VisibleForTesting` accessor `BlockPoolSlice#getAddReplicaForkPoolSize()` to return `getParallelism()`, the configured value. No production behavior changes; the assertion in `TestFsVolumeList` is the accessor's only caller.

### How was this patch tested?

`TestFsVolumeList#testAddRplicaProcessorForAddingReplicaInMap` and `#testInstanceOfAddReplicaThreadPool` pass locally (Windows 11, JDK 17, 24 cores). A standalone probe replicating the production submit/fork pattern (`ForkJoinPool(5)`, two external submits, forked non-joining subtasks) showed `getPoolSize()` returning 4 in 15/15 runs under light task demand while `getParallelism()` returned 5 in all runs — reproducing the reported failure signature and confirming the fix asserts a deterministic quantity.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: N/A
- [ ] New dependencies: N/A — no dependencies added
- [ ] LICENSE / LICENSE-binary / NOTICE-binary: N/A — no updates needed

### AI Tooling

- [x] Contains content generated by Claude Code.
- [x] My use of AI contributions follows the ASF legal policy https://www.apache.org/legal/generative-tooling.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)
