### PR TITLE
YARN-11983. Shut down leaked mini-cluster instances.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
@@ -107,103 +107,105 @@ public class TestFederationRMFailoverProxyProvider {
     final SubClusterId subClusterId = SubClusterId.newInstance("SC-1");
     final MiniYARNCluster cluster = new MiniYARNCluster(
         "testFederationRMFailoverProxyProvider", 3, 0, 1, 1);
+    try {
 
-    conf.setBoolean(YarnConfiguration.FEDERATION_FLUSH_CACHE_FOR_RM_ADDR,
-        facadeFlushCache);
+      conf.setBoolean(YarnConfiguration.FEDERATION_FLUSH_CACHE_FOR_RM_ADDR,
+          facadeFlushCache);
 
-    conf.setBoolean(YarnConfiguration.FEDERATION_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.FEDERATION_FAILOVER_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
-    conf.set(YarnConfiguration.RM_CLUSTER_ID, "cluster1");
-    conf.set(YarnConfiguration.RM_HA_IDS, "rm1,rm2,rm3");
+      conf.setBoolean(YarnConfiguration.FEDERATION_ENABLED, true);
+      conf.setBoolean(YarnConfiguration.FEDERATION_FAILOVER_ENABLED, true);
+      conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
+      conf.set(YarnConfiguration.RM_CLUSTER_ID, "cluster1");
+      conf.set(YarnConfiguration.RM_HA_IDS, "rm1,rm2,rm3");
 
-    conf.setLong(YarnConfiguration.RESOURCEMANAGER_CONNECT_RETRY_INTERVAL_MS,
-        2000);
+      conf.setLong(YarnConfiguration.RESOURCEMANAGER_CONNECT_RETRY_INTERVAL_MS,
+          2000);
 
-    HATestUtil.setRpcAddressForRM("rm1", 10000, conf);
-    HATestUtil.setRpcAddressForRM("rm2", 20000, conf);
-    HATestUtil.setRpcAddressForRM("rm3", 30000, conf);
-    conf.setBoolean(YarnConfiguration.YARN_MINICLUSTER_FIXED_PORTS, true);
+      HATestUtil.setRpcAddressForRM("rm1", 10000, conf);
+      HATestUtil.setRpcAddressForRM("rm2", 20000, conf);
+      HATestUtil.setRpcAddressForRM("rm3", 30000, conf);
+      conf.setBoolean(YarnConfiguration.YARN_MINICLUSTER_FIXED_PORTS, true);
 
-    cluster.init(conf);
-    cluster.start();
+      cluster.init(conf);
+      cluster.start();
 
-    // Transition rm3 to active;
-    makeRMActive(subClusterId, cluster, 2);
+      // Transition rm3 to active;
+      makeRMActive(subClusterId, cluster, 2);
 
-    ApplicationClientProtocol client = FederationProxyProviderUtil
-        .createRMProxy(conf, ApplicationClientProtocol.class, subClusterId,
-            UserGroupInformation.getCurrentUser());
+      ApplicationClientProtocol client = FederationProxyProviderUtil
+          .createRMProxy(conf, ApplicationClientProtocol.class, subClusterId,
+              UserGroupInformation.getCurrentUser());
 
-    verify(stateStore, times(1))
-        .getSubClusters(any(GetSubClustersInfoRequest.class));
-
-    // client will retry until the rm becomes active.
-    GetClusterMetricsResponse response =
-        client.getClusterMetrics(GetClusterMetricsRequest.newInstance());
-
-    verify(stateStore, times(1))
-        .getSubClusters(any(GetSubClustersInfoRequest.class));
-
-    // validate response
-    checkResponse(response);
-
-    // transition rm3 to standby
-    cluster.getResourceManager(2).getRMContext().getRMAdminService()
-        .transitionToStandby(new HAServiceProtocol.StateChangeRequestInfo(
-            HAServiceProtocol.RequestSource.REQUEST_BY_USER));
-
-    // Transition rm2 to active;
-    makeRMActive(subClusterId, cluster, 1);
-
-    verify(stateStore, times(1))
-        .getSubClusters(any(GetSubClustersInfoRequest.class));
-
-    threadResponse = null;
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          // In non flush cache case, we will be hitting the cache with old RM
-          // address and keep failing before the cache is flushed
-          threadResponse =
-              client.getClusterMetrics(GetClusterMetricsRequest.newInstance());
-        } catch (YarnException | IOException e) {
-          e.printStackTrace();
-        }
-      }
-    });
-    thread.start();
-
-    if (!facadeFlushCache) {
-      // Add a wait so that hopefully the thread has started hitting old cached
-      Thread.sleep(500);
-
-      // Should still be hitting cache
       verify(stateStore, times(1))
           .getSubClusters(any(GetSubClustersInfoRequest.class));
 
-      // Force flush cache, so that it will pick up the new RM address
-      FederationStateStoreFacade.getInstance(conf).getSubCluster(subClusterId,
-          true);
-    }
+      // client will retry until the rm becomes active.
+      GetClusterMetricsResponse response =
+          client.getClusterMetrics(GetClusterMetricsRequest.newInstance());
 
-    // Wait for the thread to finish and grab result
-    thread.join();
-    response = threadResponse;
-
-    if (facadeFlushCache) {
-      verify(stateStore, atLeast(2))
+      verify(stateStore, times(1))
           .getSubClusters(any(GetSubClustersInfoRequest.class));
-    } else {
-      verify(stateStore, times(2))
+
+      // validate response
+      checkResponse(response);
+
+      // transition rm3 to standby
+      cluster.getResourceManager(2).getRMContext().getRMAdminService()
+          .transitionToStandby(new HAServiceProtocol.StateChangeRequestInfo(
+              HAServiceProtocol.RequestSource.REQUEST_BY_USER));
+
+      // Transition rm2 to active;
+      makeRMActive(subClusterId, cluster, 1);
+
+      verify(stateStore, times(1))
           .getSubClusters(any(GetSubClustersInfoRequest.class));
+
+      threadResponse = null;
+      Thread thread = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            // In non flush cache case, we will be hitting the cache with old RM
+            // address and keep failing before the cache is flushed
+            threadResponse =
+                client.getClusterMetrics(GetClusterMetricsRequest.newInstance());
+          } catch (YarnException | IOException e) {
+            e.printStackTrace();
+          }
+        }
+      });
+      thread.start();
+
+      if (!facadeFlushCache) {
+        // Add a wait so that hopefully the thread has started hitting old cached
+        Thread.sleep(500);
+
+        // Should still be hitting cache
+        verify(stateStore, times(1))
+            .getSubClusters(any(GetSubClustersInfoRequest.class));
+
+        // Force flush cache, so that it will pick up the new RM address
+        FederationStateStoreFacade.getInstance(conf).getSubCluster(subClusterId,
+            true);
+      }
+
+      // Wait for the thread to finish and grab result
+      thread.join();
+      response = threadResponse;
+
+      if (facadeFlushCache) {
+        verify(stateStore, atLeast(2))
+            .getSubClusters(any(GetSubClustersInfoRequest.class));
+      } else {
+        verify(stateStore, times(2))
+            .getSubClusters(any(GetSubClustersInfoRequest.class));
+      }
+
+      // validate response
+      checkResponse(response);
+    } finally {
+      cluster.stop();
     }
-
-    // validate response
-    checkResponse(response);
-
-    cluster.stop();
   }
 
   private void checkResponse(GetClusterMetricsResponse response) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestMiniYarnClusterNodeUtilization.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestMiniYarnClusterNodeUtilization.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -89,6 +90,14 @@ public class TestMiniYarnClusterNodeUtilization {
         CONTAINER_PMEM_1, CONTAINER_VMEM_1, CONTAINER_CPU_1,
         NODE_PMEM_1, NODE_VMEM_1, NODE_CPU_1);
     nm.setNodeStatus(nodeStatus);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.stop();
+      cluster = null;
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11983. Shut down leaked mini-cluster instances

Shuts down 2 leaked `MiniYARNCluster` instances in 2 test files, the
hadoop-yarn slice of the mini-cluster leak scan recorded in HDFS-17957.

A leaked cluster keeps ResourceManager and NodeManager threads, heap and
ports alive under the remaining tests of the class, so one real failure
can cascade into bogus failures of later tests in the same class.

**`TestFederationRMFailoverProxyProvider`.** `testProxyProvider`, the
helper both failover tests drive, stopped its cluster only after the last
assertion, so the cluster leaked exactly when the test failed. The method
body now runs under `try`/`finally` and the stop covers every exit.

**`TestMiniYarnClusterNodeUtilization`.** The cluster lives in a field
with no teardown in the class or its ancestors; `@BeforeEach` builds and
starts a fresh cluster for each of the two test methods, so every run
leaked two clusters even when the tests passed. A new `@AfterEach` stops
whatever `setup()` built.

Test-scope only; no production code is touched.

### How was this patch tested?

Both touched classes were run on Ubuntu 24.04 with JDK
`17.0.19+10-1-24.04.2-Ubuntu`, the same JDK and OS as the precommit
agents:

| Module | Classes | Tests | Result |
|---|---|---|---|
| hadoop-yarn-client | 1 | 3 | green |
| hadoop-yarn-server-tests | 1 | 2 | green |

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?
- [ ] Object storage: N/A
- [ ] If adding new dependencies … — no new dependencies
- [ ] If applicable, have you updated the `LICENSE`… — N/A

### AI Tooling

Contains content generated by Claude Code.

- [x] The PR includes the phrase "Contains content generated by Claude Code"
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)
