### PR TITLE
MAPREDUCE-7543: Constant-time compare when verifying the shuffle HMAC

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/security/SecureShuffleUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/security/SecureShuffleUtils.java
@@ -24,13 +24,13 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import javax.crypto.SecretKey;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.mapreduce.security.token.JobTokenSecretManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +74,7 @@ public class SecureShuffleUtils {
    */
   private static boolean verifyHash(byte[] hash, byte[] msg, SecretKey key) {
     byte[] msg_hash = generateByteHash(msg, key);
-    return WritableComparator.compareBytes(msg_hash, 0, msg_hash.length, hash, 0, hash.length) == 0;
+    return MessageDigest.isEqual(msg_hash, hash);
   }
   
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/security/TestSecureShuffleUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/security/TestSecureShuffleUtils.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.security;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import javax.crypto.SecretKey;
+
+import org.apache.hadoop.mapreduce.security.token.JobTokenSecretManager;
+import org.junit.jupiter.api.Test;
+
+public class TestSecureShuffleUtils {
+
+  private static final SecretKey KEY =
+      JobTokenSecretManager.createSecretKey(new byte[] {1, 2, 3, 4});
+
+  @Test
+  public void testVerifyReplyAcceptsMatchingHash() throws IOException {
+    String msg = "1080/mapOutput?job=job_1&reduce=0&map=attempt_0";
+    String hash = SecureShuffleUtils.hashFromString(msg, KEY);
+    // correct hash must verify without throwing
+    SecureShuffleUtils.verifyReply(hash, msg, KEY);
+  }
+
+  @Test
+  public void testVerifyReplyRejectsTamperedHash() throws IOException {
+    String msg = "1080/mapOutput?job=job_1&reduce=0&map=attempt_0";
+    String hash = SecureShuffleUtils.hashFromString(msg, KEY);
+    // flip the last character of the base64 hash so it no longer matches
+    char last = hash.charAt(hash.length() - 1);
+    String tampered = hash.substring(0, hash.length() - 1)
+        + (last == 'A' ? 'B' : 'A');
+    assertThrows(IOException.class,
+        () -> SecureShuffleUtils.verifyReply(tampered, msg, KEY));
+  }
+
+  @Test
+  public void testVerifyReplyRejectsWrongLengthHash() throws IOException {
+    String msg = "1080/mapOutput?job=job_1&reduce=0&map=attempt_0";
+    String hash = SecureShuffleUtils.hashFromString(msg, KEY);
+    // a truncated hash must be rejected, not accepted as a prefix match
+    String truncated = hash.substring(0, hash.length() / 2);
+    assertThrows(IOException.class,
+        () -> SecureShuffleUtils.verifyReply(truncated, msg, KEY));
+  }
+}


### PR DESCRIPTION
### Description of PR

SecureShuffleUtils.verifyHash checks the caller-supplied MAC against the recomputed HMAC with WritableComparator.compareBytes, which returns as soon as two bytes differ. This switches the check to MessageDigest.isEqual so the compare runs in constant time and no longer depends on how many leading bytes happen to match. It matches how the rest of the tree already compares secrets (MessageDigest.isEqual in the delegation-token and auth Signer paths). This is a hardening cleanup with no behavior change: a matching MAC still verifies and a wrong one is still rejected.

### How was this patch tested?

Added TestSecureShuffleUtils in the mapreduce-client-core security package covering verifyReply accepting a matching hash and rejecting a tampered or truncated one, and ran it plus the existing TestFetcher against the module build on JDK 17 (both green). Checkstyle on the touched files is clean.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
