### PR TITLE
HDFS-17960. Fix snapshot count mismatch during edit log replay

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotManager.java
@@ -543,8 +543,11 @@ public class SnapshotManager implements SnapshotStatsMXBean {
       assertFirstSnapshot(srcRoot, snapshottable, snapshot);
     }
 
-    srcRoot.removeSnapshot(reclaimContext, snapshotName, now, this);
-    numSnapshots.getAndDecrement();
+    Snapshot removed = srcRoot.removeSnapshot(
+        reclaimContext, snapshotName, now, this);
+    if (removed != null) {
+      numSnapshots.decrementAndGet();
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletion.java
@@ -231,6 +231,12 @@ public class TestOrderedSnapshotDeletion {
     cluster.getNameNode().getConf().
         setBoolean(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED, false);
     cluster.restartNameNodes();
+    assertEquals(1, hdfs.getSnapshotListing(snapshottableDir).length);
+    assertEquals(1,
+        cluster.getNamesystem().getSnapshotManager().getNumSnapshots());
+    hdfs.setSafeMode(SafeModeAction.ENTER);
+    hdfs.saveNamespace();
+    hdfs.setSafeMode(SafeModeAction.LEAVE);
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR fixes [HDFS-17960](https://issues.apache.org/jira/browse/HDFS-17960).

When edit logs generated with ordered snapshot deletion enabled are replayed with ordered deletion disabled, multiple delete records may refer to the same snapshot. After the first record removes the snapshot `DirectorySnapshottableFeature.removeSnapshot()` returns `null` for a later duplicate record.

`SnapshotManager.deleteSnapshot()` previously ignored this return value and unconditionally decremented `numSnapshots`. This caused the counter to differ from the snapshots actually present in the namespace. A subsequent checkpoint could fail while serializing the snapshot section because the number of serialized snapshots did not match`numSnapshots`.

This change decrements `numSnapshots` only when `removeSnapshot()` actually returns a removed snapshot. 

### How was this patch tested?
This PR extends the existing ordered snapshot deletion restart test to verify:
  - The internal snapshot count matches the snapshot listing.
  - `saveNamespace()` can successfully create a checkpoint.

### For code changes:
  - [x] Does the title of this PR start with the corresponding JIRA issue id
    (e.g. 'HADOOP-17799. Your PR title ...')?
  - [ ] Object storage: Not applicable; this change only affects HDFS NameNode
    snapshot handling.
  - [ ] No new dependencies are added by this change.
  - [ ] No LICENSE, LICENSE-binary, or NOTICE-binary updates are required.

### AI Tooling

If an AI tool was used:
  - [x] Contains content generated by Codex
  - [x] My use of AI contributions follows the ASF legal policy
    https://www.apache.org/legal/generative-tooling.html
