### PR TITLE
YARN-11984. Federation mock sub-cluster and router do not stop cleanly on SIGTERM.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.hadoop.util.GenericOptionsParser;
+import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.hadoop.yarn.YarnUncaughtExceptionHandler;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -124,6 +125,13 @@ public class Router extends CompositeService {
 
   private static final String UI2_WEBAPP_NAME = "/ui2";
 
+  /**
+   * How long serviceStop waits for the scheduled executor to drain before it
+   * interrupts what is still running. One SubClusterCleaner run is a scan of
+   * the state store, so this only has to cover a single pass.
+   */
+  private static final long SCHEDULED_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 10;
+
   private ScheduledThreadPoolExecutor scheduledExecutorService;
   private SubClusterCleaner subClusterCleaner;
 
@@ -196,6 +204,12 @@ public class Router extends CompositeService {
     if (isStopping.getAndSet(true)) {
       return;
     }
+    // serviceStart() may have scheduled the SubClusterCleaner on this executor.
+    // Shut it down before the services below, and wait for an in-flight run to
+    // finish: the cleaner reaches the federation state store on every run, so
+    // it must not still be running once the Router has stopped.
+    HadoopExecutors.shutdown(scheduledExecutorService, LOG,
+        SCHEDULED_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     super.serviceStop();
     DefaultMetricsSystem.shutdown();
     WebServiceClient.destroy();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
@@ -202,6 +202,13 @@ public class RouterClientRMService extends AbstractService
     if (this.server != null) {
       this.server.stop();
     }
+    // serviceStart() started the secret manager's ExpiredTokenRemover; stop it
+    // here, once the server is down and no request can reach it, so it does not
+    // outlive this service and keep using the federation state store. Mirrors
+    // RMSecretManagerService#serviceStop.
+    if (this.routerDTSecretManager != null) {
+      this.routerDTSecretManager.stopThreads();
+    }
     userPipelineMap.clear();
     super.serviceStop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockRouter.java
@@ -19,7 +19,8 @@ package org.apache.hadoop.yarn.server.router.subcluster;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
-import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.service.CompositeService.CompositeServiceShutdownHook;
+import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
@@ -30,7 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tests {@link Router}.
+ * Process entry point that starts a {@link Router} for the federation
+ * end-to-end suites. This is not a test: it declares no test methods.
+ * {@link TestFederationSubCluster} launches it as a separate JVM and stops it
+ * with Process#destroy.
  */
 public class TestMockRouter {
 
@@ -73,18 +77,40 @@ public class TestMockRouter {
     conf.set(YarnConfiguration.ROUTER_WEBAPP_ADDRESS,
         getHostNameAndPort(pRouterWebAddressPort));
 
-    RetryPolicy retryPolicy = FederationStateStoreFacade.createRetryPolicy(conf);
-
+    // This class is launched as its own JVM by JavaProcess, and the parent test
+    // terminates it with Process#destroy: SIGTERM on Linux and macOS, which runs
+    // shutdown hooks. (On Windows destroy maps to TerminateProcess, which runs
+    // none, so there this is inert.) Router#main registers this hook itself;
+    // starting the Router directly, as here, skips it, so without this the JVM
+    // exits with the Router's services still running and none of them ever
+    // stopped.
+    ShutdownHookManager.get().addShutdownHook(
+        new CompositeServiceShutdownHook(router), Router.SHUTDOWN_HOOK_PRIORITY);
     router.init(conf);
     router.start();
 
-    FederationStateStore stateStore = (FederationStateStore)
-        FederationStateStoreFacade.createRetryInstance(conf,
-        YarnConfiguration.FEDERATION_STATESTORE_CLIENT_CLASS,
-        YarnConfiguration.DEFAULT_FEDERATION_STATESTORE_CLIENT_CLASS,
-        FederationStateStore.class, retryPolicy);
-    stateStore.init(conf);
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore, conf);
+    // Starting the Router has already created and initialized the facade's
+    // store: RouterClientRMService#serviceStart builds a
+    // RouterDelegationTokenSecretManager whose constructor calls
+    // FederationStateStoreFacade#getInstance(Configuration). Building a second
+    // store here and handing it to reinitialize() would orphan that first one -
+    // reinitialize swaps the reference, it does not close what it replaces - so
+    // take the store the facade is already using.
+    FederationStateStore stateStore =
+        FederationStateStoreFacade.getInstance(conf).getStateStore();
+
+    // The facade holds this store but never closes it, so its ZooKeeper
+    // connection outlives the process unless we close it ourselves. Registered
+    // at a lower priority than the Router hook above: ShutdownHookManager runs
+    // the highest priority first, so the Router is fully stopped before the
+    // store it may still be using goes away.
+    ShutdownHookManager.get().addShutdownHook(() -> {
+      try {
+        stateStore.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing FederationStateStore.", e);
+      }
+    }, Router.SHUTDOWN_HOOK_PRIORITY - 5);
   }
 
   private static String getHostNameAndPort(int port) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockRouter.java
@@ -103,7 +103,10 @@ public class TestMockRouter {
     // connection outlives the process unless we close it ourselves. Registered
     // at a lower priority than the Router hook above: ShutdownHookManager runs
     // the highest priority first, so the Router is fully stopped before the
-    // store it may still be using goes away.
+    // store it may still be using goes away. That ordering is only sound
+    // because RouterClientRMService#serviceStop stops the delegation token
+    // secret manager's ExpiredTokenRemover, which would otherwise still be
+    // reaching the facade after the Router has stopped.
     ShutdownHookManager.get().addShutdownHook(() -> {
       try {
         stateStore.close();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockSubCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestMockSubCluster.java
@@ -20,20 +20,33 @@ package org.apache.hadoop.yarn.server.router.subcluster;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.service.CompositeService.CompositeServiceShutdownHook;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
+import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubCluster.ZK_FEDERATION_STATESTORE;
 
 public class TestMockSubCluster {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestMockSubCluster.class);
+
+  /**
+   * Shutdown budget for the whole sub-cluster. Each NodeManager spends a
+   * hardcoded 10s in DeletionService#serviceStop on top of its container grace
+   * period, so three of them do not fit ShutdownHookManager's 30s default and
+   * the hook would be abandoned part-way through the teardown.
+   */
+  private static final long SHUTDOWN_TIMEOUT_SECONDS = 60;
+
   private Configuration conf;
   private String subClusterId;
 
@@ -51,6 +64,16 @@ public class TestMockSubCluster {
 
   public void startYarnSubCluster() {
     MiniYARNCluster yrCluster = new MiniYARNCluster(subClusterId, 3, 1, 1, false);
+    // This class is launched as its own JVM by JavaProcess, and the parent test
+    // terminates it with Process#destroy: SIGTERM on Linux and macOS, which runs
+    // shutdown hooks. (On Windows destroy maps to TerminateProcess, which runs
+    // none, so there this is inert.) MiniYARNCluster registers no hook of its
+    // own, so without this the JVM exits with its ResourceManager and
+    // NodeManagers still running and no service ever stopped. Registered before
+    // init/start so a failure part-way through startup still tears down
+    // whatever came up.
+    ShutdownHookManager.get().addShutdownHook(new CompositeServiceShutdownHook(yrCluster),
+        ResourceManager.SHUTDOWN_HOOK_PRIORITY, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     yrCluster.init(conf);
     yrCluster.start();
   }
@@ -87,6 +110,12 @@ public class TestMockSubCluster {
         getHostNameAndPort(pRmTrackerAddressPort));
     conf.set(YarnConfiguration.RM_WEBAPP_ADDRESS, getHostNameAndPort(pRmWebAddressPort));
     conf.setBoolean(YarnConfiguration.YARN_MINICLUSTER_FIXED_PORTS, true);
+    // These sub-clusters keep applications running for the lifetime of the
+    // suite, so on shutdown every NodeManager would otherwise wait out its full
+    // container grace period - 250ms + 5000ms + 1s of slop, rounded up to 7s by
+    // the one-second poll in ContainerManagerImpl - before it stops.
+    conf.setLong(YarnConfiguration.NM_SLEEP_DELAY_BEFORE_SIGKILL_MS, 0);
+    conf.setLong(YarnConfiguration.NM_PROCESS_KILL_WAIT_MS, 0);
     conf.setBoolean(YarnConfiguration.FEDERATION_ENABLED, true);
     conf.set(YarnConfiguration.FEDERATION_STATESTORE_CLIENT_CLASS, ZK_FEDERATION_STATESTORE);
     conf.set(CommonConfigurationKeys.ZK_ADDRESS, pZkAddress);


### PR DESCRIPTION
### Description of PR

Make the two federation mock processes shut their services down when they are
terminated, so that `TestFederationSubCluster`-based suites leave nothing
running behind them.

`TestMockSubCluster` and `TestMockRouter` are named like tests but are not
tests — they declare no `@Test` methods. They are process entry points:
`TestFederationSubCluster` launches each as its own JVM through `JavaProcess`
and tears it down in `JavaProcess#stop`, which calls `Process#destroy` (SIGTERM
on Linux and macOS) followed by `waitFor`. Neither registered a shutdown hook,
so each JVM exited with its services still running — a `MiniYARNCluster` of one
ResourceManager and three NodeManagers in the sub-cluster processes, the
Router's own services in the other. No `serviceStop` was ever called: RPC
servers, web apps and state-store connections were torn down by process death
rather than by the service lifecycle.

Not a mini-cluster leak (cf. YARN-11983, now merged, which covered those in
different files in this module): these clusters are meant to outlive the method
that starts them. The defect is that their termination is unclean.

Both entry points now register a `CompositeServiceShutdownHook` before
`init`/`start`, so a failure part-way through startup still tears down whatever
came up. `Router#main` already does exactly this (`Router.java:332-336`);
`TestMockRouter` starts the Router directly and so skipped it. Each uses the
hook priority of the daemon it actually runs — `ResourceManager`'s for the
sub-cluster, `Router`'s for the router — which every YARN daemon defines as 30.

The sub-cluster hook needs an explicit 60s budget rather than the 30s default.
Its three NodeManagers each spend a hardcoded 10s in
`DeletionService#serviceStop`, so the teardown measures 33s and
`ShutdownHookManager` abandoned it part-way through on every run — the ZK close
landed roughly 10ms after the timeout fired, which would not survive slower
hardware. Zeroing the NodeManager container grace period
(`NM_SLEEP_DELAY_BEFORE_SIGKILL_MS`, `NM_PROCESS_KILL_WAIT_MS`) trims a further
6s per NodeManager; these mock clusters keep applications running for the
lifetime of the suite, so the grace period only ever expires in full.

`TestMockRouter` also closes the ZooKeeper-backed `FederationStateStore`, which
the facade never closes. That hook is registered at a lower priority than the
Router's; `ShutdownHookManager` runs the highest priority first, so the Router is
fully stopped before the store it may still be using goes away.

That ordering assumes `router.stop()` has stopped every user of the store, and
review found two threads for which it had not. `RouterClientRMService#serviceStop`
never called `routerDTSecretManager.stopThreads()`, leaving `ExpiredTokenRemover`
running — `RMSecretManagerService` has always done this for the RM's equivalent.
And `Router#serviceStop` never shut down the `ScheduledThreadPoolExecutor`
running `SubClusterCleaner`, which is enabled by default and reaches the store
every 60s. Both are leaks in the Router daemon itself, not only in the mock, so
both are fixed in production code here rather than worked around in the mock.

It closes the store the facade already holds rather than creating a second one.
`RouterClientRMService#serviceStart` builds a
`RouterDelegationTokenSecretManager` whose constructor calls
`FederationStateStoreFacade#getInstance(Configuration)`, which creates and
initializes a store; `reinitialize()` then swaps that reference without closing
what it replaces, so a second store would orphan the first. Measured on the
Router JVM: two ZooKeeper sessions opened and one closed with a second store,
one opened and one closed now.

`TestMockRouter`'s class javadoc claimed "Tests `Router`" — the reason these are
easy to mistake for tests in the first place. It now says what the class is.

Both mock entry points are in `hadoop-yarn-server-router`, package
`org.apache.hadoop.yarn.server.router.subcluster`; the two production fixes
above are in the same module. No new dependencies.

### How was this patch tested?

- `hadoop-yarn-server-router` test-compiles cleanly:
  `mvn -B -o test-compile -P '!native-win,!shelltest' -DskipTests -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router`

- `TestYarnFederationWithCapacityScheduler` on Linux: **38/38 pass**, before and
  after. The SIGTERM teardown was verified directly from the child JVM logs in
  `target/test-dir/processes/`:

  | | trunk | this patch |
  | --- | --- | --- |
  | shutdown-hook lines (SC-1 / SC-2 / Router) | 0 / 0 / 0 | 36 / 36 / 9 |
  | ZooKeeper sessions closed | none | one per child JVM |
  | Router ZK sessions, opened / closed | 2 / 0 | 1 / 1 |
  | `ShutdownHookManager` timeouts | — | 0 |
  | child log ends with | a live HTTP request | ordered `serviceStop` calls |
  | suite runtime | 49s | 116s |

  On trunk the children are killed mid-request, with no teardown of any kind.
  With the patch each JVM runs its hook to completion: the Router in 116ms,
  ending with `Session: 0x… closed` _after_ both Router services have stopped,
  which is the priority ordering above doing its job; each sub-cluster in 33s.

- The added 62s of suite runtime is the price of actually stopping three
  NodeManagers per sub-cluster. Most of it is the hardcoded 10s each spends in
  `DeletionService#serviceStop`, which is outside this JIRA's scope.

- The Yetus `-1` on `TestFederationWebApp` is pre-existing on trunk, not caused
  by this patch: `d57814e3` without these commits gives 2 failures
  (`testAppAttemptXML`, `testGetAppsMultiThread`), this branch gives 1. Both are
  races in the tests themselves. `TestFederationWebApp` extends
  `TestRouterWebServicesREST`, which is why Yetus lists both classes — one
  inherited method, not two problems.

- Not verified on Windows, where `Process#destroy` maps to `TerminateProcess`
  and runs no shutdown hooks, so the behaviour cannot be observed there at all.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

Contains content generated by Claude Code (Claude Opus 5).