### PR TITLE
MAPREDUCE-7541. Fix AM WebUI attempts page

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebApp.java
@@ -23,6 +23,8 @@ import static org.apache.hadoop.yarn.util.StringHelper.pajoin;
 import org.apache.hadoop.mapreduce.v2.app.AppContext;
 import org.apache.hadoop.yarn.webapp.WebApp;
 
+import com.google.inject.servlet.RequestScoped;
+
 import javax.servlet.Filter;
 
 /**
@@ -38,6 +40,7 @@ public class AMWebApp extends WebApp implements AMParams {
 
   @Override
   public void setup() {
+    bind(App.class).in(RequestScoped.class);
     bind(AppContext.class).toInstance(appContext);
     route("/", AppController.class);
     route("/app", AppController.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
@@ -417,6 +417,36 @@ public class TestAMWebApp {
     }
   }
 
+  @Test
+  public void testAttemptsPageRender() throws Exception {
+    MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
+      @Override
+      protected ClientService createClientService(AppContext context) {
+        return new MRClientService(context);
+      }
+    };
+    Configuration conf = new Configuration();
+
+    Job job = app.submit(conf);
+    String hostPort =
+        NetUtils.getHostPortString(((MRClientService) app.getClientService())
+          .getWebApp().getListenerAddress());
+    URL attemptsUrl = new URL("http://" + hostPort + "/mapreduce/attempts/"
+        + job.getID().toString() + "/m/SUCCESSFUL");
+    app.waitForState(job, JobState.SUCCEEDED);
+
+    HttpURLConnection conn = (HttpURLConnection) attemptsUrl.openConnection();
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode(),
+        attemptsUrl.toString());
+    InputStream in = conn.getInputStream();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOUtils.copyBytes(in, out, 1024);
+
+    String content = out.toString();
+    assertTrue(content.contains("attempt_"), "Attempts Page should have the attepmts data");
+    app.verifyCompleted();
+  }
+
   public static void main(String[] args) {
     AppContext context = new MockAppContext(0, 8, 88, 4);
     WebApps.$for("yarn", AppContext.class, context).withResourceConfig(configure(context)).


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fix AM WebUI attempts page
<img width="1462" height="772" alt="Screenshot from 2026-08-02 18-13-04" src="https://github.com/user-attachments/assets/9f96fee7-1676-4ff8-8715-35c7b56ecbb4" />

### How was this patch tested?
Validated with updating the jar
<img width="1864" height="747" alt="Screenshot from 2026-08-02 18-32-18" src="https://github.com/user-attachments/assets/e8ef1551-52e5-4589-809f-78322599cefb" />


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html