### PR TITLE
HDFS-17955. Fix Checkpointer startup checkpoint on fresh VMs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/Checkpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/Checkpointer.java
@@ -143,7 +143,8 @@ class Checkpointer extends Daemon {
       try {
         long now = monotonicNow();
         boolean shouldCheckpoint = false;
-        if(now >= lastCheckpointTime + checkpointPeriodMSec) {
+        if(lastCheckpointTime == 0
+            || now >= lastCheckpointTime + checkpointPeriodMSec) {
           shouldCheckpoint = true;
         } else if(now >= lastEditLogCheckTime + periodMSec) {
           long txns = countUncheckpointedTxns();


### PR DESCRIPTION
### Description of PR

The Checkpointer triggers the first checkpoint when
`shouldCheckpointAtStartup()` returns true by leaving `lastCheckpointTime = 0`
and relying on `now >= lastCheckpointTime + checkpointPeriodMSec` to
evaluate true. This condition breaks when `monotonicNow()`
(`System.nanoTime` based) returns a value smaller than
`checkpointPeriodMSec` (3600000ms = 1 hour), which happens on freshly
booted VMs such as GitHub-hosted runners. The checkpoint never fires,
and any caller waiting for it hangs indefinitely.

Add an explicit `lastCheckpointTime == 0` check so the first checkpoint
fires immediately regardless of the monotonic clock value. After the
first checkpoint, `lastCheckpointTime` is set to the current time and
normal period-based scheduling resumes.

This is a latent bug present since the Checkpointer logic was introduced
in 2011 (a196766). It was exposed by the GitHub-hosted runner image
`ubuntu24/20260720.247`, which provisions VMs fast enough that host
uptime is below 1 hour at test execution. A BackupNode that restarts
within 1 hour of boot on any deployment has the same bug.

### How was this patch tested?

Verified via GitHub Actions CI on a fork branch. Before the fix,
`TestBackupNode` hangs indefinitely (fork timeout after 900s). After the
fix, the Checkpointer fires the startup checkpoint immediately and
`TestBackupNode` passes.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HDFS-17955)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by `<tool>`"
      where `<tool>` is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

Contains content generated by GLM 5.2