### PR TITLE
HADOOP-19267. Warn when shutdown timeout is below minimum

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
@@ -185,6 +185,9 @@ public final class ShutdownHookManager {
         SERVICE_SHUTDOWN_TIMEOUT_DEFAULT,
         TIME_UNIT_DEFAULT);
     if (duration < TIMEOUT_MINIMUM) {
+      LOG.warn("Configured {} value of {} seconds is below the minimum of {} "
+          + "seconds; using {} seconds",
+          SERVICE_SHUTDOWN_TIMEOUT, duration, TIMEOUT_MINIMUM, TIMEOUT_MINIMUM);
       duration = TIMEOUT_MINIMUM;
     }
     return duration;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 
 import static java.lang.Thread.sleep;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.SERVICE_SHUTDOWN_TIMEOUT;
@@ -172,8 +173,19 @@ public class TestShutdownHookManager {
     long shutdownTimeout = 50;
     conf.setTimeDuration(SERVICE_SHUTDOWN_TIMEOUT,
         shutdownTimeout, TimeUnit.NANOSECONDS);
-    assertEquals(ShutdownHookManager.TIMEOUT_MINIMUM,
-        ShutdownHookManager.getShutdownTimeout(conf), SERVICE_SHUTDOWN_TIMEOUT);
+    LogCapturer logCapturer = LogCapturer.captureLogs(
+        LoggerFactory.getLogger(ShutdownHookManager.class));
+    try {
+      assertEquals(ShutdownHookManager.TIMEOUT_MINIMUM,
+          ShutdownHookManager.getShutdownTimeout(conf),
+          SERVICE_SHUTDOWN_TIMEOUT);
+      assertTrue(logCapturer.getOutput().contains(
+          "Configured hadoop.service.shutdown.timeout value of 0 seconds "
+              + "is below the minimum of 1 seconds; using 1 seconds"),
+          logCapturer.getOutput());
+    } finally {
+      logCapturer.stopCapturing();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR

Fixes [HADOOP-19267](https://issues.apache.org/jira/browse/HADOOP-19267).

`ShutdownHookManager#getShutdownTimeout` already clamps `hadoop.service.shutdown.timeout` to its one-second minimum, but it does so silently. A mistyped or incorrectly converted duration is therefore hard for an operator to diagnose.

This patch emits a structured warning that identifies the configuration key, its value after conversion to seconds, the supported minimum, and the value Hadoop will use. The existing fallback behavior is unchanged.

### How was this patch tested?

On macOS with OpenJDK 17.0.20 and Maven Wrapper 3.9.15:

```text
./mvnw -pl hadoop-common-project/hadoop-common -am -DskipShade \
  -Dtest=TestShutdownHookManager \
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The updated bad-configuration test captures the class logger and verifies both the clamped return value and the full diagnostic warning. Before the production change, the new log assertion fails.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?
- [ ] Object storage: N/A
- [ ] If adding new dependencies: no new dependencies
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? N/A

### AI Tooling

Contains content generated by Codex.

- [x] The PR includes the phrase "Contains content generated by Codex"
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
