### PR TITLE
HADOOP-19969. Upgrade httpcore5 and httpclient5 due to security issues

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -385,8 +385,8 @@ org.apache.htrace:htrace-core:3.1.0-incubating
 org.apache.htrace:htrace-core4:4.1.0-incubating
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.httpcomponents.client5:httpclient5:5.5
-org.apache.httpcomponents.core5:httpcore5:5.5
+org.apache.httpcomponents.client5:httpclient5:6.3
+org.apache.httpcomponents.core5:httpcore5:5.4.3
 org.apache.kafka:kafka-clients:3.9.2
 org.apache.kerby:kerb-admin:2.0.3
 org.apache.kerby:kerb-client:2.0.3

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -82,8 +82,8 @@
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.13</httpcore.version>
-    <httpclient5.version>5.5</httpclient5.version>
-    <httpcore5.version>5.3.6</httpcore5.version>
+    <httpclient5.version>5.6.3</httpclient5.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
 
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19969

### How was this patch tested?


### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
