### PR TITLE
YARN: restrict web proxy redirects to the application host

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -64,8 +64,10 @@ import org.apache.hadoop.yarn.webapp.MimeType;
 import org.apache.hadoop.yarn.webapp.hamlet2.Hamlet;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import org.apache.http.Header;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.ProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -73,7 +75,9 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -265,6 +269,12 @@ public class WebAppProxyServlet extends HttpServlet {
     // similar could cause issues otherwise.
     InetAddress localAddress = InetAddress.getByName(proxyHost);
     LOG.debug("local InetAddress for proxy host: {}", localAddress);
+    // The tracking URL is supplied by the application and is fetched
+    // server-side, so a malicious AM can return a redirect pointing at the
+    // cluster's internal services or the cloud metadata endpoint. Only follow
+    // redirects that stay on the application's own host.
+    httpClientBuilder.setRedirectStrategy(
+        new SameHostRedirectStrategy(link.getHost()));
     httpClientBuilder.setDefaultRequestConfig(
         connectionTimeoutEnabled ?
             RequestConfig.custom()
@@ -335,7 +345,41 @@ public class WebAppProxyServlet extends HttpServlet {
       base.releaseConnection();
     }
   }
-  
+
+  /**
+   * Refuse to follow a proxied redirect whose target host differs from the
+   * host of the application's tracking URL. Same-host redirects (the common
+   * case for an application web UI) are still followed.
+   */
+  @VisibleForTesting
+  static void checkSameHost(String allowedHost, URI target)
+      throws ProtocolException {
+    String targetHost = target == null ? null : target.getHost();
+    if (allowedHost != null && targetHost != null
+        && !allowedHost.equalsIgnoreCase(targetHost)) {
+      throw new ProtocolException(
+          "Refusing to follow application redirect to a different host: "
+              + targetHost);
+    }
+  }
+
+  @VisibleForTesting
+  static final class SameHostRedirectStrategy extends DefaultRedirectStrategy {
+    private final String allowedHost;
+
+    SameHostRedirectStrategy(String allowedHost) {
+      this.allowedHost = allowedHost;
+    }
+
+    @Override
+    public URI getLocationURI(HttpRequest request, HttpResponse response,
+        HttpContext context) throws ProtocolException {
+      URI target = super.getLocationURI(request, response, context);
+      checkSameHost(allowedHost, target);
+      return target;
+    }
+  }
+
   private static String getCheckCookieName(ApplicationId id){
     return "checked_"+id;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
@@ -57,6 +57,15 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.http.HttpHost;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.protocol.HttpCoreContext;
+
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -565,6 +574,30 @@ public class TestWebAppProxyServlet {
         "Was expecting an HTML page explaining that an HTTPS tracking"
             + " url must be used but found " + s);
     Mockito.verify(resp, Mockito.times(1)).setContentType(MimeType.HTML);
+  }
+
+  @Test
+  void testProxyRedirectToDifferentHostIsRefused() throws Exception {
+    WebAppProxyServlet.SameHostRedirectStrategy strategy =
+        new WebAppProxyServlet.SameHostRedirectStrategy("amhost");
+
+    HttpGet request = new HttpGet("http://amhost:8042/app");
+    HttpClientContext context = HttpClientContext.create();
+    context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST,
+        new HttpHost("amhost", 8042, "http"));
+    context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+
+    BasicHttpResponse sameHost = new BasicHttpResponse(
+        new BasicStatusLine(HttpVersion.HTTP_1_1, 302, "Found"));
+    sameHost.setHeader("Location", "http://amhost:8042/app/next");
+    assertEquals("amhost",
+        strategy.getLocationURI(request, sameHost, context).getHost());
+
+    BasicHttpResponse crossHost = new BasicHttpResponse(
+        new BasicStatusLine(HttpVersion.HTTP_1_1, 302, "Found"));
+    crossHost.setHeader("Location", "http://169.254.169.254/latest/meta-data/");
+    assertThrows(ProtocolException.class,
+        () -> strategy.getLocationURI(request, crossHost, context));
   }
 
   private String readInputStream(InputStream input) throws Exception {


### PR DESCRIPTION
### Description of PR

`WebAppProxyServlet.proxyLink` fetches an application's tracking URL server-side with an HttpClient that auto-follows redirects, and that tracking URL is whatever the application master registered. A malicious AM can answer the proxied request with a redirect to `http://169.254.169.254/` (cloud metadata), a loopback admin port, or another internal cluster service, and the proxy follows it and streams the response back to the viewing user, which is a server-side request forgery. This restricts the follow to the application's own host: a `SameHostRedirectStrategy` rejects any redirect whose host differs from the tracking URL host, so a same-host application UI redirect still works while a cross-host hop is refused.

Trigger before the change: AM registers a tracking URL, the proxied `GET` returns `302 Location: http://169.254.169.254/latest/meta-data/`, and the proxy fetches the metadata endpoint from inside the cluster and returns the body. After the change that redirect is not followed and the fetch fails like any other unreachable target.

### How was this patch tested?

Added `testProxyRedirectToDifferentHostIsRefused` which drives the strategy with a same-host `Location` (followed) and a `169.254.169.254` `Location` (refused with `ProtocolException`), and ran the `hadoop-yarn-server-web-proxy` module tests. The `testAppReportForEmptyTrackingUrl` failure seen locally is unrelated and reproduces on a clean tree (this host has no resolvable hostname).

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
