### PR TITLE
HADOOP-19387. Recover LocalDirAllocator after failed initialization

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
@@ -351,9 +351,9 @@ public class LocalDirAllocator {
         }
         ctx.localDirs = dirs.toArray(new Path[dirs.size()]);
         ctx.dirDF = dfList.toArray(new DF[dirs.size()]);
-        ctx.savedLocalDirs = newLocalDirs;
 
         if (dirs.size() > 0) {
+          ctx.savedLocalDirs = newLocalDirs;
           // randomize the first disk picked in the round-robin selection
           ctx.dirNumLastAccessed.set(dirIndexRandomizer.nextInt(dirs.size()));
         }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java
@@ -24,12 +24,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.DiskChecker.DiskErrorException;
+import org.apache.hadoop.util.DiskValidator;
 import org.apache.hadoop.util.Shell;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -638,6 +641,33 @@ public class TestLocalDirAllocator {
     dirAllocator.getLocalPathForWrite("file2", -1, conf);
   }
 
+  /**
+   * Test for HADOOP-19387. LocalDirAllocator must retry initialization after
+   * a transient directory validation failure.
+   */
+  @Timeout(value = 30)
+  @Test
+  public void testInterruptionRecovery() throws Throwable {
+    initTestLocalDirAllocator(ABSOLUTE_DIR_ROOT, ABSOLUTE);
+    String interruptionContext = CONTEXT + ".interruption";
+    String dir0 = buildBufferDir(root, 7);
+    conf.set(interruptionContext, dir0);
+    localFs.delete(new Path(dir0), true);
+    AtomicBoolean failValidation = new AtomicBoolean(true);
+    DiskValidator validator = dir -> {
+      if (failValidation.getAndSet(false)) {
+        throw new DiskErrorException("interrupted");
+      }
+    };
+    LocalDirAllocator interruptedAllocator =
+        new LocalDirAllocator(interruptionContext, validator);
+
+    intercept(DiskErrorException.class,
+        () -> interruptedAllocator.getLocalPathForWrite("file", conf));
+
+    // A failed initialization must not prevent a subsequent retry.
+    interruptedAllocator.getLocalPathForWrite("file", conf);
+  }
+
 
 }
-


### PR DESCRIPTION
### Description of PR

Fixes [HADOOP-19387](https://issues.apache.org/jira/browse/HADOOP-19387).

`LocalDirAllocator` currently records a directory configuration as initialized even when every configured directory fails initialization. An interruption can therefore leave an empty directory context cached indefinitely: later calls see the unchanged configuration and never retry.

This patch records `savedLocalDirs` only after at least one directory is successfully initialized. A subsequent call can then retry a transiently failed initialization. The regression test uses a one-shot `DiskValidator` failure to exercise the same empty-context path deterministically, without relying on process timing.

This supersedes the stale, closed attempt in #7298 and updates the regression coverage to the current JUnit 5 test suite.

### How was this patch tested?

On macOS with OpenJDK 17.0.20 and Maven Wrapper 3.9.15:

```text
./mvnw -pl hadoop-common-project/hadoop-common -am -DskipShade \
  -Dtest=TestLocalDirAllocator \
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Before the production change, the new test fails on the second allocation with `DiskErrorException`, confirming the regression.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?
- [ ] Object storage: N/A
- [ ] If adding new dependencies: no new dependencies
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? N/A

### AI Tooling

Contains content generated by Codex.

- [x] The PR includes the phrase "Contains content generated by Codex"
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
