### PR TITLE
YARN-11856. DOWNLOADING resources unlock and cleanup is interrupted when killing a container that is localizing

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -1294,8 +1294,12 @@ public class ResourceLocalizationService extends CompositeService
           // On error, report failure to Container and signal ABORT
           // Notify resource of failed localization
           ContainerId cId = context.getContainerId();
-          dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
-              cId, null, exception.getMessage()));
+          try {
+            dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
+                cId, null, exception.getMessage()));
+          } catch (Exception e) {
+            LOG.info("Failed to send container resource failed event for " + cId.toString(), e);
+          }
         }
         List<Path> paths = new ArrayList<Path>();
         for (LocalizerResourceRequestEvent event : scheduled.values()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -1298,7 +1298,12 @@ public class ResourceLocalizationService extends CompositeService
             dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
                 cId, null, exception.getMessage()));
           } catch (Exception e) {
-            LOG.info("Failed to send container resource failed event for " + cId.toString(), e);
+            LOG.warn("Failed to send container resource failed event for {}",
+                cId, e);
+            if (e instanceof InterruptedException
+                || e.getCause() instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+            }
           }
         }
         List<Path> paths = new ArrayList<Path>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
@@ -867,9 +867,29 @@ public class TestResourceLocalizationService {
     // DOWNLOADING resource and schedule the deletion tasks.
     runner.run();
 
+    // The interrupt status must be restored after the dispatch failure was
+    // swallowed. Thread.interrupted() also clears it for the test thread.
+    assertTrue(Thread.interrupted());
+
     verify(rsrc).unlock();
-    verify(delService, Mockito.atLeastOnce())
-        .delete(isA(FileDeletionTask.class));
+    ArgumentCaptor<FileDeletionTask> captor =
+        ArgumentCaptor.forClass(FileDeletionTask.class);
+    verify(delService, times(2)).delete(captor.capture());
+    List<FileDeletionTask> tasks = captor.getAllValues();
+    // Localization dir and _tmp download dir of the DOWNLOADING resource.
+    FileDeletionTask rsrcTask = tasks.get(0);
+    assertEquals("user0", rsrcTask.getUser());
+    assertNull(rsrcTask.getSubDir());
+    assertEquals(Arrays.asList(
+        new Path("/local/usercache/user0/filecache/10"),
+        new Path("/local/usercache/user0/filecache/10_tmp")),
+        rsrcTask.getBaseDirs());
+    // nmPrivate token file; the path is null here because localization
+    // failed before it was resolved.
+    FileDeletionTask tokenTask = tasks.get(1);
+    assertNull(tokenTask.getUser());
+    assertNull(tokenTask.getSubDir());
+    assertNull(tokenTask.getBaseDirs());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
@@ -70,6 +70,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionMatcher;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionTask;
 import org.apache.hadoop.yarn.server.nodemanager.executor.LocalizerStartContext;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -102,9 +103,12 @@ import org.apache.hadoop.yarn.api.records.SerializedException;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
+import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.DrainDispatcher;
+import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.nodemanager.ContainerExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
@@ -816,6 +820,56 @@ public class TestResourceLocalizationService {
       dispatcher.stop();
       delService.stop();
     }
+  }
+
+  @Test
+  @Timeout(value = 10)
+  @SuppressWarnings("unchecked") // mocked generics
+  public void testDownloadingResourcesCleanedUpWhenDispatchFails()
+      throws Exception {
+    Dispatcher dispatcher = mock(Dispatcher.class);
+    EventHandler<Event> eventHandler = mock(EventHandler.class);
+    when(dispatcher.getEventHandler()).thenReturn(eventHandler);
+    // Simulate the localizer thread being interrupted by a container kill:
+    // dispatching the failure event throws instead of completing.
+    Mockito.doThrow(new YarnRuntimeException(new InterruptedException()))
+        .when(eventHandler).handle(isA(ContainerResourceFailedEvent.class));
+
+    ContainerExecutor exec = mock(ContainerExecutor.class);
+    DeletionService delService = mock(DeletionService.class);
+    LocalDirsHandlerService dirsHandlerSpy = spy(new LocalDirsHandlerService());
+    dirsHandlerSpy.init(conf);
+    // Fail localization so LocalizerRunner.run() takes the error path.
+    Mockito.doThrow(new IOException("Simulated disk failure"))
+        .when(dirsHandlerSpy).getLocalPathForWrite(isA(String.class));
+
+    ResourceLocalizationService rls =
+        new ResourceLocalizationService(dispatcher, exec, delService,
+            dirsHandlerSpy, nmContext, metrics);
+
+    final ApplicationId appId =
+        BuilderUtils.newApplicationId(314159265358979L, 3);
+    final Container c = getMockContainer(appId, 42, "user0");
+    LocalizerRunner runner = rls.new LocalizerRunner(
+        new LocalizerContext("user0", c.getContainerId(), null),
+        c.getContainerId().toString());
+
+    // A resource that was in DOWNLOADING state when the localizer died.
+    LocalizedResource rsrc = mock(LocalizedResource.class);
+    when(rsrc.getLocalPath()).thenReturn(
+        new Path("/local/usercache/user0/filecache/10/foo.jar"));
+    LocalizerResourceRequestEvent scheduledEvent =
+        mock(LocalizerResourceRequestEvent.class);
+    when(scheduledEvent.getResource()).thenReturn(rsrc);
+    runner.scheduled.put(mock(LocalResourceRequest.class), scheduledEvent);
+
+    // Must not propagate the dispatch failure, and must still unlock the
+    // DOWNLOADING resource and schedule the deletion tasks.
+    runner.run();
+
+    verify(rsrc).unlock();
+    verify(delService, Mockito.atLeastOnce())
+        .delete(isA(FileDeletionTask.class));
   }
 
   @Test


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When a container is killed while it is localizing, the `LocalizerRunner`
thread is interrupted. In the `finally` block of `LocalizerRunner.run()`,
dispatching the `ContainerResourceFailedEvent` then throws
`YarnRuntimeException(InterruptedException)`, which skips everything after
it: resources left in DOWNLOADING state are never unlocked, and the
deletion tasks for the localization dirs, the `_tmp` download dirs and the
nmPrivate token file are never scheduled.

This PR revives the fix from #7893 by @zheng-weihao (stale-closed after
100 days of inactivity), unchanged: the event dispatch is wrapped in
try/catch so the cleanup below it always runs. The remaining review
comment on #7893 (dropping `FSError` from the catch list) had already been
addressed in its final revision. Credit to the original author is kept in
the commit message.

What this PR adds on top of #7893 is a unit test, which was the other
blocker ("no new or modified tests").

We hit this in production on a ~600 NodeManager cluster running
DefaultContainerExecutor: because DCE runs the localizer inside the NM
JVM, every kill-during-localization also leaked DFS block reader sockets
into the long-lived NM process, leaving DataNodes with FIN_WAIT1
connections whose send queues never drain. The HDFS side of that leak is
tracked separately in HDFS-17965 (#8690); this issue is the YARN-side
trigger and also leaves resources stuck in DOWNLOADING state regardless of
the container executor in use.


### How was this patch tested?

New unit test
`TestResourceLocalizationService#testDownloadingResourcesCleanedUpWhenDispatchFails`:
a mocked dispatcher throws `YarnRuntimeException(InterruptedException)`
when the `ContainerResourceFailedEvent` is dispatched, simulating the
kill-during-localization interrupt. Without the fix, `run()` propagates
the exception and the DOWNLOADING resource is never unlocked (test fails).
With the fix, the resource is unlocked and the deletion tasks are
scheduled (test passes).

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
Contains content generated by Claude Code (Anthropic Claude): the
      new unit test. The fix itself is unchanged from #7893. All content
      was human-reviewed and complies with the ASF Generative Tooling
      Guidance (https://www.apache.org/legal/generative-tooling.html).
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
