### PR TITLE
MAPREDUCE-7542. Shut down leaked mini-cluster instances.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/TestNNBench.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/TestNNBench.java
@@ -92,15 +92,18 @@ public class TestNNBench extends HadoopTestCase {
   public void testNNBenchCrossCluster() throws Exception {
     MiniDFSCluster dfsCluster = new MiniDFSCluster.Builder(new JobConf())
             .numDataNodes(1).build();
-    dfsCluster.waitClusterUp();
-    String nnAddress = dfsCluster.getNameNode(0).getHostAndPort();
-    String baseDir = "hdfs://" + nnAddress + BASE_DIR;
-    runNNBench(createJobConf(), "create_write", baseDir);
+    try {
+      dfsCluster.waitClusterUp();
+      String nnAddress = dfsCluster.getNameNode(0).getHostAndPort();
+      String baseDir = "hdfs://" + nnAddress + BASE_DIR;
+      runNNBench(createJobConf(), "create_write", baseDir);
 
-    Path path = new Path(BASE_DIR + "/data/file_0_0");
-    assertTrue(dfsCluster.getFileSystem().exists(path),
-        "create_write should create the file");
-    dfsCluster.shutdown();
+      Path path = new Path(BASE_DIR + "/data/file_0_0");
+      assertTrue(dfsCluster.getFileSystem().exists(path),
+          "create_write should create the file");
+    } finally {
+      dfsCluster.shutdown();
+    }
   }
 
   private void runNNBench(Configuration conf, String operation, String baseDir)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/token/delegation/TestDelegationToken.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,14 @@ public class TestDelegationToken {
     user2 = UserGroupInformation.createUserForTesting("bob", 
                                                       new String[]{"users"});
     cluster = new MiniMRCluster(0,0,1,"file:///",1);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
   }
   
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
### Description of PR

JIRA: MAPREDUCE-7542. Shut down leaked mini-cluster instances.

Shuts down 2 leaked mini-cluster instances in 2
hadoop-mapreduce-client-jobclient test files, the hadoop-mapreduce slice
of the mini-cluster leak scan recorded in HDFS-17957.

A leaked cluster keeps NameNode/DataNode (or ResourceManager/NodeManager)
threads, heap and ports alive under the remaining tests of the class, so
one real failure can cascade into bogus failures of later tests in the
same class.

**`TestNNBench`.** `testNNBenchCrossCluster` shut its `MiniDFSCluster`
down only after the last assertion, so the cluster leaked exactly when
the test failed. The method body now runs under `try`/`finally` and the
shutdown covers every exit.

**`TestDelegationToken`.** The `MiniMRCluster` lives in a field that
`@BeforeEach` rebuilds for every test method, with no teardown in the
class or its ancestors. The class is currently `@Disabled` at class
level, so the leak bites only when the class is re-enabled; the new
`@AfterEach` shuts down whatever `setup()` built and makes re-enabling
safe.

Test-scope only; no production code is touched.

### How was this patch tested?

The touched classes were run on Ubuntu 24.04 with JDK
`17.0.19+10-1-24.04.2-Ubuntu`, the same JDK and OS as the precommit
agents:

| Module | Class | Tests | Result |
|---|---|---|---|
| hadoop-mapreduce-client-jobclient | TestNNBench | 4 | all pass (27s) |
| hadoop-mapreduce-client-jobclient | TestDelegationToken | 1 | skipped — class is `@Disabled`; change verified by test-compile |

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by Claude Code.

- [x] The PR includes the phrase "Contains content generated by Claude Code"
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
