### PR TITLE
HADOOP-17214. Allow global filesystem cache disable

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -58,6 +58,10 @@ public class CommonConfigurationKeysPublic {
   public static final String  FS_DEFAULT_NAME_KEY = "fs.defaultFS";
   /** Default value for FS_DEFAULT_NAME_KEY */
   public static final String  FS_DEFAULT_NAME_DEFAULT = "file:///";
+  /** Disable the FileSystem instance cache for all schemes. */
+  public static final String FS_IMPL_DISABLE_CACHE = "fs.impl.disable.cache";
+  /** Default value for FS_IMPL_DISABLE_CACHE. */
+  public static final boolean FS_IMPL_DISABLE_CACHE_DEFAULT = false;
   /**
    * @see
    * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
@@ -1104,4 +1108,3 @@ public class CommonConfigurationKeysPublic {
   public static final String JMX_NAN_FILTER = "hadoop.http.jmx.nan-filter.enabled";
   public static final boolean JMX_NAN_FILTER_DEFAULT = false;
 }
-

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -515,6 +515,7 @@ public abstract class FileSystem extends Configured
    * <ol>
    * <li>
    *   If the configuration has the property
+   *   {@link CommonConfigurationKeysPublic#FS_IMPL_DISABLE_CACHE} or
    *   {@code "fs.$SCHEME.impl.disable.cache"} set to true,
    *   a new instance will be created, initialized with the supplied URI and
    *   configuration, then returned without being cached.
@@ -549,7 +550,8 @@ public abstract class FileSystem extends Configured
       }
     }
     String disableCacheName = String.format("fs.%s.impl.disable.cache", scheme);
-    if (conf.getBoolean(disableCacheName, false)) {
+    if (conf.getBoolean(FS_IMPL_DISABLE_CACHE, FS_IMPL_DISABLE_CACHE_DEFAULT)
+        || conf.getBoolean(disableCacheName, false)) {
       LOGGER.debug("Bypassing cache to create filesystem {}", uri);
       return createFileSystem(uri, conf);
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.fs.viewfs;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_IMPL_DISABLE_CACHE;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_IMPL_DISABLE_CACHE_DEFAULT;
 import static org.apache.hadoop.fs.impl.PathCapabilitiesSupport.validatePathCapabilityArgs;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE_DEFAULT;
@@ -1960,7 +1962,9 @@ public class ViewFileSystem extends FileSystem {
         if (child != null) {
           String disableCacheName = String.format("fs.%s.impl.disable.cache",
               child.getUri().getScheme());
-          if (config.getBoolean(disableCacheName, false)) {
+          if (config.getBoolean(FS_IMPL_DISABLE_CACHE,
+              FS_IMPL_DISABLE_CACHE_DEFAULT)
+              || config.getBoolean(disableCacheName, false)) {
             try {
               child.close();
             } catch (IOException e) {

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1110,6 +1110,15 @@
 </property>
 
 <property>
+  <name>fs.impl.disable.cache</name>
+  <value>false</value>
+  <description>Whether to disable the FileSystem instance cache for all
+  schemes. When true, FileSystem.get creates a new instance for every call.
+  Individual schemes can disable caching with
+  fs.SCHEME.impl.disable.cache.</description>
+</property>
+
+<property>
   <name>fs.trash.interval</name>
   <value>0</value>
   <description>Number of minutes after which the checkpoint

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemCaching.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemCaching.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_CREATION_PARALLEL_COUNT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_IMPL_DISABLE_CACHE;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -154,6 +155,15 @@ public class TestFileSystemCaching extends HadoopTestBase {
     conf.setBoolean("fs.uncachedfile.impl.disable.cache", true);
     FileSystem fs1 = FileSystem.get(new URI("uncachedfile://a"), conf);
     FileSystem fs2 = FileSystem.get(new URI("uncachedfile://a"), conf);
+    assertNotSame(fs1, fs2);
+  }
+
+  @Test
+  public void testCacheDisabledGlobally() throws Exception {
+    Configuration conf = newConf();
+    conf.setBoolean(FS_IMPL_DISABLE_CACHE, true);
+    FileSystem fs1 = FileSystem.get(new URI("cachedfile://a"), conf);
+    FileSystem fs2 = FileSystem.get(new URI("cachedfile://a"), conf);
     assertNotSame(fs1, fs2);
   }
   

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
@@ -39,12 +40,14 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemTestHelper;
+import org.apache.hadoop.fs.FilterFileSystem;
 import org.apache.hadoop.fs.FsConstants;
 import org.apache.hadoop.fs.FsStatus;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.TestFileUtil;
 import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
@@ -66,6 +69,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_IMPL_DISABLE_CACHE;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
@@ -1694,6 +1698,46 @@ abstract public class ViewFileSystemBaseTest {
         assertExceptionContains("Filesystem closed", e);
       }
     }
+  }
+
+  public static class CloseTrackingFileSystem extends FilterFileSystem {
+    private static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
+
+    public CloseTrackingFileSystem() {
+      super(new RawLocalFileSystem());
+    }
+
+    @Override
+    public void close() throws IOException {
+      CLOSE_COUNT.incrementAndGet();
+      super.close();
+    }
+  }
+
+  @Test
+  public void testCloseChildrenFileSystemWithGlobalCacheDisabled()
+      throws Exception {
+    final String clusterName = "cluster" + new Random().nextInt();
+    Configuration config = new Configuration(conf);
+    config.setClass("fs.tracking.impl", CloseTrackingFileSystem.class,
+        FileSystem.class);
+    config.setBoolean(FS_IMPL_DISABLE_CACHE, true);
+    config.setBoolean(CONFIG_VIEWFS_ENABLE_INNER_CACHE, false);
+    ConfigUtil.addLink(config, clusterName, "/tracking",
+        new Path("tracking:///target").toUri());
+    URI uri = new URI("viewfs://" + clusterName + "/");
+    CloseTrackingFileSystem.CLOSE_COUNT.set(0);
+
+    ViewFileSystem viewFs = (ViewFileSystem) FileSystem.get(uri, config);
+    try {
+      assertTrue(viewFs.getChildFileSystems().length > 0,
+          "viewfs should have at least one child fs.");
+      assertEquals(0, CloseTrackingFileSystem.CLOSE_COUNT.get());
+    } finally {
+      viewFs.close();
+    }
+
+    assertEquals(1, CloseTrackingFileSystem.CLOSE_COUNT.get());
   }
 
   @Test


### PR DESCRIPTION
### Description of PR

Fixes [HADOOP-17214](https://issues.apache.org/jira/browse/HADOOP-17214).

`FileSystem.get(URI, Configuration)` currently supports disabling the filesystem instance cache only one scheme at a time through `fs.SCHEME.impl.disable.cache`. Deployments that use many schemes must enumerate every implementation and can miss dynamically introduced schemes.

This patch adds the global `fs.impl.disable.cache` configuration, defaulting to `false`. When enabled, `FileSystem.get` creates a fresh instance for every scheme. Existing per-scheme switches remain supported and either the global or scheme-specific value can disable caching.

The setting is exposed in `CommonConfigurationKeysPublic` and documented in `core-default.xml`. ViewFS also treats globally uncached child filesystems as owned resources and closes them when ViewFS closes, including when its inner cache is disabled.

### How was this patch tested?

On macOS with OpenJDK 17.0.20 and Maven Wrapper 3.9.15:

```text
./mvnw -pl hadoop-common-project/hadoop-common -am -DskipShade \
  -Dtest=TestFileSystemCaching \
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The ViewFS ownership integration was additionally tested with:

```text
./mvnw -pl hadoop-common-project/hadoop-common -am -DskipShade \
  -Dtest=TestFileSystemCaching,TestViewFileSystemLocalFileSystem \
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 112, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS
```

The cache regression test requests the same URI twice with the global switch enabled and verifies distinct instances are returned. Before the implementation change it fails because the same cached instance is returned. The ViewFS regression uses a close-tracking child filesystem and fails before the ownership fix with `expected: <1> but was: <0>`. Existing tests also verify that caching remains enabled by default and that scheme-specific disabling still works.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?
- [ ] Object storage: N/A
- [ ] If adding new dependencies: no new dependencies
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? N/A

### AI Tooling

Contains content generated by Codex.

- [x] The PR includes the phrase "Contains content generated by Codex"
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
