### PR TITLE
YARN: restrict leveldb assigned-resources deserialization to known types

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ResourceMappings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ResourceMappings.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.container;
 
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.SerializationUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -89,9 +91,24 @@ public class ResourceMappings {
     public static AssignedResources fromBytes(byte[] bytes)
         throws IOException {
       final List<Serializable> resources;
-      try {
-        resources = SerializationUtils.deserialize(bytes);
-      } catch (SerializationException e) {
+      // The bytes come from the NM recovery state store and are read back
+      // during container recovery on restart. Deserialize through a
+      // ValidatingObjectInputStream so a tampered record cannot instantiate
+      // arbitrary serializable classes on the NodeManager classpath. The
+      // allowed graph is the assigned-resource value objects the resource
+      // plugins store (device / NUMA descriptors, plain strings) plus the
+      // collection types that wrap them.
+      try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+          ValidatingObjectInputStream ois =
+              new ValidatingObjectInputStream(bais)) {
+        ois.accept(
+            "org.apache.hadoop.yarn.server.nodemanager.*",
+            "org.apache.hadoop.thirdparty.com.google.common.collect.*",
+            "java.util.*",
+            "java.lang.*",
+            "[Ljava.lang.Object;");
+        resources = (List<Serializable>) ois.readObject();
+      } catch (ClassNotFoundException e) {
         throw new IOException(e);
       }
       AssignedResources ar = new AssignedResources();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ResourceMappings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ResourceMappings.java
@@ -21,6 +21,10 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.container;
 import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.numa.NumaResourceAllocation;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.fpga.FpgaDevice;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.gpu.GpuDevice;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -94,20 +98,33 @@ public class ResourceMappings {
       // The bytes come from the NM recovery state store and are read back
       // during container recovery on restart. Deserialize through a
       // ValidatingObjectInputStream so a tampered record cannot instantiate
-      // arbitrary serializable classes on the NodeManager classpath. The
-      // allowed graph is the assigned-resource value objects the resource
-      // plugins store (device / NUMA descriptors, plain strings) plus the
-      // collection types that wrap them.
+      // arbitrary serializable classes on the NodeManager classpath.
       try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
           ValidatingObjectInputStream ois =
               new ValidatingObjectInputStream(bais)) {
+        // The concrete value objects the resource plugins store, the list
+        // types that wrap them (a fresh ArrayList, or the unmodifiable view
+        // that legacy records were serialized from), and the strings / boxed
+        // primitives those objects hold. Number is the superclass descriptor
+        // read back for the boxed Integer / Long map values.
+        ois.accept(ArrayList.class, String.class, Number.class,
+            Integer.class, Long.class, Device.class, GpuDevice.class,
+            FpgaDevice.class, NumaResourceAllocation.class);
+        ois.accept("java.util.Collections$UnmodifiableList",
+            "java.util.Collections$UnmodifiableCollection");
+        // NumaResourceAllocation serializes its shaded-guava ImmutableMaps
+        // through guava's internal SerializedForm, which carries the keys and
+        // values in an Object[]. The forms are a guava-internal detail, so the
+        // collect package is matched by pattern rather than pinned class name.
         ois.accept(
-            "org.apache.hadoop.yarn.server.nodemanager.*",
             "org.apache.hadoop.thirdparty.com.google.common.collect.*",
-            "java.util.*",
-            "java.lang.*",
             "[Ljava.lang.Object;");
-        resources = (List<Serializable>) ois.readObject();
+        Object obj = ois.readObject();
+        if (!(obj instanceof List)) {
+          throw new IOException("Unexpected assigned-resources record type: "
+              + (obj == null ? "null" : obj.getClass().getName()));
+        }
+        resources = (List<Serializable>) obj;
       } catch (ClassNotFoundException e) {
         throw new IOException(e);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestResourceMappings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestResourceMappings.java
@@ -123,8 +123,8 @@ public class TestResourceMappings {
     // A tampered record whose top-level list is fine but which carries an
     // element of a type the resource plugins never store. This stands in for a
     // serialization gadget (e.g. a commons-beanutils BeanComparator): the
-    // allowlist rejects it by class name during readObject, before the class
-    // is loaded or any of its logic runs.
+    // allowlist rejects it by class name during readObject, before the object
+    // is instantiated and any of its logic runs.
     byte[] payload = toBytes(ImmutableList.<Serializable>of(
         new File("/etc/passwd")));
     assertThrows(IOException.class,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestResourceMappings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestResourceMappings.java
@@ -19,16 +19,21 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.container;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.numa.NumaResourceAllocation;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.fpga.FpgaDevice;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.gpu.GpuDevice;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestResourceMappings {
@@ -92,6 +97,38 @@ public class TestResourceMappings {
       fail(String.format("Deserialization of test AssignedResources " +
           "failed with %s", e.getMessage()));
     }
+  }
+
+  @Test
+  public void testRoundTripCoversResourcePluginTypes() throws IOException {
+    // The elements a NodeManager actually stores for gpu / fpga / numa
+    // resources must survive the allowlist, otherwise recovery would break.
+    ResourceMappings.AssignedResources pluginResources =
+        new ResourceMappings.AssignedResources();
+    pluginResources.updateAssignedResources(ImmutableList.of(
+        new GpuDevice(2, 3),
+        new FpgaDevice("IntelOpenCL", 247, 0, "aclv0"),
+        new NumaResourceAllocation("0", 1024L, "0", 4),
+        "cpu-0"));
+
+    ResourceMappings.AssignedResources deserialized =
+        ResourceMappings.AssignedResources.fromBytes(pluginResources.toBytes());
+
+    assertEquals(pluginResources.getAssignedResources(),
+        deserialized.getAssignedResources());
+  }
+
+  @Test
+  public void testFromBytesRejectsUnexpectedType() throws IOException {
+    // A tampered record whose top-level list is fine but which carries an
+    // element of a type the resource plugins never store. This stands in for a
+    // serialization gadget (e.g. a commons-beanutils BeanComparator): the
+    // allowlist rejects it by class name during readObject, before the class
+    // is loaded or any of its logic runs.
+    byte[] payload = toBytes(ImmutableList.<Serializable>of(
+        new File("/etc/passwd")));
+    assertThrows(IOException.class,
+        () -> ResourceMappings.AssignedResources.fromBytes(payload));
   }
 
   /**


### PR DESCRIPTION
### Description of PR

`ResourceMappings.AssignedResources.fromBytes` reads the per-container assigned-resource record with `SerializationUtils.deserialize`, which is a bare `ObjectInputStream.readObject()` with no type restriction:

    resources = SerializationUtils.deserialize(bytes);

`NMLeveldbStateStoreService.loadContainerState` hands it the bytes stored under the container's `assigned-resources` key and replays them during container recovery on NM restart. A tampered recovery record can therefore instantiate any serializable class on the NodeManager classpath, not just the resource descriptors this code stores.

The read is switched to a commons-io `ValidatingObjectInputStream` restricted to the types the resource plugins actually write: the gpu/fpga/numa value objects under the nodemanager package, the shaded-guava `ImmutableMap` that `NumaResourceAllocation` holds, and the wrapping collections/strings. `toBytes` is left as-is so records written by earlier NMs still recover.

### How was this patch tested?

`mvn test -pl hadoop-yarn-project/.../hadoop-yarn-server-nodemanager -Dtest=TestResourceMappings` on trunk. Added a round-trip test over `GpuDevice`, `FpgaDevice`, `NumaResourceAllocation` and `String` so valid records still deserialize, plus a test that a record carrying an element type the plugins never store is rejected instead of instantiated.

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
