### PR TITLE
HDFS-17961. Fix ineffective bucket-size validation in RollingWindow constructor

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindow.java
@@ -76,7 +76,7 @@ public class RollingWindow {
     }
     this.windowLenMs = windowLenMs;
     this.bucketSize = windowLenMs / numBuckets;
-    if (this.bucketSize % bucketSize != 0) {
+    if (this.windowLenMs % numBuckets != 0) {
       throw new IllegalArgumentException(
           "The bucket size in the rolling window is not integer: windowLenMs= "
               + windowLenMs + " numBuckets= " + numBuckets);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.server.namenode.top.window;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestRollingWindow {
 
@@ -77,6 +78,12 @@ public class TestRollingWindow {
     assertEquals(
         5, window.getSum(time),
         "The sum of rolling window does not reflect rolling effect");
+  }
+
+  @Test
+  public void testRejectsUnevenBucketSize() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new RollingWindow(WINDOW_LEN + 1, BUCKET_CNT));
   }
 
 }


### PR DESCRIPTION
HDFS-17961. Fix ineffective bucket-size validation in RollingWindow constructor

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fix ineffective bucket-size validation in RollingWindow constructor

### How was this patch tested?
tested by newly added unit test

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
