### PR TITLE
HDFS-17962. NNTop may lose user metrics during expired window cleanup

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindowManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindowManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdfs.server.namenode.top.TopConf;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.slf4j.Logger;
@@ -249,8 +250,23 @@ public class RollingWindowManager {
    */
   public void recordMetric(long time, String command,
       String user, long delta) {
-    RollingWindow window = getRollingWindow(command, user);
-    window.incAt(time, delta);
+    RollingWindowMap rwMap = metricMap.computeIfAbsent(
+        command, key -> new RollingWindowMap());
+
+    rwMap.compute(user, (key, window) -> {
+      if (window == null) {
+        window = new RollingWindow(windowLenMs, bucketsPerWindow);
+      }
+      window.incAt(time, delta);
+      return window;
+    });
+  }
+
+  @VisibleForTesting
+  void setRollingWindowForTesting(String metric, String user,
+      RollingWindow window) {
+    metricMap.computeIfAbsent(metric, key -> new RollingWindowMap())
+        .put(user, window);
   }
 
   /**
@@ -298,54 +314,23 @@ public class RollingWindowManager {
   private UserCounts getTopUsersForMetric(long time, String metricName,
       RollingWindowMap rollingWindows) {
     UserCounts topN = new UserCounts(topUsersCnt);
-    Iterator<Map.Entry<String, RollingWindow>> iterator =
-        rollingWindows.entrySet().iterator();
-    while (iterator.hasNext()) {
-      Map.Entry<String, RollingWindow> entry = iterator.next();
-      String userName = entry.getKey();
-      RollingWindow aWindow = entry.getValue();
-      long windowSum = aWindow.getSum(time);
-      // do the gc here
-      if (windowSum == 0) {
-        LOG.debug("gc window of metric: {} userName: {}",
-            metricName, userName);
-        iterator.remove();
-        continue;
-      }
-      LOG.debug("offer window of metric: {} userName: {} sum: {}",
-          metricName, userName, windowSum);
-      topN.add(new User(userName, windowSum));
+    for (String userName : rollingWindows.keySet()) {
+      rollingWindows.computeIfPresent(userName, (key, window) -> {
+        long windowSum = window.getSum(time);
+        if (windowSum == 0) {
+          LOG.debug("gc window of metric: {} userName: {}",
+              metricName, userName);
+          return null;
+        }
+
+        LOG.debug("offer window of metric: {} userName: {} sum: {}",
+            metricName, userName, windowSum);
+        topN.add(new User(userName, windowSum));
+        return window;
+      });
     }
     LOG.debug("topN users size for command {} is: {}",
         metricName, topN.size());
     return topN;
-  }
-
-  /**
-   * Get the rolling window specified by metric and user.
-   *
-   * @param metric the updated metric
-   * @param user the user that updated the metric
-   * @return the rolling window
-   */
-  private RollingWindow getRollingWindow(String metric, String user) {
-    RollingWindowMap rwMap = metricMap.get(metric);
-    if (rwMap == null) {
-      rwMap = new RollingWindowMap();
-      RollingWindowMap prevRwMap = metricMap.putIfAbsent(metric, rwMap);
-      if (prevRwMap != null) {
-        rwMap = prevRwMap;
-      }
-    }
-    RollingWindow window = rwMap.get(user);
-    if (window != null) {
-      return window;
-    }
-    window = new RollingWindow(windowLenMs, bucketsPerWindow);
-    RollingWindow prevWindow = rwMap.putIfAbsent(user, window);
-    if (prevWindow != null) {
-      window = prevWindow;
-    }
-    return window;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindowManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindowManager.java
@@ -252,6 +252,7 @@ public class RollingWindowManager {
     RollingWindowMap rwMap = metricMap.computeIfAbsent(
         command, key -> new RollingWindowMap());
 
+    // Use compute to make action on RollingWindow atomic
     rwMap.compute(user, (key, window) -> {
       if (window == null) {
         window = new RollingWindow(windowLenMs, bucketsPerWindow);
@@ -314,6 +315,7 @@ public class RollingWindowManager {
       RollingWindowMap rollingWindows) {
     UserCounts topN = new UserCounts(topUsersCnt);
     for (String userName : rollingWindows.keySet()) {
+      // Use computeIfPresent to make action on RollingWindow atomic
       rollingWindows.computeIfPresent(userName, (key, window) -> {
         long windowSum = window.getSum(time);
         if (windowSum == 0) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindowManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/window/RollingWindowManager.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindowManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindowManager.java
@@ -21,6 +21,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -33,6 +39,7 @@ import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowMan
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.TopWindow;
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.User;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRollingWindowManager {
@@ -216,6 +223,69 @@ public class TestRollingWindowManager {
     // ensure all the top users for each op are present in the total op.
     for (int i = 1; i < numOps; i++) {
       assertTrue(topUsers.containsAll(window.getOps().get(i).getTopUsers()));
+    }
+  }
+
+  @Test
+  public void testConcurrentRecordDuringSnapshotCleanup() throws Exception {
+    String metric = "op";
+    String user = users[0];
+    BlockingRollingWindow rollingWindow = new BlockingRollingWindow(
+        WINDOW_LEN_MS, BUCKET_CNT);
+    manager.setRollingWindowForTesting(metric, user, rollingWindow);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<TopWindow> snapshot = executor.submit(
+          () -> manager.snapshot(WINDOW_LEN_MS));
+      assertTrue(rollingWindow.awaitGetSumStarted(5, TimeUnit.SECONDS));
+
+      Future<?> record = executor.submit(
+          () -> manager.recordMetric(WINDOW_LEN_MS, metric, user, 1));
+      assertThrows(TimeoutException.class,
+          () -> record.get(1, TimeUnit.SECONDS));
+
+      rollingWindow.allowGetSum();
+      snapshot.get(5, TimeUnit.SECONDS);
+      record.get(5, TimeUnit.SECONDS);
+
+      TopWindow topWindow = manager.snapshot(WINDOW_LEN_MS);
+      assertEquals(2, topWindow.getOps().size());
+      Op op = topWindow.getOps().get(1);
+      assertEquals(metric, op.getOpType());
+      assertEquals(1, op.getTotalCount());
+    } finally {
+      rollingWindow.allowGetSum();
+      executor.shutdownNow();
+    }
+  }
+
+  private static class BlockingRollingWindow extends RollingWindow {
+    private final CountDownLatch getSumStarted = new CountDownLatch(1);
+    private final CountDownLatch allowGetSum = new CountDownLatch(1);
+
+    BlockingRollingWindow(int windowLenMs, int bucketsPerWindow) {
+      super(windowLenMs, bucketsPerWindow);
+    }
+
+    @Override
+    public long getSum(long time) {
+      getSumStarted.countDown();
+      try {
+        allowGetSum.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return 0;
+    }
+
+    boolean awaitGetSumStarted(long timeout, TimeUnit unit)
+        throws InterruptedException {
+      return getSumStarted.await(timeout, unit);
+    }
+
+    void allowGetSum() {
+      allowGetSum.countDown();
     }
   }
 


### PR DESCRIPTION
HDFS-17962. NNTop may lose user metrics during expired window cleanup
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
NNTop stores a RollingWindow for each (metric, user) pair in a ConcurrentHashMap.

In RollingWindowManager#getTopUsersForMetric(), expired user windows are removed when getSum(time) returns 0. Previously, the cleanup used an iterator to remove the map entry, while RollingWindowManager#recordMetric() obtained a RollingWindow from the map and incremented it outside of any per-key atomic operation.

This allows the following race:

1. A recordMetric() thread obtains an existing RollingWindow for a user.
2. A snapshot thread observes that the window sum is 0 and removes the user-to-window mapping.
3. The recordMetric() thread increments the RollingWindow it obtained earlier.
4. The increment is applied to an object that is no longer in the map, so the metric is lost from subsequent NNTop snapshots.

### How was this patch tested?
Tested by newly added unit test

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
