### PR TITLE
HADOOP-19958. Support IPv6 delegation token service addresses

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -241,6 +241,9 @@ public class NetUtils {
     URI uri = createURI(target, hasScheme, helpText, useCacheIfPresent);
 
     String host = uri.getHost();
+    if (host != null && host.startsWith("[") && host.endsWith("]")) {
+      host = host.substring(1, host.length() - 1);
+    }
     int port = uri.getPort();
     if (port == -1) {
       port = defaultPort;
@@ -763,10 +766,29 @@ public class NetUtils {
    * Compose a "host:port" string from the address.
    *
    * @param addr address.
-   * @return hort port string.
+   * @return host port string.
    */
   public static String getHostPortString(InetSocketAddress addr) {
-    return addr.getHostName() + ":" + addr.getPort();
+    return getHostPortString(addr.getHostName(), addr.getPort());
+  }
+
+  /**
+   * Compose a "host:port" string, bracketing IPv6 literals.
+   *
+   * @param host host name or IP address.
+   * @param port port number.
+   * @return host port string.
+   */
+  public static String getHostPortString(String host, int port) {
+    String normalizedHost = host;
+    if (normalizedHost != null && normalizedHost.startsWith("[")
+        && normalizedHost.endsWith("]")) {
+      normalizedHost = normalizedHost.substring(1, normalizedHost.length() - 1);
+    }
+    if (normalizedHost != null && normalizedHost.contains(":")) {
+      return "[" + normalizedHost + "]:" + port;
+    }
+    return normalizedHost + ":" + port;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
@@ -480,7 +480,7 @@ public final class SecurityUtil {
    *          hadoop.security.token.service.use_ip
    */
   public static Text buildTokenService(InetSocketAddress addr) {
-    String host = null;
+    String host;
     if (useIpForTokenService) {
       if (addr.isUnresolved()) { // host has no ip address
         throw new IllegalArgumentException(
@@ -491,7 +491,7 @@ public final class SecurityUtil {
     } else {
       host = StringUtils.toLowerCase(addr.getHostName());
     }
-    return new Text(host + ":" + addr.getPort());
+    return new Text(NetUtils.getHostPortString(host, addr.getPort()));
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -784,6 +784,19 @@ public class TestNetUtils {
   }
 
   @Test
+  public void testIPv6HostPortString() {
+    assertEquals("[::1]:123", NetUtils.getHostPortString("::1", 123));
+    assertEquals("[::1]:123", NetUtils.getHostPortString("[::1]", 123));
+
+    InetSocketAddress addr = NetUtils.createSocketAddrUnresolved("[::1]:123");
+    assertEquals("::1", addr.getHostString());
+    assertEquals(123, addr.getPort());
+
+    assertThrows(IllegalArgumentException.class,
+        () -> NetUtils.createSocketAddr("::1:123"));
+  }
+
+  @Test
   public void testGetPortFromHostPortString() throws Exception {
 
     assertEquals(1002, NetUtils.getPortFromHostPortString("testHost:1002"));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSecurityUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSecurityUtil.java
@@ -297,7 +297,7 @@ public class TestSecurityUtil {
     String serviceHost = useIp ? ip : StringUtils.toLowerCase(host);
     
     Token<?> token = new Token<TokenIdentifier>();
-    Text service = new Text(serviceHost+":"+port);
+    Text service = new Text(NetUtils.getHostPortString(serviceHost, port));
     
     assertEquals(service, SecurityUtil.buildTokenService(addr));
     SecurityUtil.setTokenService(token, addr);
@@ -364,6 +364,14 @@ public class TestSecurityUtil {
     String staticHost = "127.0.0.1";
     NetUtils.addStaticResolution(staticHost, "localhost");
     verifyServiceAddr(staticHost, "127.0.0.1");
+  }
+
+  @Test
+  public void testSocketAddrWithIPv6() throws Exception {
+    SecurityUtil.setTokenServiceUseIp(false);
+    String host = "::1";
+    InetSocketAddress addr = NetUtils.createSocketAddr("[::1]:123");
+    verifyAddress(addr, host, InetAddress.getByName(host).getHostAddress(), 123);
   }
 
   @Test


### PR DESCRIPTION
Generated-by: Codex (GPT-5.6 Sol)

### Description of PR

Jira: [HADOOP-19958](https://issues.apache.org/jira/browse/HADOOP-19958)

Parent Jira: [HADOOP-11890](https://issues.apache.org/jira/browse/HADOOP-11890)

Delegation token services use `host:port`. This representation is ambiguous when the host is an IPv6 literal.

This change:

- adds a shared `NetUtils` helper that formats IPv6 addresses as `[host]:port`;
- accepts bracketed IPv6 authorities when creating socket addresses;
- uses the shared format for delegation token services in both token-service modes;
- verifies token service round trips when `hadoop.security.token.service.use_ip` is `true` or `false`;
- rejects ambiguous unbracketed IPv6 authorities; and
- preserves existing DNS and IPv4 behavior.

### How was this patch tested?

- `JAVA_HOME=<JDK17> mvn -B -pl :hadoop-common -Dtest=TestNetUtils,TestSecurityUtil test --no-transfer-progress`
- Result: 76 tests passed with no failures, errors, or skips.
- `git diff --check asf/trunk...HEAD`

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id
      (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.* Not applicable to this change.
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion
      under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? No new dependencies are added.
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
      No license or notice changes are required.

### AI Tooling

Contains content generated by Codex.

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html