### PR TITLE
HADOOP-19950. Capture surefire diagnostics on fork timeout in CI

### DIFF
--- a/.github/workflows/tmpl_build_and_test.yml
+++ b/.github/workflows/tmpl_build_and_test.yml
@@ -321,5 +321,5 @@ jobs:
         with:
           name: unit-test-logs-${{ matrix.comment }}-java${{ inputs.java }})-${{ inputs.os }}-${{ inputs.branch }}
           path: |
-            **/target/*.log
-            **/target/*.xml
+            **/target/**/*.log
+            **/target/surefire-reports/**

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -207,6 +207,7 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
+    <surefire.fork.exitTimeout>60</surefire.fork.exitTimeout>
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.35.4</aws-java-sdk-v2.version>
     <amazon-s3-encryption-client-java.version>4.0.0</amazon-s3-encryption-client-java.version>
@@ -2594,6 +2595,7 @@
         <configuration>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>${surefire.fork.timeout}</forkedProcessTimeoutInSeconds>
+          <forkedProcessExitTimeoutInSeconds>${surefire.fork.exitTimeout}</forkedProcessExitTimeoutInSeconds>
           <!-- @{argLine} is Surefire's late (deferred) property substitution: it
                is replaced at test-run time with the value of the "argLine"
                property. jacoco:prepare-agent sets that property to the


### PR DESCRIPTION
### Description of PR

Set `forkedProcessExitTimeoutInSeconds` (60s) in the root surefire
configuration so that a hung fork is force-killed after a grace window
and surefire writes the dumpstream (thread dump) naming the non-daemon
thread keeping the fork alive. Without this, the only signal is a
generic "timeout in the fork" error.

Expand the test-logs artifact upload globs from:

```
**/target/*.log
**/target/*.xml
```

to:

```
**/target/**/*.log
**/target/surefire-reports/**
```

The original globs only matched files directly under `target/`
(`site.xml`, `plugin-enhanced.xml`), missing the actual test reports and
thread dumps in nested directories. The new globs capture `TEST-*.xml`,
`*.dump`, and `*.dumpstream` surefire output needed to diagnose fork
hangs.

### How was this patch tested?

Verified via GitHub Actions CI on a fork branch. With the previous
globs, the uploaded artifact was 7KB (2 incidental files). With the new
globs, the artifact is ~112MB and contains the full `surefire-reports/`
directory, including the `*.dump` thread dump that named the culprit
test keeping a fork alive.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (HADOOP-19950)?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by `<tool>`"
      where `<tool>` is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

Contains content generated by GLM 5.2