### PR TITLE
HADOOP-19965. GHA update build status runs in forked repos

### DIFF
--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -29,6 +29,7 @@ jobs:
   update:
     name: "Update Build Status"
     runs-on: ubuntu-slim
+    if: github.repository == 'apache/hadoop'
     permissions:
       actions: read
       checks: write


### PR DESCRIPTION

### Description of PR

shuts down build status run on forks

### How was this patch tested?

pushed it up as trunk to my own repo to see what happens

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
