### PR TITLE
HDFS-17945. Validate HDFS user home directory prefix

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
@@ -1118,7 +1118,12 @@ public class DFSUtilClient {
           HdfsClientConfigKeys.DFS_USER_HOME_DIR_PREFIX_KEY,
           HdfsClientConfigKeys.DFS_USER_HOME_DIR_PREFIX_DEFAULT);
     }
-    return userHomePrefix + Path.SEPARATOR + ugi.getShortUserName();
+    String homeDirectory =
+        userHomePrefix + Path.SEPARATOR + ugi.getShortUserName();
+    Preconditions.checkArgument(new Path(homeDirectory).isAbsolute(),
+        "Invalid value of %s: %s; must be an absolute path",
+        HdfsClientConfigKeys.DFS_USER_HOME_DIR_PREFIX_KEY, userHomePrefix);
+    return homeDirectory;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -1115,6 +1116,34 @@ public class TestDFSUtil {
       assertEquals(new Path(prefix + inode),
           DFSUtilClient.makePathFromFileId(inode));
     }
+  }
+
+  @Test
+  public void testUserHomeDirectoryPrefix() throws Exception {
+    UserGroupInformation ugi =
+        UserGroupInformation.createRemoteUser("test-user");
+    Configuration conf = new Configuration(false);
+
+    assertEquals("/user/test-user",
+        DFSUtilClient.getHomeDirectory(conf, ugi));
+
+    conf.set(HdfsClientConfigKeys.DFS_USER_HOME_DIR_PREFIX_KEY, "/home");
+    assertEquals("/home/test-user",
+        DFSUtilClient.getHomeDirectory(conf, ugi));
+
+    conf.set(HdfsClientConfigKeys.DFS_USER_HOME_DIR_PREFIX_KEY, "@name@");
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> DFSUtilClient.getHomeDirectory(conf, ugi));
+    assertEquals("Invalid value of dfs.user.home.dir.prefix: @name@; "
+        + "must be an absolute path", exception.getMessage());
+
+    conf.setClass("fs.hdfs.impl", DistributedFileSystem.class,
+        FileSystem.class);
+    exception = assertThrows(IllegalArgumentException.class,
+        () -> FileSystem.newInstance(new URI("hdfs://127.0.0.1:9000"), conf));
+    assertEquals("Invalid value of dfs.user.home.dir.prefix: @name@; "
+        + "must be an absolute path", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

[HDFS-17945](https://issues.apache.org/jira/browse/HDFS-17945) reports a `NullPointerException` while initializing an HDFS `FileSystem` with invalid configuration. Isolating the reproduction shows that the trigger is a relative `dfs.user.home.dir.prefix`, rather than the checkpoint-directory setting also present in the example.

`DistributedFileSystem` qualifies the configured home directory before its working directory has been initialized. This patch validates the assembled HDFS user home directory at the shared client configuration boundary and reports an `IllegalArgumentException` containing the configuration key and invalid value when the result is not absolute.

The regression test covers the default and a custom absolute prefix, the direct invalid-prefix error, and the complete `FileSystem.newInstance` initialization path. The change does not modify checkpoint configuration, generic `Path` behavior, public APIs, dependencies, protocols, or default configuration.

The implementation was derived from the Jira reproduction and merged Hadoop trunk source. It does not reuse an open or unmerged pull request implementation.

### How was this patch tested?

- Passed the targeted regression test (1 test; all 12 reactor modules succeeded):
  `./mvnw -pl hadoop-hdfs-project/hadoop-hdfs -am -Dtest=TestDFSUtil#testUserHomeDirectoryPrefix -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -DskipShade -DskipDocs -P=-native-win test`
- Running the complete `TestDFSUtil` class executed the new test successfully. The report had 40 non-skipped tests pass, 1 skipped test, and 1 environment error in the pre-existing `testGetPassword` because `hadoop-common/target/bin/winutils` is unavailable on this Windows host; this is not represented as a fully green class run.
- `checkstyle:check` completed for `hadoop-hdfs-client` and `hadoop-hdfs`; the changed lines have 0 Checkstyle violations. The aggregate report also lists 12,610 pre-existing unsuppressed violations and uses `failOnViolation=false`, so its zero exit status is not represented as a clean module-wide result.
- `git diff --check` passed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: not applicable; this change only affects HDFS client home-directory configuration.
- [x] No new dependencies are added.
- [x] No `LICENSE`, `LICENSE-binary`, or `NOTICE-binary` updates are applicable.

### AI Tooling

Contains content generated by Codex.

- [x] The PR includes the phrase "Contains content generated by Codex".
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
