### PR TITLE
HADOOP-19973. Hadoop file system can not browse the folder that has children folder with colon in Windows.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -1809,7 +1808,7 @@ public abstract class AbfsClient implements Closeable {
           entry.lastModified());
     }
 
-    Path entryPath = new Path(File.separator + entry.name());
+    Path entryPath = new Path(AbfsHttpConstants.FORWARD_SLASH + entry.name());
     if (uri != null) {
       entryPath = entryPath.makeQualified(uri, entryPath);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -29,8 +29,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AbfsCountersImpl;
 import org.apache.hadoop.fs.azurebfs.MockIntercept;
+import org.apache.hadoop.fs.azurebfs.contracts.services.DfsListResultEntrySchema;
 import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.FORWARD_SLASH;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRICS_FORMAT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRICS_SHOULD_EMIT_ON_IDLE_TIME;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsMetricsManager.ABFS_CLIENT_TIMER_THREAD_NAME;
@@ -124,6 +126,47 @@ public class TestAbfsClient {
         assertThat(isThreadRunning(ABFS_CLIENT_TIMER_THREAD_NAME))
                 .describedAs("Unexpected thread 'abfs-timer-client' found")
                 .isEqualTo(false);
+    }
+
+    /**
+     * Test that {@link AbfsClient#getVersionedFileStatusFromEntry} always builds the
+     * entry path using a forward slash, regardless of the platform-dependent
+     * {@link java.io.File#separator}. On Windows, {@code File.separator} is a
+     * backslash, and using it here used to break browsing of directories whose
+     * child entry names contain a colon (e.g. "dir:name"), because
+     * "\dir:name" gets misparsed as a URI with scheme "\dir".
+     */
+    @Test
+    public void testGetVersionedFileStatusFromEntryUsesForwardSlash() throws Exception {
+        final Configuration configuration = new Configuration();
+        AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, ACCOUNT_NAME);
+
+        AbfsCounters abfsCounters = spy(new AbfsCountersImpl(new URI("abcd")));
+        AbfsClientContext abfsClientContext = new AbfsClientContextBuilder().withAbfsCounters(abfsCounters)
+            .withFileSystemId(UUID.randomUUID().toString()).build();
+
+        AbfsClient client = new AbfsDfsClient(new URL("https://" + ACCOUNT_NAME + "/"),
+                null,
+                abfsConfiguration,
+                (AccessTokenProvider) null,
+                null,
+                null,
+                abfsClientContext);
+
+        final String entryName = "dir:withColon";
+        DfsListResultEntrySchema entry = new DfsListResultEntrySchema()
+            .withName(entryName)
+            .withIsDirectory(true);
+
+        VersionedFileStatus status = client.getVersionedFileStatusFromEntry(entry, null);
+
+        assertThat(status.getPath().toUri().getPath())
+                .describedAs("Entry path must be built with '/' regardless of the "
+                        + "platform's File.separator, so folder names containing ':' "
+                        + "are not misparsed as a URI scheme on Windows")
+                .isEqualTo(FORWARD_SLASH + entryName);
+
+        client.close();
     }
 
     /**


### PR DESCRIPTION
### Description of PR

Backport of [HADOOP-19973](https://issues.apache.org/jira/browse/HADOOP-19973) to `branch-3.5`, targeting 3.5.1. Trunk PR: #8536.

`AbfsClient.getVersionedFileStatusFromEntry()` built the entry path as
`new Path(File.separator + entry.name())`. On Windows `File.separator` is a
backslash, so for a child entry named `FestSpecial:` the string handed to
`Path` is `\FestSpecial:`. `Path` looks for the first `:` before the first
`/`; finding no `/`, it treats `\FestSpecial` as a URI scheme and listing
fails:

```
java.net.URISyntaxException: Illegal character in scheme name at index 0: \FestSpecial:
```

The separator here is part of an ABFS/URI path, not a local filesystem path,
so it must always be `/`. Linux was unaffected because `File.separator` is
already `/` there.

This is a clean cherry-pick of the trunk commit — the patch is identical.

### How was this patch tested?

New unit test `TestAbfsClient#testGetVersionedFileStatusFromEntryUsesForwardSlash`,
asserting the entry path is built with `/` independently of the platform's
`File.separator`. It fails on Windows before the fix and is a regression guard
on every platform afterwards. Yetus reported `+1 overall` on the pre-rebase
revision, including `+1 unit — hadoop-azure in the patch passed`; CI is
re-running after the rebase onto the current `branch-3.5` tip.

Manually reproduced and verified against Azure Data Lake Storage using the
`test_hadoop_azure.zip` reproducer attached to the JIRA (`AbfsListStatusOAuthTest.java`).

<!-- FILL IN — required for ABFS review. Replace the line below, e.g.
Ran the full hadoop-azure integration suite against <account>.dfs.core.windows.net
(<region>), HNS-<enabled|disabled>, auth = <SharedKey|OAuth>:
    mvn -T 1C clean verify -Dparallel-tests=abfs -Dscale
Results: <n> tests, <n> failures (pre-existing: ...).
-->
Integration test endpoint declaration: TODO — see
`hadoop-tools/hadoop-azure/src/site/markdown/testing_azure.md`.

Note on the `Build` check: `.github/workflows/build_and_test.yml` was added to
trunk by HADOOP-19858 on 2026-04-22, after `branch-3.5` was cut, so no such
workflow run can exist for this branch and the check reports `action_required`.
This is the case for every PR against `branch-3.4`/`branch-3.5`. The Apache
CI checks (Yetus, jenkins/pr-merge) are the meaningful ones here.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?
- [ ] Object storage: Have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? (no new dependencies)
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? (not applicable)

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by Claude" where Claude is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy https://www.apache.org/legal/generative-tooling.html

Contains content generated by Claude in creating the unit test.

