### PR TITLE
HADOOP-19963. Shut down leaked mini-cluster instances in hadoop-distcp and hadoop-streaming tests.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyMapper.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.tools.util.DistCpUtils;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.StringUtils;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -92,6 +93,14 @@ public class TestCopyMapper {
                 .numDataNodes(1)
                 .format(true)
                 .build());
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.*;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * This class tests cacheArchive option of streaming
@@ -79,6 +80,23 @@ public class TestMultipleArchiveFiles extends TestStreaming
   protected void setInputOutput() {
     inputFile = INPUT_FILE;
     outDir = OUTPUT_DIR;
+  }
+
+  @Override
+  @AfterEach
+  public void tearDown() {
+    try {
+      super.tearDown();
+    } finally {
+      if (mr != null) {
+        mr.shutdown();
+        mr = null;
+      }
+      if (dfs != null) {
+        dfs.shutdown();
+        dfs = null;
+      }
+    }
   }
 
   protected void createInput() throws IOException


### PR DESCRIPTION
### Description of PR

The hadoop-tools slice of the mini-cluster leak scan recorded in HDFS-17957.
Two test classes hold mini-cluster references with no teardown in the class or
any ancestor, so the clusters run until the surefire fork exits.

`TestCopyMapper` builds a `MiniDFSCluster` in `@BeforeAll` and never shuts it
down; 18 test methods share it. The new `@AfterAll` also covers
`TestCopyMapperCompositeCrc`, which hides `setup()` to build its own cluster
through `setCluster()` and inherits the teardown.

`TestMultipleArchiveFiles` builds a `MiniDFSCluster` and a `MiniMRCluster` in
its constructor. `TestStreaming` declares no `@TestInstance`, so the default
per-method lifecycle constructs a fresh pair for every test method — teardown
is therefore `@AfterEach`, not `@AfterAll`. It delegates to
`TestStreaming#tearDown()` and shuts both clusters down in a `finally`, so they
come down even if the superclass teardown throws.

Impact: a leaked cluster keeps threads, heap and ports alive under the
remaining tests of the class.

Test-scope only; no production code is touched.

Disclosure: no CI failure was reproduced for this change. The relevant
ci-hadoop artifacts have aged out and Yetus reports at class granularity, so
these leaks were found by reading the code. They are real defects
independently, but causation against specific red runs is not proven.

### How was this patch tested?

`mvn test-compile -pl hadoop-tools/hadoop-distcp,hadoop-tools/hadoop-streaming`
— BUILD SUCCESS, both modules.

Neither test was executed locally: `MiniDFSCluster` requires winutils on this
Windows machine, and the streaming test drives a POSIX shell (`xargs cat`).
Relying on Yetus for the run.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

Contains content generated by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
