### PR TITLE
HDFS-17956. Bound TestBackupNode.waitCheckpointDone with timeout

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBackupNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBackupNode.java
@@ -116,18 +116,15 @@ public class TestBackupNode {
     return bn;
   }
 
-  void waitCheckpointDone(MiniDFSCluster cluster, long txid) {
-    long thisCheckpointTxId;
-    do {
-      try {
-        LOG.info("Waiting checkpoint to complete... " +
-            "checkpoint txid should increase above " + txid);
-        Thread.sleep(1000);
-      } catch (Exception e) {}
-      // The checkpoint is not done until the nn has received it from the bn
-      thisCheckpointTxId = cluster.getNameNode().getFSImage().getStorage()
+  void waitCheckpointDone(MiniDFSCluster cluster, long txid)
+      throws Exception {
+    GenericTestUtils.waitFor(
+        () -> cluster.getNameNode().getFSImage().getStorage()
+            .getMostRecentCheckpointTxId() >= txid,
+        1000, 60000,
+        "Checkpoint txid did not advance above " + txid);
+    long thisCheckpointTxId = cluster.getNameNode().getFSImage().getStorage()
         .getMostRecentCheckpointTxId();
-    } while (thisCheckpointTxId < txid);
     // Check that the checkpoint got uploaded to NN successfully
     FSImageTestUtil.assertNNHasCheckpoints(cluster,
         Collections.singletonList((int)thisCheckpointTxId));
@@ -504,7 +501,7 @@ public class TestBackupNode {
    * Verify that a file can be read both from NameNode and BackupNode.
    */
   @Test
-  public void testCanReadData() throws IOException {
+  public void testCanReadData() throws Exception {
     Path file1 = new Path("/fileToRead.dat");
     Configuration conf = new HdfsConfiguration();
     MiniDFSCluster cluster = null;


### PR DESCRIPTION
### Description of PR

Replace the unbounded do-while polling loop in `waitCheckpointDone` with
`GenericTestUtils.waitFor`, capping the wait at 60 seconds.

When a checkpoint never arrives, the loop sleeps indefinitely, hanging
the surefire fork until `forkedProcessTimeoutInSeconds` (900s) kills it.
The fork kill produces a generic "timeout in the fork" error with no
indication of which test hung. The bounded wait converts this into a
fast, clear `TimeoutException` naming the checkpoint txid that never
advanced.

### How was this patch tested?

Verified via GitHub Actions CI on a fork branch. Before the change, the
fork hangs 900s with no indication of the culprit. After the change,
`TestBackupNode` fails within 60s with:

```
TimeoutException: Timed out waiting for condition.
Error Message: Checkpoint txid did not advance above 1
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HDFS-17956)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by `<tool>`"
      where `<tool>` is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

Contains content generated by GLM 5.2