### PR TITLE
HDFS-17965. DFSInputStream.close() should release the block reader even if the DFSClient is already closed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -733,26 +733,33 @@ public class DFSInputStream extends FSInputStream
         DFSClient.LOG.debug("DFSInputStream has been closed already");
         return;
       }
-      dfsClient.checkOpen();
+      try {
+        dfsClient.checkOpen();
 
-      if ((extendedReadBuffers != null) && (!extendedReadBuffers.isEmpty())) {
-        final StringBuilder builder = new StringBuilder();
-        extendedReadBuffers
-            .visitAll(new IdentityHashStore.Visitor<ByteBuffer, Object>() {
-              private String prefix = "";
+        if ((extendedReadBuffers != null) && (!extendedReadBuffers.isEmpty())) {
+          final StringBuilder builder = new StringBuilder();
+          extendedReadBuffers
+              .visitAll(new IdentityHashStore.Visitor<ByteBuffer, Object>() {
+                private String prefix = "";
 
-              @Override
-              public void accept(ByteBuffer k, Object v) {
-                builder.append(prefix).append(k);
-                prefix = ", ";
-              }
-            });
-        DFSClient.LOG.warn("closing file " + src + ", but there are still "
-            + "unreleased ByteBuffers allocated by read().  "
-            + "Please release " + builder.toString() + ".");
+                @Override
+                public void accept(ByteBuffer k, Object v) {
+                  builder.append(prefix).append(k);
+                  prefix = ", ";
+                }
+              });
+          DFSClient.LOG.warn("closing file " + src + ", but there are still "
+              + "unreleased ByteBuffers allocated by read().  "
+              + "Please release " + builder.toString() + ".");
+        }
+      } finally {
+        // Release the block reader even if checkOpen() throws because the
+        // DFSClient was closed first. Otherwise the block reader's socket
+        // leaks and the DataNode side of the connection can be stuck in
+        // FIN_WAIT1 for the lifetime of the client JVM.
+        closeCurrentBlockReaders();
+        super.close();
       }
-      closeCurrentBlockReaders();
-      super.close();
     } finally {
       /**
        * If dfsInputStream is closed and datanode is in
@@ -1824,6 +1831,11 @@ public class DFSInputStream extends FSInputStream
     }
     blockReader = null;
     blockEnd = -1;
+  }
+
+  @VisibleForTesting
+  BlockReader getCurrentBlockReader() {
+    return blockReader;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_READ
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -362,6 +363,36 @@ public class TestDFSInputStream {
     } finally {
       DFSClientFaultInjector.set(oldFaultInjector);
       IOUtils.closeStream(out);
+    }
+  }
+
+  @Test
+  @Timeout(30)
+  public void testCloseReleasesBlockReaderWhenClientAlreadyClosed()
+      throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    try (MiniDFSCluster cluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(1).build()) {
+      cluster.waitActive();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      Path file = new Path("/testfile");
+      DFSTestUtil.createFile(fs, file, 4096, (short) 1, 0);
+
+      DFSClient client = new DFSClient(cluster.getURI(), conf);
+      DFSInputStream in = client.open("/testfile");
+      assertTrue(in.read() != -1);
+      assertNotNull(in.getCurrentBlockReader());
+
+      // Close the client before the stream. close() must still release the
+      // block reader (and its socket to the DataNode) even though
+      // checkOpen() fails with "Filesystem closed".
+      client.close();
+      try {
+        in.close();
+      } catch (IOException e) {
+        GenericTestUtils.assertExceptionContains("Filesystem closed", e);
+      }
+      assertNull(in.getCurrentBlockReader());
     }
   }
 }


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


DFSInputStream.close() calls dfsClient.checkOpen() before
closeCurrentBlockReaders(). When the DFSClient is closed first (e.g.
FileSystem.closeAllForUGI() during cleanup), checkOpen() throws and the
block reader is never closed; since the closed flag is already set, the
socket can never be released afterwards. In a long-lived JVM this leaks the
connection and leaves the DataNode side stuck in FIN_WAIT1 with a
non-draining send queue.

We hit this in production through the DefaultContainerExecutor localizer
path (see YARN-11856): killing a container during localization closes the
UGI filesystems while a download thread still holds an open DFSInputStream.

This PR wraps the checkOpen()/buffer-warning section in try/finally so
closeCurrentBlockReaders() and super.close() always run. The existing
behavior of throwing "Filesystem closed" from close() is preserved.

### How was this patch tested?

New unit test
TestDFSInputStream#testCloseReleasesBlockReaderWhenClientAlreadyClosed:
opens a stream, reads to materialize a block reader, closes the DFSClient
first, then closes the stream and asserts the block reader was released.
Fails without the fix (block reader still present), passes with it.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
Generative AI: Contains content generated by Claude Code (Anthropic
      Claude). The change was human-reviewed and verified on a production
      cluster, and complies with the ASF Generative Tooling Guidance
      (https://www.apache.org/legal/generative-tooling.html).
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
