### PR TITLE
YARN-11974. CS UI: comma-separated usernames in placement rule form

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/placement-rules/components/PlacementRuleForm.tsx
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/placement-rules/components/PlacementRuleForm.tsx
@@ -63,7 +63,7 @@ const PARENT_QUEUE_POLICIES = [
 ] as const;
 
 const MATCH_PLACEHOLDERS: Record<PlacementRule['type'], string> = {
-  user: '* for all, or specify usernames',
+  user: '* for all, or comma-separated usernames',
   group: 'Enter group names (wildcard not supported)',
   application: '* for all apps, or patterns like spark-*',
 };
@@ -179,7 +179,7 @@ export function PlacementRuleForm({ rule, ruleIndex, onSubmit, onCancel }: Place
                       />
                     </FieldControl>
                     <FieldDescription>
-                      {selectedType === 'user' && 'Use * to match all users, or specify usernames'}
+                      {selectedType === 'user' && 'Use * for all users, or enter one or more usernames separated by commas'}
                       {selectedType === 'group' &&
                         'Specify explicit group names; * wildcard is not supported'}
                       {selectedType === 'application' &&

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/placement-rules/schemas/placement-rule-schema.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/placement-rules/schemas/placement-rule-schema.ts
@@ -86,8 +86,16 @@ export const placementRuleFormSchema = z
       }
       return true;
     },
+  .refine(
+    (data) => {
+      if (data.type !== 'user' || data.matches.trim() === '*') {
+        return true;
+      }
+      const users = data.matches.split(',');
+      return users.every((user) => user.trim().length > 0);
+    },
     {
-      message: 'Wildcard "*" is not supported for group rules',
+      message: 'User match pattern must not contain empty usernames between commas',
       path: ['matches'],
     },
   );

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/placement-rules/schemas/placement-rule-schema.ts
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-capacity-scheduler-ui/src/main/webapp/src/features/placement-rules/schemas/placement-rule-schema.ts
@@ -86,6 +86,11 @@ export const placementRuleFormSchema = z
       }
       return true;
     },
+    {
+      message: 'Wildcard "*" is not supported for group rules',
+      path: ['matches'],
+    },
+  )
   .refine(
     (data) => {
       if (data.type !== 'user' || data.matches.trim() === '*') {


### PR DESCRIPTION
### Summary
Update the Apache **Capacity Scheduler UI** (`hadoop-yarn-capacity-scheduler-ui`) placement rule form to support comma-separated usernames in the Match Pattern field.

This is **not** Cloudera Manager or Queue Manager code — it is the upstream YARN Capacity Scheduler web UI shipped in `hadoop-yarn-project`.

### Changes
- `PlacementRuleForm.tsx` — placeholder and help text for comma-separated usernames
- `placement-rule-schema.ts` — reject empty tokens between commas (e.g. `alice,,bob`)

### Dependencies
- Requires **YARN-11973** (RM engine) for comma-separated values to take effect at runtime

### Related
- Parent: YARN-11972
- Engine PR: https://github.com/apache/hadoop/pull/8656
- Docs PR: https://github.com/apache/hadoop/pull/8658

### Test plan
- [ ] Manual: enter `alice,bob` in user rule Match Pattern; verify save/load round-trip
- [ ] Manual: verify `alice,,bob` shows validation error

Sub-task of YARN-11972.
Fixes: https://issues.apache.org/jira/browse/YARN-11974