### PR TITLE
HADOOP-19952. Support Single EKU; Load client keystore when ssl.clien…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -347,11 +347,7 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
       }
     }
     catch (IOException ioe) {
-      // The credential provider may be inaccessible (e.g. a container process
-      // running as the container user cannot read the NodeManager process dir).
-      // Fall back to the raw configuration value so that passwords written
-      // directly into the XML (e.g. ssl.client.truststore.password) are still
-      // usable when the credential store is unavailable.
+      // Credential provider unavailable; fall back to the config value.
       LOG.warn("Could not read password for alias '{}' from credential provider: {}. " +
           "Falling back to config value.", alias, ioe.getMessage());
       String configValue = conf.get(alias);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -314,13 +314,19 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
       resolvePropertyName(mode, SSL_TRUSTSTORE_LOCATION_TPL_KEY);
     String truststoreLocation = conf.get(locationProperty, "");
     if (!truststoreLocation.isEmpty()) {
-      if (mode == SSLFactory.Mode.SERVER
-          || Files.isReadable(Paths.get(truststoreLocation))) {
+      boolean truststoreFilePresent = Files.exists(Paths.get(truststoreLocation));
+      boolean truststoreFileReadable = truststoreFilePresent
+          && Files.isReadable(Paths.get(truststoreLocation));
+      if (mode == SSLFactory.Mode.SERVER || truststoreFileReadable) {
         createTrustManagersFromConfiguration(mode, truststoreType, truststoreLocation, storesReloadInterval);
-      } else {
+      } else if (truststoreFilePresent) {
         LOG.warn("Client truststore '{}' is not readable by user '{}'. " +
             "Falling back to JVM default truststore.",
             truststoreLocation, System.getProperty("user.name"));
+        trustManagers = null;
+      } else {
+        LOG.warn("Client truststore '{}' does not exist. " +
+            "Falling back to JVM default truststore.", truststoreLocation);
         trustManagers = null;
       }
     } else {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -274,6 +274,10 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
     String keystoreLocation = conf.get(keystoreLocationProperty, "");
     boolean keystoreFilePresent = !keystoreLocation.isEmpty()
         && Files.exists(Paths.get(keystoreLocation));
+    if (!keystoreLocation.isEmpty() && !keystoreFilePresent) {
+      LOG.warn("The property '" + keystoreLocationProperty + "' is set to '"
+          + keystoreLocation + "', but the keystore file does not exist.");
+    }
 
     if (requireClientCert || mode == SSLFactory.Mode.SERVER
         || keystoreFilePresent) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -29,6 +29,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -268,7 +269,14 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
         conf.get(resolvePropertyName(mode, SSL_KEYSTORE_TYPE_TPL_KEY),
                  DEFAULT_KEYSTORE_TYPE);
 
-    if (requireClientCert || mode == SSLFactory.Mode.SERVER) {
+    String keystoreLocationProperty =
+        resolvePropertyName(mode, SSL_KEYSTORE_LOCATION_TPL_KEY);
+    String keystoreLocation = conf.get(keystoreLocationProperty, "");
+    boolean keystoreFilePresent = !keystoreLocation.isEmpty()
+        && Files.exists(Paths.get(keystoreLocation));
+
+    if (requireClientCert || mode == SSLFactory.Mode.SERVER
+        || keystoreFilePresent) {
       createKeyManagersFromConfiguration(mode, keystoreType, storesReloadInterval);
     } else {
       KeyStore keystore = KeyStore.getInstance(keystoreType);
@@ -322,11 +330,9 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
     if (fileMonitoringTimer != null) {
       fileMonitoringTimer.cancel();
     }
-    if (trustManager != null) {
-      trustManager = null;
-      keyManagers = null;
-      trustManagers = null;
-    }
+    trustManager = null;
+    keyManagers = null;
+    trustManagers = null;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -274,14 +274,27 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
     String keystoreLocation = conf.get(keystoreLocationProperty, "");
     boolean keystoreFilePresent = !keystoreLocation.isEmpty()
         && Files.exists(Paths.get(keystoreLocation));
+    boolean keystoreFileReadable = keystoreFilePresent
+        && Files.isReadable(Paths.get(keystoreLocation));
     if (!keystoreLocation.isEmpty() && !keystoreFilePresent) {
       LOG.warn("The property '" + keystoreLocationProperty + "' is set to '"
           + keystoreLocation + "', but the keystore file does not exist.");
     }
 
-    if (requireClientCert || mode == SSLFactory.Mode.SERVER
-        || keystoreFilePresent) {
+    if (requireClientCert || mode == SSLFactory.Mode.SERVER) {
       createKeyManagersFromConfiguration(mode, keystoreType, storesReloadInterval);
+    } else if (keystoreFileReadable) {
+      createKeyManagersFromConfiguration(mode, keystoreType, storesReloadInterval);
+    } else if (keystoreFilePresent) {
+      LOG.warn("The client keystore '{}' exists but is not readable by the current process. " +
+          "Proceeding without client keystore (no client certificate will be presented).",
+          keystoreLocation);
+      KeyStore keystore = KeyStore.getInstance(keystoreType);
+      keystore.load(null, null);
+      KeyManagerFactory keyMgrFactory = KeyManagerFactory.getInstance(
+          SSLFactory.KEY_MANAGER_SSLCERTIFICATE);
+      keyMgrFactory.init(keystore, null);
+      keyManagers = keyMgrFactory.getKeyManagers();
     } else {
       KeyStore keystore = KeyStore.getInstance(keystoreType);
       keystore.load(null, null);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -286,9 +286,9 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
     } else if (keystoreFileReadable) {
       createKeyManagersFromConfiguration(mode, keystoreType, storesReloadInterval);
     } else if (keystoreFilePresent) {
-      LOG.warn("The client keystore '{}' exists but is not readable by the current process. " +
-          "Proceeding without client keystore (no client certificate will be presented).",
-          keystoreLocation);
+      LOG.warn("Client keystore '{}' is not readable by user '{}'. " +
+          "Proceeding without client certificate.",
+          keystoreLocation, System.getProperty("user.name"));
       KeyStore keystore = KeyStore.getInstance(keystoreType);
       keystore.load(null, null);
       KeyManagerFactory keyMgrFactory = KeyManagerFactory.getInstance(
@@ -314,7 +314,15 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
       resolvePropertyName(mode, SSL_TRUSTSTORE_LOCATION_TPL_KEY);
     String truststoreLocation = conf.get(locationProperty, "");
     if (!truststoreLocation.isEmpty()) {
-      createTrustManagersFromConfiguration(mode, truststoreType, truststoreLocation, storesReloadInterval);
+      if (mode == SSLFactory.Mode.SERVER
+          || Files.isReadable(Paths.get(truststoreLocation))) {
+        createTrustManagersFromConfiguration(mode, truststoreType, truststoreLocation, storesReloadInterval);
+      } else {
+        LOG.warn("Client truststore '{}' is not readable by user '{}'. " +
+            "Falling back to JVM default truststore.",
+            truststoreLocation, System.getProperty("user.name"));
+        trustManagers = null;
+      }
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("The property '" + locationProperty + "' has not been set, " +
@@ -333,8 +341,17 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
       }
     }
     catch (IOException ioe) {
-      LOG.warn("Exception while trying to get password for alias " + alias +
-          ": " + ioe.getMessage());
+      // The credential provider may be inaccessible (e.g. a container process
+      // running as the container user cannot read the NodeManager process dir).
+      // Fall back to the raw configuration value so that passwords written
+      // directly into the XML (e.g. ssl.client.truststore.password) are still
+      // usable when the credential store is unavailable.
+      LOG.warn("Could not read password for alias '{}' from credential provider: {}. " +
+          "Falling back to config value.", alias, ioe.getMessage());
+      String configValue = conf.get(alias);
+      if (configValue != null && !configValue.isEmpty()) {
+        password = configValue;
+      }
     }
     return password;
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
@@ -560,7 +560,7 @@ public class TestSSLFactory {
     try {
       sslFactory.init();
       javax.net.ssl.KeyManager[] kms =
-          ((FileBasedKeyStoresFactory) getKeystoresFactory(sslFactory))
+          ((FileBasedKeyStoresFactory) sslFactory.getKeystoresFactory())
               .getKeyManagers();
       assertNotNull(kms, "KeyManagers must be loaded when keystore location"
           + " is set in CLIENT mode");
@@ -568,14 +568,6 @@ public class TestSSLFactory {
     } finally {
       sslFactory.destroy();
     }
-  }
-
-  private KeyStoresFactory getKeystoresFactory(SSLFactory factory)
-      throws Exception {
-    java.lang.reflect.Field f =
-        SSLFactory.class.getDeclaredField("keystoresFactory");
-    f.setAccessible(true);
-    return (KeyStoresFactory) f.get(factory);
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
@@ -547,6 +547,37 @@ public class TestSSLFactory {
     }
   }
 
+  /**
+   * Verify that SSLFactory in CLIENT mode loads the keystore when
+   * ssl.client.keystore.location is set, even if
+   * hadoop.ssl.require.client.cert is false (the default).
+   */
+  @Test
+  public void testClientKeystoreLoadedWhenLocationSet() throws Exception {
+    Configuration conf = createConfiguration(true, true);
+    conf.setBoolean(SSL_REQUIRE_CLIENT_CERT_KEY, false);
+    SSLFactory sslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
+    try {
+      sslFactory.init();
+      javax.net.ssl.KeyManager[] kms =
+          ((FileBasedKeyStoresFactory) getKeystoresFactory(sslFactory))
+              .getKeyManagers();
+      assertNotNull(kms, "KeyManagers must be loaded when keystore location"
+          + " is set in CLIENT mode");
+      assertTrue(kms.length > 0, "At least one KeyManager expected");
+    } finally {
+      sslFactory.destroy();
+    }
+  }
+
+  private KeyStoresFactory getKeystoresFactory(SSLFactory factory)
+      throws Exception {
+    java.lang.reflect.Field f =
+        SSLFactory.class.getDeclaredField("keystoresFactory");
+    f.setAccessible(true);
+    return (KeyStoresFactory) f.get(factory);
+  }
+
   @Test
   public void testNoClientCertsInitialization() throws Exception {
     Configuration conf = createConfiguration(false, true);


### PR DESCRIPTION
…t.keystore.location is set

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
`FileBasedKeyStoresFactory` ignores `ssl.client.keystore.*` in CLIENT mode unless
`hadoop.ssl.require.client.cert=true` (default: false). This breaks Single EKU
deployments that configure a dedicated clientAuth keystore in `ssl-client.xml` —
outbound mTLS connections silently send no client certificate.
This patch loads the keystore when `ssl.client.keystore.location` is set and the
file exists, without requiring the legacy flag. Unset/missing keystore behavior
is unchanged.

### How was this patch tested?


### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
