### PR TITLE
HADOOP-19956. Upgrade lz4-java to 1.11.2 due to security issues

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -211,7 +211,7 @@ to be inclusive of all which may be included:
 
 hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/nvd3-1.8.5.* (css and js files)
 
-at.yawk.lz4:lz4-java:1.11.1
+at.yawk.lz4:lz4-java:1.11.2
 ch.qos.reload4j:reload4j:1.2.22
 com.aliyun:aliyun-java-core:0.2.11-beta
 com.aliyun:aliyun-java-sdk-core:4.5.10

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -154,7 +154,7 @@
     <metrics.version>3.2.4</metrics.version>
     <netty4.version>4.1.135.Final</netty4.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>
-    <lz4-java.version>1.11.1</lz4-java.version>
+    <lz4-java.version>1.11.2</lz4-java.version>
     <zstd-jni.version>1.5.7-8</zstd-jni.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19956

### How was this patch tested?


### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
