### PR TITLE
YARN-11845. WebAppProxy add Connection close header to prevent CLOSE_WAIT leaks

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -312,7 +312,7 @@ public class WebAppProxyServlet extends HttpServlet {
     }
     // Tell the AM/history server to close the connection after the response
     // so that the proxied connection is not left in CLOSE_WAIT state on the
-    // proxy side (SOHU-HADOOP-11).
+    // proxy side (YARN-11845).
     base.setHeader("Connection", "close");
     String user = req.getRemoteUser();
     if (user != null && !user.isEmpty()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -310,7 +310,10 @@ public class WebAppProxyServlet extends HttpServlet {
         base.setHeader(name, value);
       }
     }
-
+    // Tell the AM/history server to close the connection after the response
+    // so that the proxied connection is not left in CLOSE_WAIT state on the
+    // proxy side (SOHU-HADOOP-11).
+    base.setHeader("Connection", "close");
     String user = req.getRemoteUser();
     if (user != null && !user.isEmpty()) {
       base.setHeader("Cookie",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
@@ -99,8 +99,8 @@ public class TestWebAppProxyServlet {
   private static boolean hasUnknownHeader = false;
   // Value of the Connection header received by the proxied server (the
   // embedded TestServlet backend). Used to verify the proxy sends
-  // 'Connection: close' (SOHU-HADOOP-11).
-  private static String proxiedConnectionHeader = null;
+  // 'Connection: close' (YARN-11845).
+  private static volatile String proxiedConnectionHeader = null;
   Configuration configuration = new Configuration();
 
 
@@ -509,7 +509,7 @@ public class TestWebAppProxyServlet {
    * HttpClient per request, so if the backend connection is kept alive the
    * socket is left in CLOSE_WAIT state on the proxy host until GC reclaims
    * it. Setting the 'Connection: close' request header makes the backend
-   * close the connection as soon as the response is sent (SOHU-HADOOP-11).
+   * close the connection as soon as the response is sent (YARN-11845).
    */
   @Test
   @Timeout(5000)
@@ -526,6 +526,7 @@ public class TestWebAppProxyServlet {
 
     try {
       // GET: the proxied request must carry 'Connection: close'
+      proxiedConnectionHeader = null;
       URL url = new URL("http://localhost:" + proxyPort
           + "/proxy/application_00_0");
       HttpURLConnection proxyConn = (HttpURLConnection) url.openConnection();
@@ -535,38 +536,44 @@ public class TestWebAppProxyServlet {
       assertEquals(HttpURLConnection.HTTP_OK, proxyConn.getResponseCode());
       assertNotNull(proxiedConnectionHeader,
           "The proxied server did not receive a Connection header at all");
-      assertEquals("close", proxiedConnectionHeader.trim().toLowerCase(),
+      assertEquals("close", StringUtils.toLowerCase(proxiedConnectionHeader.trim()),
           "The proxy must send 'Connection: close' to the proxied server "
               + "so the backend closes the connection instead of leaving it "
-              + "in CLOSE_WAIT state (SOHU-HADOOP-11)");
+              + "in CLOSE_WAIT state (YARN-11845)");
 
       // even if the incoming client request asked for keep-alive, the proxy
       // must still ask the backend to close the connection
+      proxiedConnectionHeader = null;
       proxyConn = (HttpURLConnection) url.openConnection();
       proxyConn.setRequestProperty("Cookie",
           "checked_application_0_0000=true");
       proxyConn.setRequestProperty("Connection", "keep-alive");
       proxyConn.connect();
       assertEquals(HttpURLConnection.HTTP_OK, proxyConn.getResponseCode());
-      assertEquals("close", proxiedConnectionHeader.trim().toLowerCase(),
+      assertNotNull(proxiedConnectionHeader,
+          "The proxied server did not receive a Connection header at all");
+      assertEquals("close", StringUtils.toLowerCase(proxiedConnectionHeader.trim()),
           "The proxy must override a client 'Connection: keep-alive' "
-              + "request header with 'close' (SOHU-HADOOP-11)");
+              + "request header with 'close' (YARN-11845)");
 
       // PUT: the header must be set on PUT requests as well
+      proxiedConnectionHeader = null;
       proxyConn = (HttpURLConnection) url.openConnection();
       proxyConn.setRequestMethod("PUT");
       proxyConn.setDoOutput(true);
       proxyConn.setRequestProperty("Cookie",
           "checked_application_0_0000=true");
       proxyConn.connect();
-      byte[] body = "SOHU-HADOOP-11".getBytes(StandardCharsets.UTF_8);
+      byte[] body = "test-body".getBytes(StandardCharsets.UTF_8);
       try (OutputStream os = proxyConn.getOutputStream()) {
         os.write(body);
       }
       assertEquals(HttpURLConnection.HTTP_OK, proxyConn.getResponseCode());
-      assertEquals("close", proxiedConnectionHeader.trim().toLowerCase(),
+      assertNotNull(proxiedConnectionHeader,
+          "The proxied server did not receive a Connection header at all");
+      assertEquals("close", StringUtils.toLowerCase(proxiedConnectionHeader.trim()),
           "The proxy must send 'Connection: close' on PUT requests too "
-              + "(SOHU-HADOOP-11)");
+              + "(YARN-11845)");
     } finally {
       proxy.close();
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
@@ -97,6 +97,10 @@ public class TestWebAppProxyServlet {
   private static int numberOfHeaders = 0;
   private static final String UNKNOWN_HEADER = "Unknown-Header";
   private static boolean hasUnknownHeader = false;
+  // Value of the Connection header received by the proxied server (the
+  // embedded TestServlet backend). Used to verify the proxy sends
+  // 'Connection: close' (SOHU-HADOOP-11).
+  private static String proxiedConnectionHeader = null;
   Configuration configuration = new Configuration();
 
 
@@ -129,6 +133,7 @@ public class TestWebAppProxyServlet {
         throws ServletException, IOException {
       int numHeaders = 0;
       hasUnknownHeader = false;
+      proxiedConnectionHeader = req.getHeader("Connection");
       @SuppressWarnings("unchecked")
       Enumeration<String> names = req.getHeaderNames();
       while(names.hasMoreElements()) {
@@ -145,6 +150,23 @@ public class TestWebAppProxyServlet {
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp)
         throws ServletException, IOException {
+      proxiedConnectionHeader = req.getHeader("Connection");
+      InputStream is = req.getInputStream();
+      OutputStream os = resp.getOutputStream();
+      int c = is.read();
+      while (c > -1) {
+        os.write(c);
+        c = is.read();
+      }
+      is.close();
+      os.close();
+      resp.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp)
+        throws ServletException, IOException {
+      proxiedConnectionHeader = req.getHeader("Connection");
       InputStream is = req.getInputStream();
       OutputStream os = resp.getOutputStream();
       int c = is.read();
@@ -476,6 +498,75 @@ public class TestWebAppProxyServlet {
       // by proxy as it is not in the list of allowed headers.
       assertEquals(numberOfHeaders, 9);
       assertFalse(hasUnknownHeader);
+    } finally {
+      proxy.close();
+    }
+  }
+
+  /**
+   * Test that the proxy tells the proxied server (AM / history server) to
+   * close the connection after each response. The proxy builds a new
+   * HttpClient per request, so if the backend connection is kept alive the
+   * socket is left in CLOSE_WAIT state on the proxy host until GC reclaims
+   * it. Setting the 'Connection: close' request header makes the backend
+   * close the connection as soon as the response is sent (SOHU-HADOOP-11).
+   */
+  @Test
+  @Timeout(5000)
+  void testWebAppProxyConnectionCloseHeader() throws Exception {
+    Configuration configuration = new Configuration();
+    configuration.set(YarnConfiguration.PROXY_ADDRESS, "localhost:9093");
+    configuration.setInt("hadoop.http.max.threads", 10);
+    WebAppProxyServerForTest proxy = new WebAppProxyServerForTest();
+    proxy.init(configuration);
+    proxy.start();
+
+    int proxyPort = proxy.proxy.proxyServer.getConnectorAddress(0).getPort();
+    proxy.proxy.appReportFetcher.answer = 0;
+
+    try {
+      // GET: the proxied request must carry 'Connection: close'
+      URL url = new URL("http://localhost:" + proxyPort
+          + "/proxy/application_00_0");
+      HttpURLConnection proxyConn = (HttpURLConnection) url.openConnection();
+      proxyConn.setRequestProperty("Cookie",
+          "checked_application_0_0000=true");
+      proxyConn.connect();
+      assertEquals(HttpURLConnection.HTTP_OK, proxyConn.getResponseCode());
+      assertNotNull(proxiedConnectionHeader,
+          "The proxied server did not receive a Connection header at all");
+      assertEquals("close", proxiedConnectionHeader.trim().toLowerCase(),
+          "The proxy must send 'Connection: close' to the proxied server "
+              + "so the backend closes the connection instead of leaving it "
+              + "in CLOSE_WAIT state (SOHU-HADOOP-11)");
+
+      // even if the incoming client request asked for keep-alive, the proxy
+      // must still ask the backend to close the connection
+      proxyConn = (HttpURLConnection) url.openConnection();
+      proxyConn.setRequestProperty("Cookie",
+          "checked_application_0_0000=true");
+      proxyConn.setRequestProperty("Connection", "keep-alive");
+      proxyConn.connect();
+      assertEquals(HttpURLConnection.HTTP_OK, proxyConn.getResponseCode());
+      assertEquals("close", proxiedConnectionHeader.trim().toLowerCase(),
+          "The proxy must override a client 'Connection: keep-alive' "
+              + "request header with 'close' (SOHU-HADOOP-11)");
+
+      // PUT: the header must be set on PUT requests as well
+      proxyConn = (HttpURLConnection) url.openConnection();
+      proxyConn.setRequestMethod("PUT");
+      proxyConn.setDoOutput(true);
+      proxyConn.setRequestProperty("Cookie",
+          "checked_application_0_0000=true");
+      proxyConn.connect();
+      byte[] body = "SOHU-HADOOP-11".getBytes(StandardCharsets.UTF_8);
+      try (OutputStream os = proxyConn.getOutputStream()) {
+        os.write(body);
+      }
+      assertEquals(HttpURLConnection.HTTP_OK, proxyConn.getResponseCode());
+      assertEquals("close", proxiedConnectionHeader.trim().toLowerCase(),
+          "The proxy must send 'Connection: close' on PUT requests too "
+              + "(SOHU-HADOOP-11)");
     } finally {
       proxy.close();
     }


### PR DESCRIPTION
# YARN-11845. WebAppProxy: add `Connection: close` header to prevent CLOSE_WAIT leaks

## Description of PR

This PR fixes an accumulation of sockets stuck in `CLOSE_WAIT` state on the
ResourceManager host that runs the WebAppProxy.

`WebAppProxyServlet.proxyLink()` creates a brand-new `HttpClient` for every
proxied request (`HttpClientBuilder.create()` → `build()`), sends the request,
and only calls `base.releaseConnection()` afterward. It never closes the
`HttpClient` itself.

Apache HttpClient enables connection pooling / keep-alive by default, so the
backend (Application Master or History Server) keeps the connection open after
returning the response, waiting to reuse it. But since the proxy throws away
the `HttpClient` right after each request, that pooled connection can never be
reused. The corresponding socket on the proxy side therefore lingers in
`CLOSE_WAIT` until the `HttpClient` is finally garbage collected.

The fix is to explicitly ask the backend to close the connection once the
response has been sent, by setting a `Connection: close` request header on the
outgoing request:

```java
base.setHeader("Connection", "close");
```

Because `Connection` is not in `PASS_THROUGH_HEADERS`, a client-supplied
`Connection: keep-alive` header is never forwarded, so the proxy always sends
`close` and the backend closes the connection as soon as the response is
written.

## How was this patch tested?

- Added `testWebAppProxyConnectionCloseHeader()` in
  `TestWebAppProxyServlet`, which verifies that the proxied backend receives a
  `Connection: close` header in three cases:
  1. a plain `GET` request,
  2. a `GET` request where the client explicitly sends `Connection: keep-alive`
     (asserting the proxy overrides it with `close`),
  3. a `PUT` request (asserting the header is also set on the PUT path).
- The existing `testWebAppProxyPassThroughHeaders` assertion (9 headers
  received by the backend) is unaffected: the `Connection` header was already
  among the counted headers, only its value changes from `Keep-Alive` to
  `close`.

## For code changes

- [ ] The title of this PR accurately describes the issue.
- [ ] The code follows the project's style guidelines.
- [ ] New tests are added, and existing tests still pass.
- [ ] No user-facing API/behavior change is introduced (the proxy continues to
      return the same responses; it only instructs the backend to close the
      underlying connection).

## Additional notes

- `Connection: close` does not change the response returned to the client; it
  only affects the lifetime of the internal proxied connection, so it has no
  user-visible impact.
- This is a one-line, low-risk change scoped to the web-proxy module.

## Commit message

```text
YARN-11845. WebAppProxy: add Connection: close header to prevent CLOSE_WAIT socket buildup. Contributed by weishao <weishao@sohu-inc.com>.

WebAppProxyServlet.proxyLink() creates a new HttpClient per request and never
closes it. With keep-alive enabled by default, the backend keeps the proxied
connection open and the proxy-side socket lingers in CLOSE_WAIT until GC.
Explicitly setting Connection: close makes the backend close the connection
after each response.
```
