### PR TITLE
YARN-11973. RM engine: comma-separated username matching in placement rules

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRule.java
@@ -110,7 +110,7 @@ public class MappingRule {
       if (source.equals("%user")) {
         matcher = MappingRuleMatchers.createAllMatcher();
       } else {
-        matcher = MappingRuleMatchers.createUserMatcher(source);
+        matcher = MappingRuleMatchers.createUserMatcherFromMatches(source);
       }
       break;
     case GROUP_MAPPING:

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
@@ -257,7 +257,7 @@ public class MappingRuleMatchers {
       return createAllMatcher();
     }
 
-    String[] users = StringUtils.split(matches, ',');
+    String[] users = StringUtils.splitPreserveAllTokens(matches, ',');
     if (users.length == 1) {
       String user = StringUtils.trim(users[0]);
       if (user.isEmpty()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.VariableContext;
 
 import java.util.Arrays;
@@ -241,6 +242,39 @@ public class MappingRuleMatchers {
    */
   public static MappingRuleMatcher createUserMatcher(String userName) {
     return new VariableMatcher("%user", userName);
+  }
+
+  /**
+   * Creates a matcher for one or more comma-separated usernames. The entire
+   * string {@code *} matches all users; otherwise each comma-separated token
+   * is matched against the submitting user.
+   *
+   * @param matches one username, comma-separated usernames, or {@code *}
+   * @return matcher for the provided user match expression
+   */
+  public static MappingRuleMatcher createUserMatcherFromMatches(String matches) {
+    if ("*".equals(matches)) {
+      return createAllMatcher();
+    }
+
+    String[] users = StringUtils.split(matches, ',');
+    if (users.length == 1) {
+      String user = StringUtils.trim(users[0]);
+      if (user.isEmpty()) {
+        throw new IllegalArgumentException("Match string contains an empty username");
+      }
+      return createUserMatcher(user);
+    }
+
+    MappingRuleMatcher[] matchers = new MappingRuleMatcher[users.length];
+    for (int i = 0; i < users.length; i++) {
+      String user = StringUtils.trim(users[i]);
+      if (user.isEmpty()) {
+        throw new IllegalArgumentException("Match string contains an empty username");
+      }
+      matchers[i] = createUserMatcher(user);
+    }
+    return new OrMatcher(matchers);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/placement/MappingRuleCreator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/placement/MappingRuleCreator.java
@@ -105,11 +105,7 @@ public class MappingRuleCreator {
     MappingRuleMatcher matcher = null;
     switch (type) {
     case USER:
-      if (ALL_USER.equals(matches)) {
-        matcher = MappingRuleMatchers.createAllMatcher();
-      } else {
-        matcher = MappingRuleMatchers.createUserMatcher(matches);
-      }
+      matcher = MappingRuleMatchers.createUserMatcherFromMatches(matches);
       break;
     case GROUP:
       checkArgument(!ALL_USER.equals(matches), "Cannot match '*' for groups");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/json_schema/MappingRulesDescription.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/json_schema/MappingRulesDescription.json
@@ -29,7 +29,10 @@
                  "properties": {
                      "type": { "type": "string",
                           "enum": ["user", "group", "application"] },
-                     "matches": { "type": "string" },
+                     "matches": {
+                         "type": "string",
+                         "description": "For user rules: a single username, comma-separated usernames, or * for all users."
+                     },
                      "policy": { "type": "string",
                          "enum": [
                               "specified",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRule.java
@@ -131,6 +131,11 @@ public class TestMappingRule {
         "u:%user:root.%primary_group", matching, "root.developer");
     evaluateLegacyStringTestcase(
         "u:%user:root.%primary_group", mismatching, "root.tester");
+
+    evaluateLegacyStringTestcase(
+        "u:alice,bob:root.shared", matching, "root.shared");
+    evaluateLegacyStringTestcase(
+        "u:alice,bob:root.shared", mismatching, null);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
@@ -239,6 +239,33 @@ public class TestMappingRuleMatchers  {
   }
 
   @Test
+  public void testUserMatcherFromMatches() {
+    VariableContext aliceContext = new VariableContext();
+    aliceContext.put("%user", "alice");
+
+    VariableContext bobContext = new VariableContext();
+    bobContext.put("%user", "bob");
+
+    VariableContext carolContext = new VariableContext();
+    carolContext.put("%user", "carol");
+
+    MappingRuleMatcher matcher =
+        MappingRuleMatchers.createUserMatcherFromMatches("alice,bob");
+
+    assertTrue(matcher.match(aliceContext));
+    assertTrue(matcher.match(bobContext));
+    assertFalse(matcher.match(carolContext));
+  }
+
+  @Test
+  public void testUserMatcherFromMatchesAllUsers() {
+    VariableContext context = new VariableContext();
+    context.put("%user", "anyone");
+
+    assertTrue(MappingRuleMatchers.createUserMatcherFromMatches("*").match(context));
+  }
+
+  @Test
   public void testToStrings() {
     MappingRuleMatcher var = new MappingRuleMatchers.VariableMatcher("%a", "b");
     MappingRuleMatcher all = MappingRuleMatchers.createAllMatcher();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.VariableContext;
@@ -263,6 +264,13 @@ public class TestMappingRuleMatchers  {
     context.put("%user", "anyone");
 
     assertTrue(MappingRuleMatchers.createUserMatcherFromMatches("*").match(context));
+  }
+
+  @Test
+  public void testUserMatcherFromMatchesRejectsEmptyToken() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+        MappingRuleMatchers.createUserMatcherFromMatches("alice,,bob"));
+    assertTrue(ex.getMessage().contains("empty username"));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/placement/TestMappingRuleCreator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/placement/TestMappingRuleCreator.java
@@ -87,6 +87,40 @@ public class TestMappingRuleCreator {
   }
 
   @Test
+  public void testMultipleUserMatcherPasses() {
+    rule.setMatches("alice,bob," + USER_NAME);
+
+    verifyPlacementSucceeds(USER_NAME);
+  }
+
+  @Test
+  public void testMultipleUserMatcherPassesWithWhitespace() {
+    rule.setMatches(" dummyuser , " + USER_NAME + " ");
+
+    variableContext.put("%user", "dummyuser");
+    verifyPlacementSucceeds("dummyuser");
+  }
+
+  @Test
+  public void testMultipleUserMatcherFails() {
+    rule.setMatches("alice,bob");
+
+    verifyNoPlacementOccurs();
+  }
+
+  @Test
+  public void testMultipleUserMatcherEmptyTokenFails() {
+    IllegalArgumentException illegalArgumentException =
+        assertThrows(IllegalArgumentException.class, () -> {
+          rule.setMatches("alice,,bob");
+          ruleCreator.getMappingRules(description);
+        });
+
+    assertTrue(illegalArgumentException.getMessage().
+        contains("empty username"));
+  }
+
+  @Test
   public void testSpecificUserMatcherFails() {
     rule.setMatches(USER_NAME);
     variableContext.put("%user", "dummyuser");


### PR DESCRIPTION
### Summary
RM engine support for comma-separated usernames in Capacity Scheduler user placement rules.

### Changes
- Add `MappingRuleMatchers.createUserMatcherFromMatches()` using existing `OrMatcher`
- Wire into `MappingRuleCreator` (JSON) and `MappingRule.createLegacyRule()` (legacy `u:` mappings)
- Update JSON schema description for `matches`
- Unit/integration tests in `TestMappingRuleCreator`, `TestMappingRuleMatchers`, `TestMappingRule`

### Related sub-tasks (YARN-11972)
- **YARN-11974** CS UI: https://github.com/apache/hadoop/pull/8657
- **YARN-11975** Docs: https://github.com/apache/hadoop/pull/8658

### Test plan
- [ ] `mvn test -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager -Dtest=TestMappingRuleCreator,TestMappingRuleMatchers,TestMappingRule -am`

Sub-task of YARN-11972.
Fixes: https://issues.apache.org/jira/browse/YARN-11973