### PR TITLE
HADOOP-19966. ZKDelegationTokenSecretManager startup cache load races with CuratorCache initialization

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
@@ -24,6 +24,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -118,6 +120,8 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
 
   private static final Logger LOG = LoggerFactory
       .getLogger(ZKDelegationTokenSecretManager.class);
+
+  private static final long CACHE_INITIALIZED_TIMEOUT_SECONDS = 10;
 
   private static final String JAAS_LOGIN_ENTRY_NAME =
       "ZKDelegationTokenSecretManagerClient";
@@ -290,8 +294,13 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
     try {
       keyCache = CuratorCache.bridgeBuilder(zkClient, ZK_DTSM_MASTER_KEY_ROOT)
           .build();
+      CountDownLatch keyCacheInitialized = new CountDownLatch(1);
       CuratorCacheListener keyCacheListener = CuratorCacheListener.builder()
           .forCreatesAndChanges((oldNode, node) -> {
+            if (ZK_DTSM_MASTER_KEY_ROOT.equals(node.getPath())) {
+              // The root node itself is a container, not a key.
+              return;
+            }
             try {
               processKeyAddOrUpdate(node.getData());
             } catch (IOException e) {
@@ -301,9 +310,11 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
             }
           })
           .forDeletes(childData -> processKeyRemoved(childData.getPath()))
+          .forInitialized(keyCacheInitialized::countDown)
           .build();
       keyCache.listenable().addListener(keyCacheListener);
       keyCache.start();
+      awaitCacheInitialized(keyCacheInitialized, "key");
       loadFromZKCache(false);
     } catch (Exception e) {
       throw new IOException("Could not start Curator keyCacheListener for keys",
@@ -314,8 +325,13 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
       try {
         tokenCache = CuratorCache.bridgeBuilder(zkClient, ZK_DTSM_TOKENS_ROOT)
             .build();
+        CountDownLatch tokenCacheInitialized = new CountDownLatch(1);
         CuratorCacheListener tokenCacheListener = CuratorCacheListener.builder()
             .forCreatesAndChanges((oldNode, node) -> {
+              if (ZK_DTSM_TOKENS_ROOT.equals(node.getPath())) {
+                // The root node itself is a container, not a token.
+                return;
+              }
               try {
                 processTokenAddOrUpdate(node.getData());
               } catch (IOException e) {
@@ -333,9 +349,11 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
                 throw new UncheckedIOException(e);
               }
             })
+            .forInitialized(tokenCacheInitialized::countDown)
             .build();
         tokenCache.listenable().addListener(tokenCacheListener);
         tokenCache.start();
+        awaitCacheInitialized(tokenCacheInitialized, "token");
         loadFromZKCache(true);
       } catch (Exception e) {
         throw new IOException(
@@ -363,6 +381,11 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
 
     final AtomicInteger count = new AtomicInteger(0);
     children.forEach(childData -> {
+      if (childData.getPath().equals(
+          isTokenCache ? ZK_DTSM_TOKENS_ROOT : ZK_DTSM_MASTER_KEY_ROOT)) {
+        // The root node itself is a container, not a key or token.
+        return;
+      }
       try {
         if (isTokenCache) {
           processTokenAddOrUpdate(childData.getData());
@@ -384,6 +407,20 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
           cacheName);
     }
     LOG.info("Loaded {} cache.", cacheName);
+  }
+
+  private void awaitCacheInitialized(CountDownLatch initialized,
+      String cacheName) throws IOException {
+    try {
+      if (!initialized.await(CACHE_INITIALIZED_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        throw new IOException("Timed out waiting for " + cacheName
+            + " cache initialization");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while waiting for " + cacheName
+          + " cache initialization", e);
+    }
   }
 
   private void processKeyAddOrUpdate(byte[] data) throws IOException {
@@ -425,6 +462,10 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   }
 
   private void processTokenRemoved(ChildData data) throws IOException {
+    if (ZK_DTSM_TOKENS_ROOT.equals(data.getPath())) {
+      // The root node itself is a container, not a token.
+      return;
+    }
     ByteArrayInputStream bin = new ByteArrayInputStream(data.getData());
     DataInputStream din = new DataInputStream(bin);
     TokenIdent ident = createIdentifier();
@@ -474,7 +515,9 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
 
   private void createPersistentNode(String nodePath) throws Exception {
     try {
-      zkClient.create().withMode(CreateMode.PERSISTENT).forPath(nodePath);
+      // Pass empty data explicitly; Curator 5.2.0+ defaults data-less creates
+      // to the local address, which breaks parsing of the container nodes.
+      zkClient.create().withMode(CreateMode.PERSISTENT).forPath(nodePath, new byte[0]);
     } catch (KeeperException.NodeExistsException ne) {
       LOG.debug(nodePath + " znode already exists !!");
     } catch (Exception e) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.security.SecurityUtil.TruststoreKeystore;
 import org.apache.hadoop.security.authentication.util.ZookeeperClient;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenManager;
+import org.apache.hadoop.util.Preconditions;
 
 import static org.apache.hadoop.security.SecurityUtil.getServerPrincipal;
 import static org.apache.hadoop.util.Time.now;
@@ -81,6 +82,10 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
       + "zkConnectionTimeout";
   public static final String ZK_DTSM_ZK_SHUTDOWN_TIMEOUT = ZK_CONF_PREFIX
       + "zkShutdownTimeout";
+  // Max time in ms to wait for the key/token cache initial load on startup,
+  // 0 or negative waits indefinitely.
+  public static final String ZK_DTSM_ZK_CACHE_INIT_TIMEOUT = ZK_CONF_PREFIX
+      + "zkCacheInitTimeout";
   public static final String ZK_DTSM_ZNODE_WORKING_PATH = ZK_CONF_PREFIX
       + "znodeWorkingPath";
   public static final String ZK_DTSM_ZK_AUTH_TYPE = ZK_CONF_PREFIX
@@ -113,6 +118,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   public static final int ZK_DTSM_ZK_SESSION_TIMEOUT_DEFAULT = 10000;
   public static final int ZK_DTSM_ZK_CONNECTION_TIMEOUT_DEFAULT = 10000;
   public static final int ZK_DTSM_ZK_SHUTDOWN_TIMEOUT_DEFAULT = 10000;
+  public static final int ZK_DTSM_ZK_CACHE_INIT_TIMEOUT_DEFAULT = 0;
   public static final String ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT = "zkdtsm";
   // By default, increase seq number by 100 each time to reduce overflow
   // speed of znode dataVersion which is 32-integer now.
@@ -120,8 +126,6 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
 
   private static final Logger LOG = LoggerFactory
       .getLogger(ZKDelegationTokenSecretManager.class);
-
-  private static final long CACHE_INITIALIZED_TIMEOUT_SECONDS = 10;
 
   private static final String JAAS_LOGIN_ENTRY_NAME =
       "ZKDelegationTokenSecretManagerClient";
@@ -154,6 +158,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   private CuratorCacheBridge keyCache;
   private CuratorCacheBridge tokenCache;
   private final int seqNumBatchSize;
+  private final int cacheInitTimeoutMs;
   private int currentSeqNum;
   private int currentMaxSeqNum;
 
@@ -172,6 +177,8 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
         ZK_DTSM_TOKEN_SEQNUM_BATCH_SIZE_DEFAULT);
     isTokenWatcherEnabled = conf.getBoolean(ZK_DTSM_TOKEN_WATCHER_ENABLED,
         ZK_DTSM_TOKEN_WATCHER_ENABLED_DEFAULT);
+    cacheInitTimeoutMs = conf.getInt(ZK_DTSM_ZK_CACHE_INIT_TIMEOUT,
+        ZK_DTSM_ZK_CACHE_INIT_TIMEOUT_DEFAULT);
     
     String workPath = conf.get(ZK_DTSM_ZNODE_WORKING_PATH, ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT);
     String nameSpace = workPath + "/" + ZK_DTSM_NAMESPACE;
@@ -244,6 +251,23 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
 
   @Override
   public void startThreads() throws IOException {
+    // Fail fast so the cleanup below never tears down a running instance.
+    Preconditions.checkState(!isRunning(), "Secret manager is already running");
+    try {
+      doStartThreads();
+    } catch (IOException | RuntimeException e) {
+      // The caller does not invoke stopThreads() after a failed start, so
+      // release the caches, counters and Curator client here.
+      try {
+        stopThreads();
+      } catch (RuntimeException ce) {
+        e.addSuppressed(ce);
+      }
+      throw e;
+    }
+  }
+
+  private void doStartThreads() throws IOException {
     if (!isExternalClient) {
       try {
         zkClient.start();
@@ -412,9 +436,14 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   private void awaitCacheInitialized(CountDownLatch initialized,
       String cacheName) throws IOException {
     try {
-      if (!initialized.await(CACHE_INITIALIZED_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        throw new IOException("Timed out waiting for " + cacheName
-            + " cache initialization");
+      if (cacheInitTimeoutMs > 0) {
+        if (!initialized.await(cacheInitTimeoutMs, TimeUnit.MILLISECONDS)) {
+          throw new IOException("Timed out after " + cacheInitTimeoutMs
+              + " ms waiting for " + cacheName + " cache initialization, "
+              + "consider increasing " + ZK_DTSM_ZK_CACHE_INIT_TIMEOUT);
+        }
+      } else {
+        initialized.await();
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -515,8 +544,8 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
 
   private void createPersistentNode(String nodePath) throws Exception {
     try {
-      // Pass empty data explicitly; Curator 5.2.0+ defaults data-less creates
-      // to the local address, which breaks parsing of the container nodes.
+      // Store empty data instead of Curator's default (the local address);
+      // HADOOP-17835 (3.4.0): CuratorCache includes the root node in the cache.
       zkClient.create().withMode(CreateMode.PERSISTENT).forPath(nodePath, new byte[0]);
     } catch (KeeperException.NodeExistsException ne) {
       LOG.debug(nodePath + " znode already exists !!");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -522,6 +522,13 @@ public class TestZKDelegationTokenSecretManager {
 
     // The good token should be loaded on startup, and removed after expiry.
     id = smNew.decodeTokenIdentifier(token);
+    final AbstractDelegationTokenIdentifier idGood = id;
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return zksmNew.getTokenInfoFromMemory(idGood) != null;
+      }
+    }, 100, 5000);
     dtinfo = zksmNew.getTokenInfoFromMemory(id);
     assertNotNull(dtinfo, "good dt should be in memory!");
 
@@ -551,22 +558,27 @@ public class TestZKDelegationTokenSecretManager {
         .build();
     curatorFramework.start();
     ZKDelegationTokenSecretManager.setCurator(curatorFramework);
-    DelegationTokenManager tm1 = new DelegationTokenManager(conf, new Text("foo"));
+    try {
+      DelegationTokenManager tm1 = new DelegationTokenManager(conf, new Text("foo"));
 
-    // When the init method is called,
-    // the ZKDelegationTokenSecretManager#startThread method will be called,
-    // and the creatingParentContainersIfNeeded will be called to create the nameSpace.
-    tm1.init();
+      // When the init method is called,
+      // the ZKDelegationTokenSecretManager#startThread method will be called,
+      // and the creatingParentContainersIfNeeded will be called to create the nameSpace.
+      tm1.init();
 
-    String workingPath = "/" + conf.get(ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH,
-        ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT) + "/ZKDTSMRoot";
+      String workingPath = "/" + conf.get(ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH,
+          ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT) + "/ZKDTSMRoot";
 
-    // Check if the created NameSpace exists.
-    Stat stat = curatorFramework.checkExists().forPath(workingPath);
-    assertNotNull(stat);
+      // Check if the created NameSpace exists.
+      Stat stat = curatorFramework.checkExists().forPath(workingPath);
+      assertNotNull(stat);
 
-    tm1.destroy();
-    curatorFramework.close();
+      tm1.destroy();
+    } finally {
+      // Restore the default curator so later tests do not see a closed client.
+      ZKDelegationTokenSecretManager.setCurator(null);
+      curatorFramework.close();
+    }
   }
 
   @Test
@@ -616,36 +628,40 @@ public class TestZKDelegationTokenSecretManager {
 
     DelegationTokenManager tm1 = new DelegationTokenManager(conf, new Text("foo"));
     DelegationTokenManager tm2 = new DelegationTokenManager(conf, new Text("bar"));
-    // When the init method is called,
-    // the ZKDelegationTokenSecretManager#startThread method will be called,
-    // and the creatingParentContainersIfNeeded will be called to create the nameSpace.
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    try {
+      // When the init method is called,
+      // the ZKDelegationTokenSecretManager#startThread method will be called,
+      // and the creatingParentContainersIfNeeded will be called to create the nameSpace.
+      ExecutorService executorService = Executors.newFixedThreadPool(2);
 
-    Callable<Boolean> tm1Callable = () -> {
-      tm1.init();
-      return true;
-    };
-    Callable<Boolean> tm2Callable = () -> {
-      tm2.init();
-      return true;
-    };
-    List<Future<Boolean>> futures = executorService.invokeAll(
-        Arrays.asList(tm1Callable, tm2Callable));
-    for(Future<Boolean> future : futures) {
-      assertTrue(future.get());
+      Callable<Boolean> tm1Callable = () -> {
+        tm1.init();
+        return true;
+      };
+      Callable<Boolean> tm2Callable = () -> {
+        tm2.init();
+        return true;
+      };
+      List<Future<Boolean>> futures = executorService.invokeAll(
+          Arrays.asList(tm1Callable, tm2Callable));
+      for (Future<Boolean> future : futures) {
+        assertTrue(future.get());
+      }
+      executorService.shutdownNow();
+      assertTrue(executorService.awaitTermination(1, TimeUnit.SECONDS));
+      tm1.destroy();
+      tm2.destroy();
+
+      String workingPath = "/" + conf.get(ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH,
+          ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT) + "/ZKDTSMRoot";
+
+      // Check if the created NameSpace exists.
+      Stat stat = curatorFramework.checkExists().forPath(workingPath);
+      assertNotNull(stat);
+    } finally {
+      // Restore the default curator so later tests do not see a closed client.
+      ZKDelegationTokenSecretManager.setCurator(null);
+      curatorFramework.close();
     }
-    executorService.shutdownNow();
-    assertTrue(executorService.awaitTermination(1, TimeUnit.SECONDS));
-    tm1.destroy();
-    tm2.destroy();
-
-    String workingPath = "/" + conf.get(ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH,
-        ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT) + "/ZKDTSMRoot";
-
-    // Check if the created NameSpace exists.
-    Stat stat = curatorFramework.checkExists().forPath(workingPath);
-    assertNotNull(stat);
-
-    curatorFramework.close();
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -558,8 +558,9 @@ public class TestZKDelegationTokenSecretManager {
         .build();
     curatorFramework.start();
     ZKDelegationTokenSecretManager.setCurator(curatorFramework);
+    DelegationTokenManager tm1 = null;
     try {
-      DelegationTokenManager tm1 = new DelegationTokenManager(conf, new Text("foo"));
+      tm1 = new DelegationTokenManager(conf, new Text("foo"));
 
       // When the init method is called,
       // the ZKDelegationTokenSecretManager#startThread method will be called,
@@ -572,9 +573,10 @@ public class TestZKDelegationTokenSecretManager {
       // Check if the created NameSpace exists.
       Stat stat = curatorFramework.checkExists().forPath(workingPath);
       assertNotNull(stat);
-
-      tm1.destroy();
     } finally {
+      if (tm1 != null) {
+        tm1.destroy();
+      }
       // Restore the default curator so later tests do not see a closed client.
       ZKDelegationTokenSecretManager.setCurator(null);
       curatorFramework.close();
@@ -628,11 +630,12 @@ public class TestZKDelegationTokenSecretManager {
 
     DelegationTokenManager tm1 = new DelegationTokenManager(conf, new Text("foo"));
     DelegationTokenManager tm2 = new DelegationTokenManager(conf, new Text("bar"));
+    ExecutorService executorService = null;
     try {
       // When the init method is called,
       // the ZKDelegationTokenSecretManager#startThread method will be called,
       // and the creatingParentContainersIfNeeded will be called to create the nameSpace.
-      ExecutorService executorService = Executors.newFixedThreadPool(2);
+      executorService = Executors.newFixedThreadPool(2);
 
       Callable<Boolean> tm1Callable = () -> {
         tm1.init();
@@ -647,10 +650,6 @@ public class TestZKDelegationTokenSecretManager {
       for (Future<Boolean> future : futures) {
         assertTrue(future.get());
       }
-      executorService.shutdownNow();
-      assertTrue(executorService.awaitTermination(1, TimeUnit.SECONDS));
-      tm1.destroy();
-      tm2.destroy();
 
       String workingPath = "/" + conf.get(ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH,
           ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT) + "/ZKDTSMRoot";
@@ -659,6 +658,12 @@ public class TestZKDelegationTokenSecretManager {
       Stat stat = curatorFramework.checkExists().forPath(workingPath);
       assertNotNull(stat);
     } finally {
+      if (executorService != null) {
+        executorService.shutdownNow();
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
+      }
+      tm1.destroy();
+      tm2.destroy();
       // Restore the default curator so later tests do not see a closed client.
       ZKDelegationTokenSecretManager.setCurator(null);
       curatorFramework.close();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -105,6 +105,7 @@ public class TestZKDelegationTokenSecretManager {
    conf.set(ZKDelegationTokenSecretManager.ZK_DTSM_ZNODE_WORKING_PATH, "testPath");
    conf.set(ZKDelegationTokenSecretManager.ZK_DTSM_ZK_AUTH_TYPE, "none");
    conf.setLong(ZKDelegationTokenSecretManager.ZK_DTSM_ZK_SHUTDOWN_TIMEOUT, 100);
+   conf.setLong(ZKDelegationTokenSecretManager.ZK_DTSM_ZK_CACHE_INIT_TIMEOUT, 10000);
    conf.setLong(DelegationTokenManager.UPDATE_INTERVAL, DAY_IN_SECS);
    conf.setLong(DelegationTokenManager.MAX_LIFETIME, DAY_IN_SECS);
    conf.setLong(DelegationTokenManager.RENEW_INTERVAL, DAY_IN_SECS);
@@ -522,13 +523,6 @@ public class TestZKDelegationTokenSecretManager {
 
     // The good token should be loaded on startup, and removed after expiry.
     id = smNew.decodeTokenIdentifier(token);
-    final AbstractDelegationTokenIdentifier idGood = id;
-    GenericTestUtils.waitFor(new Supplier<Boolean>() {
-      @Override
-      public Boolean get() {
-        return zksmNew.getTokenInfoFromMemory(idGood) != null;
-      }
-    }, 100, 5000);
     dtinfo = zksmNew.getTokenInfoFromMemory(id);
     assertNotNull(dtinfo, "good dt should be in memory!");
 


### PR DESCRIPTION
### Description of PR

Since HADOOP-17835 (3.4.0), `ZKDelegationTokenSecretManager` starts its
`CuratorCache` asynchronously and reads it immediately, so `loadFromZKCache` runs
against an empty or partial cache. Token verify/renew/cancel are unaffected
because they fall back to ZooKeeper, and the cache listener fills the in-memory
map a few seconds later. The lasting effects are:

- token owner stats (Router `getTopTokenRealOwners`) are computed from a partial
  map and never corrected for pre-restart tokens;
- the root container znode, which carries Curator's default data (the local
  address), is parsed as a key/token on every startup and logs an ERROR;
- `testNodesLoadedAfterRestart` is flaky in CI.

This change:
- Waits for `CuratorCache` initialization (`forInitialized`) before loading each
  cache; the tests bound the wait so a regression fails instead of hanging.
- Skips the root container znodes (`/ZKDTSMMasterKeyRoot`, `/ZKDTSMTokensRoot`)
  when processing cache events and when streaming the cache.
- Creates the root container znodes with explicit empty data instead of
  Curator's default (the local address). Existing roots keep their old
  payload, so the root skip above is the actual fix.
- Calls `stopThreads()` when `startThreads()` fails so a failed start does not
  leak the caches, counters, or the Curator client.
- Restores the thread-local curator and closes the client in the tests that
  use `setCurator`.

Contains content generated by deepseek-v4-pro and Claude Fable 5.1

### How was this patch tested?

```
mvn -pl hadoop-common-project/hadoop-common -am \
  -Dtest=TestZKDelegationTokenSecretManager test
```

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html


