### PR TITLE
YARN-11987. container-executor delete-as-user fails to rmdir private filecache directories.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
@@ -2782,22 +2782,27 @@ static int delete_path(const char *full_path,
     return -1;
   }
 
-  /*
-   * If required, do the final rmdir as root on the top level.
-   * That handles the case where the top level directory is in a directory
-   * owned by the node manager.
-   */
-  if (needs_tt_user) {
-    return rmdir_as_nm(full_path);
-  }
-  /* Otherwise rmdir the top level as the current user. */
+  /* rmdir the top level as the current user. */
   if (rmdir(full_path) != 0) {
     ret = errno;
-    if (ret != ENOENT) {
-      fprintf(LOGFILE, "Couldn't delete directory %s - %s\n",
-              full_path, strerror(ret));
-      return -1;
+    if (ret == ENOENT) {
+      return 0;
     }
+    /*
+     * If required, retry the final rmdir as the node manager user.
+     * That handles the case where the top level directory is in a directory
+     * owned by the node manager, e.g. usercache/<user>. The first attempt
+     * as the current user handles the opposite case where the top level
+     * directory is in a directory owned by the run-as user but not writable
+     * by the node manager user, e.g. the private file cache
+     * usercache/<user>/filecache/<id>.
+     */
+    if (needs_tt_user && (ret == EACCES || ret == EPERM)) {
+      return rmdir_as_nm(full_path);
+    }
+    fprintf(LOGFILE, "Couldn't delete directory %s - %s\n",
+            full_path, strerror(ret));
+    return -1;
   }
   return 0;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/test/test-container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/test/test-container-executor.c
@@ -641,6 +641,62 @@ void test_delete_user() {
 }
 
 /**
+ * Test that delete_as_user with an empty relative path can remove a top
+ * level directory whose parent is owned by the run-as user and is not
+ * writable by the node manager user, as happens when the private file
+ * cache (usercache/<user>/filecache/<id>) is evicted. Run this test as
+ * root with two different users (test-container-executor <nm-user>
+ * <run-as-user>) to exercise the failure mode.
+ */
+void test_delete_dir_in_user_owned_parent() {
+  printf("\nTesting delete_dir_in_user_owned_parent\n");
+  if (seteuid(0) != 0) {
+    printf("Ignoring test_delete_dir_in_user_owned_parent; not running as root\n");
+    return;
+  }
+  char buffer[100000];
+  // the private filecache is created by the ContainerLocalizer with perms
+  // 0710 and is owned by the run-as user, so the node manager user cannot
+  // write to it.
+  sprintf(buffer, "mkdir -p " TEST_ROOT "/local-1/usercache/%s/filecache/10",
+          yarn_username);
+  run(buffer);
+  sprintf(buffer, "chown -R %s " TEST_ROOT "/local-1/usercache/%s",
+          yarn_username, yarn_username);
+  run(buffer);
+  sprintf(buffer, "chmod 710 " TEST_ROOT "/local-1/usercache/%s/filecache",
+          yarn_username);
+  run(buffer);
+
+  if (set_user(yarn_username) != 0) {
+    printf("FAIL: failed to set user to %s\n", yarn_username);
+    exit(1);
+  }
+  char child[PATH_MAX];
+  sprintf(child, TEST_ROOT "/local-1/usercache/%s/filecache/10",
+          yarn_username);
+  char * dirs[] = {child, 0};
+  int ret = delete_as_user(yarn_username, "", dirs);
+  if (seteuid(0) != 0) {
+    printf("FAIL: could not become root again\n");
+    exit(1);
+  }
+  if (ret != 0) {
+    printf("FAIL: return code from delete_as_user is %d\n", ret);
+    exit(1);
+  }
+  if (access(child, F_OK) == 0) {
+    printf("FAIL: failed to delete the directory - %s\n", child);
+    exit(1);
+  }
+  sprintf(buffer, TEST_ROOT "/local-1/usercache/%s/filecache", yarn_username);
+  if (access(buffer, F_OK) != 0) {
+    printf("FAIL: accidently deleted the parent directory - %s\n", buffer);
+    exit(1);
+  }
+}
+
+/**
  * Read a file and tokenize it on newlines.  Place up to max lines into lines.
  * The max+1st element of lines will be set to NULL.
  *
@@ -1779,6 +1835,7 @@ int main(int argc, char **argv) {
   ret++;
   // test_delete_user must run as root since that's how we use the delete_as_user
   test_delete_user();
+  test_delete_dir_in_user_owned_parent();
   free_executor_configurations();
 
   printf("\nTrying banned default user()\n");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

See YARN-11987 for the full analysis. Summary:

When LocalizerRunner cleans up after an aborted localization, it batches the leftover dirs as baseDirs with an empty relative path, so `delete_as_user()` sets `needs_tt_user = 1` and `delete_path()` performs the final top-level rmdir *only* as the NM user. That works for NM-owned parents (`usercache/<user>`), but always fails with EACCES for private filecache entries (`usercache/<user>/filecache/<id>`), whose parent is owned by the run-as user with mode 0710. Every aborted localization logs a `DeleteAsUser ... exit code: 255` error and leaks an empty directory that is never retried.

This PR makes `delete_path()` try the final rmdir as the current (run-as) user first, falling back to `rmdir_as_nm()` on EACCES/EPERM when `needs_tt_user` is set:

* NM-owned parents keep working exactly as before (rmdir as user fails, NM fallback succeeds).
* User-owned parents are fixed (rmdir as user succeeds immediately).
* No privilege escalation: the NM-user rmdir already existed; the fix only tries the less-privileged user first. The fallback is restricted to EACCES/EPERM because other errors (ENOTEMPTY, EBUSY, ...) would fail identically for the NM user.

An alternative would be to fix the caller (one FileDeletionTask per path, with the path as subDir), but batching several absolute paths into one container-executor invocation is only possible through baseDirs, so that costs one exec per path and leaves the same trap for any other caller. Fixing `delete_path()` covers all callers in one place.

### How was this patch tested?

Added `test_delete_dir_in_user_owned_parent` to test-container-executor.c. The failure mode needs the final rmdir to run as a non-root NM user different from the directory owner, so the test only exercises the bug in the root invocation mode with two distinct users:

```bash
# build native, then as root:
./test-container-executor <nm-user> <run-as-user>   # e.g. yarn nobody
```

Before the fix this fails the new test (rmdir_as_nm gets EACCES); after the fix it passes. Notably, without the fix even the *existing* `test_delete_user` fails in this two-user root mode — its empty-subdir scenario deletes a dir under the run-as user's `appcache`, which hits the same EACCES:

```
Testing delete_user
rmdir of .../local-1/usercache/nobody/appcache/app_3/ failed - Permission denied
FAIL: directory not deleted
```

Non-root runs (cetest in CI) skip the privileged part gracefully, same as the existing test_delete_user.

Also verified manually with the exact NM invocation against a directory laid out like a private filecache entry:

```bash
install -d -o nobody -g nobody -m 755 /data/01/yarn/nm/usercache/alice/filecache/999999
sudo -u yarn $HADOOP_YARN_HOME/bin/container-executor nobody alice 3 "" /data/01/yarn/nm/usercache/alice/filecache/999999
```

Before: exit 255, `rmdir of ... failed - Permission denied`, empty dir remains. After: exit 0, dir removed. The preserved NM-owned-parent case (`... 3 "" /data/01/yarn/nm/usercache/alice`) still succeeds.


### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
Generative AI: Contains content generated by Claude Code (Anthropic
      Claude). The change was human-reviewed and verified on a production
      cluster, and complies with the ASF Generative Tooling Guidance
      (https://www.apache.org/legal/generative-tooling.html).
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html