### PR TITLE
HADOOP-19971. Remove servlet and Jetty types from classes that do not need them

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -658,9 +658,10 @@ org.glassfish.jersey.core:jersey-server:2.46
 org.glassfish.jersey.inject:jersey-hk2:2.46
 org.glassfish.jersey.core:jersey-client:2.46
 org.glassfish.jersey.test-framework:jersey-test-framework-core:2.46
-org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty:2.46
+org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http:2.46
 org.glassfish.jersey.containers:jersey-container-servlet:2.46
 org.glassfish.jersey.containers:jersey-container-servlet-core:2.46
+org.glassfish.jersey.containers:jersey-container-jdk-http:2.46
 org.glassfish.jersey.media:jersey-media-json-jettison:2.46
 org.glassfish.jersey.media:jersey-media-jaxb:2.46
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -625,7 +625,6 @@ CDDL 1.1 + GPLv2 with classpath exception
 com.sun.xml.bind:jaxb-impl:2.2.3-1
 javax.annotation:javax.annotation-api:1.3.2
 javax.cache:cache-api:1.1.1
-javax.servlet:javax.servlet-api:3.1.0
 javax.servlet.jsp:jsp-api:2.1
 javax.websocket:javax.websocket-api:1.0
 
@@ -645,7 +644,6 @@ Eclipse Public License (EPL) 2.0
 --------------------------
 
 jakarta.ws.rs-api:jakarta.ws.rs-api:2.1.6
-jakarta.servlet.jsp:jakarta.servlet.jsp-api:2.3.6
 jakarta.servlet:jakarta.servlet-api:4.0.4
 
 Eclipse Public License (EPL) 2.0 with some parts being

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -423,6 +423,7 @@ org.eclipse.jetty:jetty-util:9.4.58.v20250814
 org.eclipse.jetty:jetty-util-ajax:9.4.58.v20250814
 org.eclipse.jetty:jetty-webapp:9.4.58.v20250814
 org.eclipse.jetty:jetty-xml:9.4.58.v20250814
+org.eclipse.jetty.toolchain:jetty-servlet-api:4.0.9
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.58.v20250814
 org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.58.v20250814
 org.ehcache:ehcache:3.8.2
@@ -644,7 +645,6 @@ Eclipse Public License (EPL) 2.0
 --------------------------
 
 jakarta.ws.rs-api:jakarta.ws.rs-api:2.1.6
-jakarta.servlet:jakarta.servlet-api:4.0.4
 
 Eclipse Public License (EPL) 2.0 with some parts being
 GNU General Public License (GPL), Version 2, With Classpath Exception,

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -463,7 +463,6 @@ Oracle
 The following artifacts are CDDL + GPLv2 with classpath exception.
 https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
 
- * javax.servlet:javax.servlet-api
  * javax.annotation:javax.annotation-api
  * javax.transaction:javax.transaction-api
  * javax.websocket:javax.websocket-api

--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -632,7 +632,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <exclusions>
         <exclusion>
           <groupId>jakarta.ws.rs</groupId>
@@ -940,11 +940,13 @@
                         <exclude>com/sun/security/*</exclude>
                         <exclude>com/sun/jndi/*</exclude>
                         <exclude>com/sun/management/*</exclude>
+                        <exclude>com/sun/net/httpserver/*</exclude>
                         <exclude>com/sun/tools/**/*</exclude>
                         <exclude>com/sun/javadoc/**/*</exclude>
                         <exclude>com/sun/security/**/*</exclude>
                         <exclude>com/sun/jndi/**/*</exclude>
                         <exclude>com/sun/management/**/*</exclude>
+                        <exclude>com/sun/net/httpserver/**/*</exclude>
                         <exclude>com/ibm/security/*</exclude>
                         <exclude>com/ibm/security/**/*</exclude>
                         <!-- Exclude zstd-jni -->

--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -124,8 +124,8 @@
           <artifactId>javax.servlet-api</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-servlet-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>jakarta.ws.rs</groupId>
@@ -419,7 +419,7 @@
     </dependency>
     <!-- Add back in the transitive dependencies excluded from hadoop-common in client TODO remove once we have a filter for "is in these artifacts" -->
     <!-- skip javax.servlet:javax.servlet-api because it's in client -->
-    <!-- skip jakarta.servlet:jakarta.servlet-api because it's in client -->
+    <!-- skip org.eclipse.jetty.toolchain:jetty-servlet-api because it's in client -->
     <!-- skip jakarta.ws.rs-api:jakarta.ws.rs because it's in client -->
     <!-- Skip commons-logging:commons-logging-api because it looks like nothing actually included it -->
     <!-- Skip jetty-util because it's in client -->
@@ -464,7 +464,7 @@
     </dependency>
     <!-- add back in transitive dependencies of hadoop-mapreduce-client-app removed in client -->
     <!-- Skipping javax.servlet:javax.servlet-api because it's in client -->
-    <!-- Skipping jakarta.servlet:jakarta.servlet-api because it's in client -->
+    <!-- Skipping org.eclipse.jetty.toolchain:jetty-servlet-api because it's in client -->
     <!-- Skipping jakarta.ws.rs-api:jakarta.ws.rs because it's in client -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -476,8 +476,8 @@
           <artifactId>javax.servlet-api</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-servlet-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>jakarta.ws.rs</groupId>
@@ -551,8 +551,8 @@
           <artifactId>javax.servlet-api</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-servlet-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>jakarta.ws.rs</groupId>

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -170,7 +170,6 @@
                       <exclude>org.eclipse.jetty:jetty-util</exclude>
                       <exclude>org.eclipse.jetty:jetty-util-ajax</exclude>
                       <exclude>org.eclipse.jetty:jetty-server</exclude>
-                      <exclude>org.eclipse.jetty:jetty-continuation</exclude>
                       <exclude>org.ow2.asm:*</exclude>
                       <!-- Leave bouncycastle unshaded because it's signed with a special Oracle certificate so it can be a custom JCE security provider -->
                       <exclude>org.bouncycastle:*</exclude>

--- a/hadoop-common-project/hadoop-auth-examples/pom.xml
+++ b/hadoop-common-project/hadoop-auth-examples/pom.xml
@@ -32,8 +32,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -62,8 +62,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationToken.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationToken.java
@@ -18,12 +18,10 @@ import org.apache.hadoop.security.authentication.util.AuthToken;
 
 import java.security.Principal;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
  * The {@link AuthenticationToken} contains information about an authenticated
  * HTTP client and doubles as the {@link Principal} to be returned by
- * authenticated {@link HttpServletRequest}s
+ * authenticated HTTP requests.
  * <p>
  * The token can be serialized/deserialized to and from a string as it is sent
  * and received in HTTP client responses and requests as a HTTP cookie (this is

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/JWTRedirectAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/JWTRedirectAuthenticationHandler.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Properties;
 import java.text.ParseException;
 
+import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 
 import org.apache.hadoop.classification.VisibleForTesting;
@@ -125,7 +126,11 @@ public class JWTRedirectAuthenticationHandler extends
         throw new ServletException(
             "Public key for signature validation must be provisioned.");
       }
-      publicKey = CertificateUtil.parseRSAPublicKey(pemPublicKey);
+      try {
+        publicKey = CertificateUtil.toRSAPublicKey(pemPublicKey);
+      } catch (CertificateException ce) {
+        throw new ServletException(ce.getMessage(), ce);
+      }
     }
     // setup the list of valid audiences for token validation
     String auds = config.getProperty(EXPECTED_JWT_AUDIENCES);

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/CertificateUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/CertificateUtil.java
@@ -50,7 +50,12 @@ public class CertificateUtil {
     try {
       return toRSAPublicKey(pem);
     } catch (CertificateException ce) {
-      throw new ServletException(ce.getMessage(), ce);
+      // Report the exception toRSAPublicKey wrapped, not the wrapper, so that
+      // the cause a caller sees is the one this method has always reported:
+      // the CertificateException the parse itself raised. Wrapping the wrapper
+      // would add a level to the chain that was not there before.
+      Throwable cause = ce.getCause() == null ? ce : ce.getCause();
+      throw new ServletException(ce.getMessage(), cause);
     }
   }
 

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/CertificateUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/CertificateUtil.java
@@ -38,8 +38,32 @@ public class CertificateUtil {
    *          - the pem encoding from config without the header and footer
    * @return RSAPublicKey the RSA public key
    * @throws ServletException thrown if a processing error occurred
+   * @deprecated use {@link #toRSAPublicKey(String)}, which reports the
+   *             {@link CertificateException} it is really raising instead of
+   *             wrapping it in a servlet type. This method is kept so that
+   *             existing callers still compile and behave as before, and will
+   *             be removed with the move to the jakarta servlet namespace.
    */
-  public static RSAPublicKey parseRSAPublicKey(String pem) throws ServletException {
+  @Deprecated
+  public static RSAPublicKey parseRSAPublicKey(String pem)
+      throws ServletException {
+    try {
+      return toRSAPublicKey(pem);
+    } catch (CertificateException ce) {
+      throw new ServletException(ce.getMessage(), ce);
+    }
+  }
+
+  /**
+   * Gets an RSAPublicKey from the provided PEM encoding.
+   *
+   * @param pem
+   *          - the pem encoding from config without the header and footer
+   * @return RSAPublicKey the RSA public key
+   * @throws CertificateException thrown if the PEM could not be parsed
+   */
+  public static RSAPublicKey toRSAPublicKey(String pem)
+      throws CertificateException {
     String fullPem = PEM_HEADER + pem + PEM_FOOTER;
     PublicKey key = null;
     try {
@@ -57,7 +81,7 @@ public class CertificateUtil {
       } else {
         message = "CertificateException - PEM may be corrupt";
       }
-      throw new ServletException(message, ce);
+      throw new CertificateException(message, ce);
     }
     return (RSAPublicKey) key;
   }

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/FileSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/FileSignerSecretProvider.java
@@ -17,7 +17,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 
-import javax.servlet.ServletContext;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -37,7 +36,7 @@ public class FileSignerSecretProvider extends SignerSecretProvider {
   public FileSignerSecretProvider() {}
 
   @Override
-  public void init(Properties config, ServletContext servletContext,
+  public void initialize(Properties config, SecretProviderContext context,
                    long tokenValidity) throws Exception {
 
     String signatureSecretFile = config.getProperty(

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/RolloverSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/RolloverSignerSecretProvider.java
@@ -17,7 +17,6 @@ import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.servlet.ServletContext;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -61,12 +60,12 @@ public abstract class RolloverSignerSecretProvider
    * and starts the scheduler for the rollover to run at an interval of
    * tokenValidity.
    * @param config configuration properties
-   * @param servletContext servlet context
+   * @param context the attribute store to initialize against
    * @param tokenValidity The amount of time a token is valid for
    * @throws Exception thrown if an error occurred
    */
   @Override
-  public void init(Properties config, ServletContext servletContext,
+  public void initialize(Properties config, SecretProviderContext context,
           long tokenValidity) throws Exception {
     initSecrets(generateNewSecret(), null);
     startScheduler(tokenValidity, tokenValidity);

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SecretProviderContext.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SecretProviderContext.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.hadoop.security.authentication.util;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * The attribute store a {@link SignerSecretProvider} is initialized against.
+ * <p>
+ * A SignerSecretProvider that has to share an object with the rest of the
+ * application it is embedded in - as {@link ZKSignerSecretProvider} shares its
+ * CuratorFramework client - reads and writes that object here.  When the
+ * provider is running inside a servlet container the attributes are those of
+ * the ServletContext, so the sharing is unchanged; see
+ * {@link org.apache.hadoop.security.authentication.server.AuthenticationFilter}.
+ * <p>
+ * This interface exists so that a SignerSecretProvider need not name a servlet
+ * type.  Implementations of it that are backed by a ServletContext do, but the
+ * providers themselves stay independent of the servlet API and so of which
+ * servlet namespace - javax or jakarta - the container provides.
+ */
+@InterfaceStability.Unstable
+@InterfaceAudience.Private
+public interface SecretProviderContext {
+
+  /**
+   * Returns the attribute stored under the given name, or null if there is
+   * none.
+   * @param name the attribute name
+   * @return the attribute value, or null
+   */
+  Object getAttribute(String name);
+
+  /**
+   * Stores an attribute under the given name, replacing any previous value.
+   * @param name the attribute name
+   * @param value the attribute value
+   */
+  void setAttribute(String name, Object value);
+}

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/ServletSecretProviderContext.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/ServletSecretProviderContext.java
@@ -18,6 +18,9 @@ import java.util.Map;
 import javax.servlet.ServletContext;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Presents a ServletContext to a {@link SignerSecretProvider} as a
@@ -37,6 +40,9 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceStability.Unstable
 @InterfaceAudience.Private
 final class ServletSecretProviderContext implements SecretProviderContext {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ServletSecretProviderContext.class);
 
   private final ServletContext servletContext;
 
@@ -77,7 +83,8 @@ final class ServletSecretProviderContext implements SecretProviderContext {
    * Attributes live as long as the provider does and are seen by nothing else,
    * which is what passing a null ServletContext already meant.
    */
-  private static final class MapSecretProviderContext
+  @VisibleForTesting
+  static final class MapSecretProviderContext
       implements SecretProviderContext {
 
     private final Map<String, Object> attributes = new HashMap<>();
@@ -87,8 +94,23 @@ final class ServletSecretProviderContext implements SecretProviderContext {
       return attributes.get(name);
     }
 
+    /**
+     * Stores the attribute, and says so.
+     * <p>
+     * A provider only writes here to share an object with the rest of the
+     * application - the CuratorFramework client of
+     * {@link ZKSignerSecretProvider} is the one case in this tree. There is
+     * nothing to share it with: this store is private to the provider, so a
+     * second provider in the same JVM builds a second client rather than
+     * finding this one. Before there was a store at all a null ServletContext
+     * threw, which was at least loud; this keeps it visible.
+     */
     @Override
     public void setAttribute(String name, Object value) {
+      LOG.warn("SignerSecretProvider was initialized without a ServletContext,"
+          + " so the attribute {} is being stored in a map private to this"
+          + " provider. Anything that expects to share it - including another"
+          + " provider in this JVM - will not find it there.", name);
       attributes.put(name, value);
     }
   }

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/ServletSecretProviderContext.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/ServletSecretProviderContext.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.hadoop.security.authentication.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.ServletContext;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * Presents a ServletContext to a {@link SignerSecretProvider} as a
+ * {@link SecretProviderContext}.
+ * <p>
+ * Reads and writes go straight through to the ServletContext, so an object a
+ * provider shares this way - the CuratorFramework client of
+ * {@link ZKSignerSecretProvider} - is still a ServletContext attribute under
+ * the same name, and is still found there by everything that looks for it,
+ * including DelegationTokenAuthenticationFilter in hadoop-common.
+ * <p>
+ * This class is the one place in the provider hierarchy that names a servlet
+ * type, and it goes away with the deprecated
+ * {@link SignerSecretProvider#init(java.util.Properties, ServletContext, long)}
+ * it exists to support.
+ */
+@InterfaceStability.Unstable
+@InterfaceAudience.Private
+final class ServletSecretProviderContext implements SecretProviderContext {
+
+  private final ServletContext servletContext;
+
+  private ServletSecretProviderContext(ServletContext servletContext) {
+    this.servletContext = servletContext;
+  }
+
+  /**
+   * Returns a context backed by the given ServletContext, or one backed by a
+   * map of its own when there is no ServletContext.
+   * <p>
+   * Most callers of the deprecated init pass null - only AuthenticationFilter
+   * ever passes a real context - and a provider that does not use the store is
+   * unaffected either way. Handing back a store rather than null keeps a
+   * provider that does use it from having to check.
+   *
+   * @param servletContext the servlet context, or null
+   * @return an attribute store, never null
+   */
+  static SecretProviderContext of(ServletContext servletContext) {
+    return servletContext == null
+        ? new MapSecretProviderContext()
+        : new ServletSecretProviderContext(servletContext);
+  }
+
+  @Override
+  public Object getAttribute(String name) {
+    return servletContext.getAttribute(name);
+  }
+
+  @Override
+  public void setAttribute(String name, Object value) {
+    servletContext.setAttribute(name, value);
+  }
+
+  /**
+   * The store used when there is no ServletContext to write through to.
+   * Attributes live as long as the provider does and are seen by nothing else,
+   * which is what passing a null ServletContext already meant.
+   */
+  private static final class MapSecretProviderContext
+      implements SecretProviderContext {
+
+    private final Map<String, Object> attributes = new HashMap<>();
+
+    @Override
+    public Object getAttribute(String name) {
+      return attributes.get(name);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+      attributes.put(name, value);
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SignerSecretProvider.java
@@ -24,20 +24,66 @@ import org.apache.hadoop.classification.InterfaceStability;
  * do more complicated things in the backend.
  * See the RolloverSignerSecretProvider class for an implementation that
  * supports rolling over the secret at a regular interval.
+ * <p>
+ * Implementations should override
+ * {@link #initialize(Properties, SecretProviderContext, long)}, which names no
+ * servlet type. The older {@link #init(Properties, ServletContext, long)} is
+ * still the entry point callers use and is still honoured when an
+ * implementation overrides it, so providers written against it keep working
+ * unchanged; it is deprecated and will be removed with the move to the jakarta
+ * servlet namespace.
  */
 @InterfaceStability.Unstable
 @InterfaceAudience.Private
 public abstract class SignerSecretProvider {
 
   /**
-   * Initialize the SignerSecretProvider
+   * Initialize the SignerSecretProvider.
+   * <p>
+   * The default implementation adapts the ServletContext to a
+   * {@link SecretProviderContext} and calls
+   * {@link #initialize(Properties, SecretProviderContext, long)}, so a provider
+   * that overrides only that method is initialized correctly through this
+   * entry point. A provider that overrides this method instead is called
+   * directly, as before.
+   *
    * @param config configuration properties
    * @param servletContext servlet context
    * @param tokenValidity The amount of time a token is valid for
    * @throws Exception thrown if an error occurred
+   * @deprecated override
+   *             {@link #initialize(Properties, SecretProviderContext, long)},
+   *             which does not name a servlet type and so is unaffected by
+   *             which servlet namespace the container provides.
    */
-  public abstract void init(Properties config, ServletContext servletContext,
-          long tokenValidity) throws Exception;
+  @Deprecated
+  public void init(Properties config, ServletContext servletContext,
+          long tokenValidity) throws Exception {
+    initialize(config, ServletSecretProviderContext.of(servletContext),
+        tokenValidity);
+  }
+
+  /**
+   * Initialize the SignerSecretProvider against an attribute store.
+   * <p>
+   * The default implementation throws, because a provider has to implement one
+   * of the two initialization methods. It is never reached by a provider that
+   * overrides the deprecated
+   * {@link #init(Properties, ServletContext, long)}, since callers go through
+   * that method and its override does not delegate here.
+   *
+   * @param config configuration properties
+   * @param context the attribute store to initialize against
+   * @param tokenValidity The amount of time a token is valid for
+   * @throws Exception thrown if an error occurred
+   */
+  public void initialize(Properties config, SecretProviderContext context,
+          long tokenValidity) throws Exception {
+    throw new UnsupportedOperationException(getClass().getName()
+        + " implements neither initialize(Properties, SecretProviderContext,"
+        + " long) nor the deprecated init(Properties, ServletContext, long)");
+  }
+
   /**
    * Will be called on shutdown; subclasses should perform any cleanup here.
    */

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SignerSecretProvider.java
@@ -32,6 +32,17 @@ import org.apache.hadoop.classification.InterfaceStability;
  * implementation overrides it, so providers written against it keep working
  * unchanged; it is deprecated and will be removed with the move to the jakarta
  * servlet namespace.
+ * <p>
+ * One consequence for code that reflects over these classes: the providers
+ * shipped here override
+ * {@link #initialize(Properties, SecretProviderContext, long)} rather than
+ * {@link #init(Properties, ServletContext, long)}, so init is no longer among
+ * their declared methods. Calls and overrides are unaffected - init is
+ * inherited from this class and resolves as it always did - but
+ * Class#getDeclaredMethod("init", ...) on a subclass such as
+ * {@link FileSignerSecretProvider} now raises NoSuchMethodException where it
+ * used to succeed. Class#getMethod, which searches superclasses, still finds
+ * it.
  */
 @InterfaceStability.Unstable
 @InterfaceAudience.Private

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/ZKSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/ZKSignerSecretProvider.java
@@ -18,7 +18,6 @@ import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Properties;
 import java.util.Random;
-import javax.servlet.ServletContext;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -100,9 +99,11 @@ public class ZKSignerSecretProvider extends RolloverSignerSecretProvider {
           CONFIG_PREFIX + "disconnect.on.shutdown";
 
   /**
-   * Constant for the ServletContext attribute that can be used for providing a
-   * custom CuratorFramework client. If set ZKSignerSecretProvider will use this
-   * Curator client instead of creating a new one. The providing class is
+   * Constant for the {@link SecretProviderContext} attribute that can be used
+   * for providing a custom CuratorFramework client. In a servlet container that
+   * is the ServletContext attribute of the same name, so the way it is set is
+   * unchanged. If set ZKSignerSecretProvider will use this Curator client
+   * instead of creating a new one. The providing class is
    * responsible for creating and configuring the Curator client (including
    * security and ACLs) in this case.
    */
@@ -159,16 +160,16 @@ public class ZKSignerSecretProvider extends RolloverSignerSecretProvider {
   }
 
   @Override
-  public void init(Properties config, ServletContext servletContext,
+  public void initialize(Properties config, SecretProviderContext context,
           long tokenValidity) throws Exception {
-    Object curatorClientObj = servletContext.getAttribute(
+    Object curatorClientObj = context.getAttribute(
             ZOOKEEPER_SIGNER_SECRET_PROVIDER_CURATOR_CLIENT_ATTRIBUTE);
     if (curatorClientObj != null
             && curatorClientObj instanceof CuratorFramework) {
       client = (CuratorFramework) curatorClientObj;
     } else {
       client = createCuratorClient(config);
-      servletContext.setAttribute(
+      context.setAttribute(
           ZOOKEEPER_SIGNER_SECRET_PROVIDER_CURATOR_CLIENT_ATTRIBUTE, client);
     }
     this.tokenValidity = tokenValidity;

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/StringSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/StringSignerSecretProvider.java
@@ -15,7 +15,6 @@ package org.apache.hadoop.security.authentication.util;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
-import javax.servlet.ServletContext;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -34,7 +33,7 @@ class StringSignerSecretProvider extends SignerSecretProvider {
   public StringSignerSecretProvider() {}
 
   @Override
-  public void init(Properties config, ServletContext servletContext,
+  public void initialize(Properties config, SecretProviderContext context,
           long tokenValidity) throws Exception {
     String signatureSecret = config.getProperty(
             AuthenticationFilter.SIGNATURE_SECRET, null);

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestCertificateUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestCertificateUtil.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 
 import javax.servlet.ServletException;
@@ -45,9 +46,9 @@ public class TestCertificateUtil {
         + "9aTyR+HGHCfvwoCegc9rAVw/DLaRriSO/jnEXzYK6XLVKH+hx5UXrJ7Oyc7JjZUc3g9kCWORThCX"
         + "Mzc1xA==" + "\n-----END CERTIFICATE-----";
     try {
-      CertificateUtil.parseRSAPublicKey(pem);
-      fail("Should not have thrown ServletException");
-    } catch (ServletException se) {
+      CertificateUtil.toRSAPublicKey(pem);
+      fail("Should not have thrown CertificateException");
+    } catch (CertificateException se) {
       assertTrue(se.getMessage().contains("PEM header"));
     }
   }
@@ -66,9 +67,9 @@ public class TestCertificateUtil {
         + "9aTyR+HGHCfvwoCegc9rAVw/DLaRriSO/jnEXzYK6XLVKH+hx5UXrJ7Oyc7JjZUc3g9kCWORThCX"
         + "Mzc1xA++";
     try {
-      CertificateUtil.parseRSAPublicKey(pem);
-      fail("Should not have thrown ServletException");
-    } catch (ServletException se) {
+      CertificateUtil.toRSAPublicKey(pem);
+      fail("Should not have thrown CertificateException");
+    } catch (CertificateException se) {
       assertTrue(se.getMessage().contains("corrupt"));
     }
   }
@@ -87,11 +88,29 @@ public class TestCertificateUtil {
         + "9aTyR+HGHCfvwoCegc9rAVw/DLaRriSO/jnEXzYK6XLVKH+hx5UXrJ7Oyc7JjZUc3g9kCWORThCX"
         + "Mzc1xA==";
     try {
-      RSAPublicKey pk = CertificateUtil.parseRSAPublicKey(pem);
+      RSAPublicKey pk = CertificateUtil.toRSAPublicKey(pem);
       assertNotNull(pk);
       assertEquals("RSA", pk.getAlgorithm());
-    } catch (ServletException se) {
+    } catch (CertificateException se) {
+      fail("Should not have thrown CertificateException");
+    }
+  }
+
+  /**
+   * The deprecated entry point still reports a ServletException, so callers
+   * written against it keep compiling and keep catching what they caught
+   * before.
+   */
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testDeprecatedEntryPointStillThrowsServletException() {
+    String pem = "not a certificate";
+    try {
+      CertificateUtil.parseRSAPublicKey(pem);
       fail("Should not have thrown ServletException");
+    } catch (ServletException se) {
+      assertTrue(se.getMessage().contains("corrupt"));
+      assertTrue(se.getCause() instanceof CertificateException);
     }
   }
 

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestCertificateUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestCertificateUtil.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.security.authentication.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -114,4 +115,36 @@ public class TestCertificateUtil {
     }
   }
 
+  /**
+   * The deprecated entry point reports the CertificateException the parse
+   * raised, not the one toRSAPublicKey wraps it in. Routing through the new
+   * method must not lengthen the chain a caller walks.
+   */
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testDeprecatedEntryPointDoesNotDeepenTheCauseChain() {
+    try {
+      CertificateUtil.parseRSAPublicKey("not a certificate");
+      fail("Should not have thrown ServletException");
+    } catch (ServletException se) {
+      Throwable cause = se.getCause();
+      assertNotNull(cause, "the ServletException should carry a cause");
+      assertTrue(cause instanceof CertificateException,
+          "expected a CertificateException, got " + cause.getClass());
+      assertFalse(cause.getCause() instanceof CertificateException,
+          "the wrapper toRSAPublicKey adds must not appear in the chain;"
+              + " chain was " + chainOf(se));
+    }
+  }
+
+  private static String chainOf(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (sb.length() > 0) {
+        sb.append(" -> ");
+      }
+      sb.append(c.getClass().getSimpleName());
+    }
+    return sb.toString();
+  }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSignerSecretProviderCompatibility.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSignerSecretProviderCompatibility.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.hadoop.security.authentication.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.servlet.ServletContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A SignerSecretProvider written against the deprecated
+ * {@link SignerSecretProvider#init(Properties, ServletContext, long)} must keep
+ * working without being recompiled, because implementations of it live outside
+ * this tree - signer.secret.provider takes a classname.
+ * <p>
+ * These tests pin that contract. They are the reason
+ * {@link SignerSecretProvider#init(Properties, ServletContext, long)} is a
+ * concrete bridge rather than a changed abstract method, and they go when it
+ * does.
+ */
+@SuppressWarnings("deprecation")
+public class TestSignerSecretProviderCompatibility {
+
+  private static final byte[] SECRET =
+      "secret".getBytes(StandardCharsets.UTF_8);
+
+  /**
+   * A provider as it would have been written before SecretProviderContext
+   * existed: it overrides init and takes a ServletContext.
+   */
+  private static final class LegacyProvider extends SignerSecretProvider {
+    private ServletContext seen;
+    private boolean initCalled;
+
+    @Override
+    public void init(Properties config, ServletContext servletContext,
+        long tokenValidity) {
+      this.seen = servletContext;
+      this.initCalled = true;
+    }
+
+    @Override
+    public byte[] getCurrentSecret() {
+      return SECRET;
+    }
+
+    @Override
+    public byte[][] getAllSecrets() {
+      return new byte[][]{SECRET};
+    }
+  }
+
+  /**
+   * The same, extending RolloverSignerSecretProvider and chaining to super as
+   * such a provider is expected to.
+   */
+  private static final class LegacyRolloverProvider
+      extends RolloverSignerSecretProvider {
+    private boolean initCalled;
+
+    @Override
+    public void init(Properties config, ServletContext servletContext,
+        long tokenValidity) throws Exception {
+      this.initCalled = true;
+      super.init(config, servletContext, tokenValidity);
+    }
+
+    @Override
+    protected byte[] generateNewSecret() {
+      return SECRET;
+    }
+  }
+
+  /** A provider written against the servlet-free method. */
+  private static final class ContextProvider extends SignerSecretProvider {
+    private SecretProviderContext seen;
+
+    @Override
+    public void initialize(Properties config, SecretProviderContext context,
+        long tokenValidity) {
+      this.seen = context;
+    }
+
+    @Override
+    public byte[] getCurrentSecret() {
+      return SECRET;
+    }
+
+    @Override
+    public byte[][] getAllSecrets() {
+      return new byte[][]{SECRET};
+    }
+  }
+
+  /** A provider that implements neither method. */
+  private static final class UninitializableProvider extends SignerSecretProvider {
+    @Override
+    public byte[] getCurrentSecret() {
+      return SECRET;
+    }
+
+    @Override
+    public byte[][] getAllSecrets() {
+      return new byte[][]{SECRET};
+    }
+  }
+
+  @Test
+  public void testLegacyProviderStillReceivesTheServletContext()
+      throws Exception {
+    ServletContext servletContext = mock(ServletContext.class);
+    LegacyProvider provider = new LegacyProvider();
+
+    provider.init(new Properties(), servletContext, 1000);
+
+    assertTrue(provider.initCalled, "the legacy override should have run");
+    assertSame(servletContext, provider.seen);
+  }
+
+  @Test
+  public void testLegacyRolloverProviderIsStillRolledOver() throws Exception {
+    LegacyRolloverProvider provider = new LegacyRolloverProvider();
+    try {
+      provider.init(new Properties(), mock(ServletContext.class), 100000);
+
+      // The override ran, and chaining to super still reached
+      // RolloverSignerSecretProvider.initialize, which seeds the secret. Were
+      // the bridge dispatched statically, this would silently be null.
+      assertTrue(provider.initCalled, "the legacy override should have run");
+      assertArrayEquals(SECRET, provider.getCurrentSecret());
+    } finally {
+      provider.destroy();
+    }
+  }
+
+  @Test
+  public void testContextProviderIsReachedThroughTheDeprecatedEntryPoint()
+      throws Exception {
+    Map<String, Object> attributes = new HashMap<>();
+    ServletContext servletContext = mock(ServletContext.class);
+    when(servletContext.getAttribute("a"))
+        .thenAnswer(invocation -> attributes.get("a"));
+
+    ContextProvider provider = new ContextProvider();
+    provider.init(new Properties(), servletContext, 1000);
+
+    assertNotNull(provider.seen, "initialize should have been called");
+
+    // Writes reach the real ServletContext, so an object a provider shares
+    // this way is still found there by everything that looks for it.
+    provider.seen.setAttribute("a", "value");
+    org.mockito.Mockito.verify(servletContext).setAttribute("a", "value");
+  }
+
+  @Test
+  public void testNullServletContextYieldsAUsableStore() throws Exception {
+    ContextProvider provider = new ContextProvider();
+    provider.init(new Properties(), null, 1000);
+
+    assertNotNull(provider.seen,
+        "a null ServletContext should still yield a store");
+    provider.seen.setAttribute("a", "value");
+    assertSame("value", provider.seen.getAttribute("a"));
+    assertFalse(provider.seen instanceof ServletSecretProviderContext);
+  }
+
+  @Test
+  public void testProviderImplementingNeitherMethodFailsLoudly() {
+    UninitializableProvider provider = new UninitializableProvider();
+
+    UnsupportedOperationException e =
+        assertThrows(UnsupportedOperationException.class,
+            () -> provider.init(new Properties(), null, 1000));
+    assertTrue(e.getMessage().contains(UninitializableProvider.class.getName()));
+  }
+}

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSignerSecretProviderCompatibility.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSignerSecretProviderCompatibility.java
@@ -16,6 +16,7 @@ package org.apache.hadoop.security.authentication.util;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -186,6 +187,33 @@ public class TestSignerSecretProviderCompatibility {
     provider.seen.setAttribute("a", "value");
     assertSame("value", provider.seen.getAttribute("a"));
     assertFalse(provider.seen instanceof ServletSecretProviderContext);
+  }
+
+  /**
+   * A provider that shares an object through the store - which in this tree
+   * means ZKSignerSecretProvider and its Curator client - gets a store private
+   * to itself when there is no ServletContext, so a second provider does not
+   * find what the first one put there. That is a real change from the
+   * NullPointerException a null ServletContext used to raise, so it is pinned
+   * here rather than left to be discovered.
+   */
+  @Test
+  public void testNullServletContextDoesNotShareBetweenProviders()
+      throws Exception {
+    ContextProvider first = new ContextProvider();
+    ContextProvider second = new ContextProvider();
+    first.init(new Properties(), null, 1000);
+    second.init(new Properties(), null, 1000);
+
+    first.seen.setAttribute("shared", "from-first");
+
+    assertNull(second.seen.getAttribute("shared"),
+        "a store backed by no ServletContext is private to its provider");
+    assertTrue(
+        first.seen instanceof ServletSecretProviderContext
+            .MapSecretProviderContext,
+        "expected the private map store, got "
+            + first.seen.getClass().getName());
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -128,8 +128,8 @@
       depending on which jar happened to come first on the classpath.
     -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -93,11 +93,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet.jsp</groupId>
-      <artifactId>jakarta.servlet.jsp-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
       <scope>compile</scope>
@@ -125,6 +120,17 @@
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <!--
+      HttpServer2 and the filters around it are written against javax.servlet.
+      The API used to arrive only as a transitive of jetty-server; it is declared
+      here so the module states which servlet API it compiles against instead of
+      depending on which jar happened to come first on the classpath.
+    -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/hadoop-common-project/hadoop-kms/pom.xml
+++ b/hadoop-common-project/hadoop-kms/pom.xml
@@ -69,8 +69,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/hadoop-common-project/hadoop-nfs/pom.xml
+++ b/hadoop-common-project/hadoop-nfs/pom.xml
@@ -59,8 +59,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
@@ -63,8 +63,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/pom.xml
@@ -149,8 +149,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>${transient.protobuf2.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -142,8 +142,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>${transient.protobuf2.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -104,11 +104,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-    <!-- JobEndNotifier uses org.eclipse.jetty.util.log.Log -->
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -104,6 +104,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <!-- JobEndNotifier uses org.eclipse.jetty.util.log.Log -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -136,7 +136,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/JobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/JobEndNotifier.java
@@ -32,7 +32,8 @@ import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.mapreduce.CustomJobEndNotifier;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.v2.api.records.JobReport;
-import org.eclipse.jetty.util.log.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>This class handles job end notification. Submitters of jobs can choose to
@@ -48,6 +49,9 @@ import org.eclipse.jetty.util.log.Log;
  * (eg. SUCCEEDED/KILLED/FAILED) </li> </ul>
  */
 public class JobEndNotifier implements Configurable {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(JobEndNotifier.class);
+
   private static final String JOB_ID = "$jobId";
   private static final String JOB_STATUS = "$jobStatus";
 
@@ -109,11 +113,11 @@ public class JobEndNotifier implements Configurable {
         int port = Integer.parseInt(portConf);
         proxyToUse = new Proxy(proxyType,
           new InetSocketAddress(hostname, port));
-        Log.getLog().info("Job end notification using proxy type \""
+        LOG.info("Job end notification using proxy type \""
             + proxyType + "\" hostname \"" + hostname + "\" and port \"" + port
             + "\"");
       } catch(NumberFormatException nfe) {
-        Log.getLog().warn("Job end notification couldn't parse configured"
+        LOG.warn("Job end notification couldn't parse configured"
             + "proxy's port " + portConf + ". Not going to use a proxy");
       }
     }
@@ -141,24 +145,24 @@ public class JobEndNotifier implements Configurable {
   private boolean notifyViaBuiltInNotifier() {
     boolean success = false;
     try {
-      Log.getLog().info("Job end notification trying " + urlToNotify);
+      LOG.info("Job end notification trying " + urlToNotify);
       HttpURLConnection conn =
         (HttpURLConnection) urlToNotify.openConnection(proxyToUse);
       conn.setConnectTimeout(timeout);
       conn.setReadTimeout(timeout);
       conn.setAllowUserInteraction(false);
       if(conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
-        Log.getLog().warn("Job end notification to " + urlToNotify
+        LOG.warn("Job end notification to " + urlToNotify
             + " failed with code: " + conn.getResponseCode() + " and message \""
             + conn.getResponseMessage() + "\"");
       }
       else {
         success = true;
-        Log.getLog().info("Job end notification to " + urlToNotify
+        LOG.info("Job end notification to " + urlToNotify
             + " succeeded");
       }
     } catch(IOException ioe) {
-      Log.getLog().warn("Job end notification to " + urlToNotify + " failed",
+      LOG.warn("Job end notification to " + urlToNotify + " failed",
           ioe);
     }
     return success;
@@ -169,7 +173,7 @@ public class JobEndNotifier implements Configurable {
    */
   private boolean notifyViaCustomNotifier() {
     try {
-      Log.getLog().info("Will be using " + customJobEndNotifierClassName
+      LOG.info("Will be using " + customJobEndNotifierClassName
                         + " for Job end notification");
 
       final Class<? extends CustomJobEndNotifier> customJobEndNotifierClass =
@@ -180,15 +184,15 @@ public class JobEndNotifier implements Configurable {
 
       boolean success = customJobEndNotifier.notifyOnce(urlToNotify, conf);
       if (success) {
-        Log.getLog().info("Job end notification to " + urlToNotify
+        LOG.info("Job end notification to " + urlToNotify
                           + " succeeded");
       } else {
-        Log.getLog().warn("Job end notification to " + urlToNotify
+        LOG.warn("Job end notification to " + urlToNotify
                           + " failed");
       }
       return success;
     } catch (Exception e) {
-      Log.getLog().warn("Job end notification to " + urlToNotify
+      LOG.warn("Job end notification to " + urlToNotify
                         + " failed", e);
       return false;
     }
@@ -215,24 +219,24 @@ public class JobEndNotifier implements Configurable {
     try {
       urlToNotify = new URL(userUrl);
     } catch (MalformedURLException mue) {
-      Log.getLog().warn("Job end notification couldn't parse " + userUrl, mue);
+      LOG.warn("Job end notification couldn't parse " + userUrl, mue);
       return;
     }
 
     // Send notification
     boolean success = false;
     while (numTries-- > 0 && !success) {
-      Log.getLog().info("Job end notification attempts left " + numTries);
+      LOG.info("Job end notification attempts left " + numTries);
       success = notifyURLOnce();
       if (!success) {
         Thread.sleep(waitInterval);
       }
     }
     if (!success) {
-      Log.getLog().warn("Job end notification failed to notify : "
+      LOG.warn("Job end notification failed to notify : "
           + urlToNotify);
     } else {
-      Log.getLog().info("Job end notification succeeded for "
+      LOG.info("Job end notification succeeded for "
           + jobReport.getJobId());
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/pom.xml
@@ -55,6 +55,11 @@
       <groupId>${leveldbjni.group}</groupId>
       <artifactId>leveldbjni-all</artifactId>
     </dependency>
+    <!-- ShuffleChannelHandler uses org.eclipse.jetty.http.HttpHeader -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/pom.xml
@@ -55,11 +55,6 @@
       <groupId>${leveldbjni.group}</groupId>
       <artifactId>leveldbjni-all</artifactId>
     </dependency>
-    <!-- ShuffleChannelHandler uses org.eclipse.jetty.http.HttpHeader -->
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleChannelHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleChannelHandler.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.SecureIOUtils;
 import org.apache.hadoop.mapreduce.security.SecureShuffleUtils;
 import org.apache.hadoop.mapreduce.task.reduce.ShuffleHeader;
-import org.eclipse.jetty.http.HttpHeader;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -128,6 +127,15 @@ import static org.apache.hadoop.mapred.ShuffleHandler.LOG;
  * </pre>
  */
 public class ShuffleChannelHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+  /**
+   * Spelled out rather than taken from a library so that the bytes on the wire
+   * do not depend on which library supplies the constant: Netty's
+   * HttpHeaderNames and HttpHeaderValues are lowercase AsciiStrings, and these
+   * headers have been sent capitalised since this handler was written.
+   */
+  static final String CONNECTION = "Connection";
+  static final String KEEP_ALIVE = "Keep-Alive";
+
   private final ShuffleChannelHandlerContext handlerCtx;
 
   ShuffleChannelHandler(ShuffleChannelHandlerContext ctx) {
@@ -420,11 +428,10 @@ public class ShuffleChannelHandler extends SimpleChannelInboundHandler<FullHttpR
   protected void setResponseHeaders(HttpResponse response,
                                     boolean keepAliveParam, long contentLength) {
     if (!handlerCtx.connectionKeepAliveEnabled && !keepAliveParam) {
-      response.headers().set(HttpHeader.CONNECTION.asString(), CONNECTION_CLOSE);
+      response.headers().set(CONNECTION, CONNECTION_CLOSE);
     } else {
-      response.headers().set(HttpHeader.CONNECTION.asString(),
-          HttpHeader.KEEP_ALIVE.asString());
-      response.headers().set(HttpHeader.KEEP_ALIVE.asString(),
+      response.headers().set(CONNECTION, KEEP_ALIVE);
+      response.headers().set(KEEP_ALIVE,
           "timeout=" + handlerCtx.connectionKeepAliveTimeOut);
     }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleChannelHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleChannelHandler.java
@@ -81,7 +81,6 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
-import org.eclipse.jetty.http.HttpHeader;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
@@ -371,10 +370,11 @@ public class TestShuffleChannelHandler extends TestShuffleHandlerBase {
       headers.set(ShuffleHeader.HTTP_HEADER_NAME, ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
       headers.set(ShuffleHeader.HTTP_HEADER_VERSION, ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       if (keepAlive) {
-        headers.set(HttpHeader.CONNECTION.asString(), HttpHeader.KEEP_ALIVE.asString());
-        headers.set(HttpHeader.KEEP_ALIVE.asString(), "timeout=" + ctx.connectionKeepAliveTimeOut);
+        headers.set(ShuffleChannelHandler.CONNECTION,
+            ShuffleChannelHandler.KEEP_ALIVE);
+        headers.set(ShuffleChannelHandler.KEEP_ALIVE, "timeout=" + ctx.connectionKeepAliveTimeOut);
       } else {
-        response.headers().set(HttpHeader.CONNECTION.asString(), CONNECTION_CLOSE);
+        response.headers().set(ShuffleChannelHandler.CONNECTION, CONNECTION_CLOSE);
       }
       HttpUtil.setContentLength(response, contentLength);
       return response;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/pom.xml
@@ -161,7 +161,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
         <exclusions>
             <exclusion>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/pom.xml
@@ -101,7 +101,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -37,6 +37,12 @@
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <jetty.version>9.4.58.v20250814</jetty.version>
+    <!--
+      Jetty's build of the Servlet 4.0 API. The classes are javax.servlet, the
+      same ones jakarta.servlet:jakarta.servlet-api:4.0.x publishes; this is the
+      coordinate jetty-ee8 depends on, and 4.0.9 is the version Jetty 12 pins.
+    -->
+    <jetty-servlet-api.version>4.0.9</jetty-servlet-api.version>
     <test.exclude>_</test.exclude>
     <test.exclude.pattern>_</test.exclude.pattern>
 
@@ -969,9 +975,9 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.servlet</groupId>
-        <artifactId>jakarta.servlet-api</artifactId>
-        <version>4.0.4</version>
+        <groupId>org.eclipse.jetty.toolchain</groupId>
+        <artifactId>jetty-servlet-api</artifactId>
+        <version>${jetty-servlet-api.version}</version>
       </dependency>
 
       <dependency>
@@ -2191,11 +2197,30 @@
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>jersey-test-framework-core</artifactId>
         <version>${jersey2.version}</version>
+        <exclusions>
+          <!--
+            It declares the servlet API under the jakarta.servlet coordinate.
+            Those are the same javax.servlet classes jetty-servlet-api carries,
+            so letting it through puts two of them on the test classpath and
+            which one a module compiles against comes down to jar order.
+          -->
+          <exclusion>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
         <version>${jersey2.version}</version>
+        <exclusions>
+          <!-- Reaches the servlet API again through jersey-test-framework-core. -->
+          <exclusion>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -928,18 +928,6 @@
         <artifactId>jetty-http</artifactId>
         <version>${jetty.version}</version>
       </dependency>
-      <!--
-        Not declared by any Hadoop module. It is managed here because
-        jersey-test-framework-provider-jetty drags it onto the test classpath of
-        around twenty modules at its own, older Jetty release, and Jersey's
-        JettyHttpContainer needs the class at run time so it cannot simply be
-        excluded. Managing it keeps every module on ${jetty.version}.
-      -->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-continuation</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
@@ -2206,14 +2194,8 @@
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-        <artifactId>jersey-test-framework-provider-jetty</artifactId>
+        <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
         <version>${jersey2.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -909,7 +909,36 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>javax.servlet-api</artifactId>
           </exclusion>
+          <!--
+            The exclusion above names a group jetty-server has never used, so it
+            matches nothing. The real coordinates are javax.servlet, and without
+            this that API lands on the classpath beside the managed
+            jakarta.servlet-api; both publish the javax.servlet packages, so
+            which one a module compiles and runs against comes down to the order
+            of the jars.
+          -->
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <!--
+        Not declared by any Hadoop module. It is managed here because
+        jersey-test-framework-provider-jetty drags it onto the test classpath of
+        around twenty modules at its own, older Jetty release, and Jersey's
+        JettyHttpContainer needs the class at run time so it cannot simply be
+        excluded. Managing it keeps every module on ${jetty.version}.
+      -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-continuation</artifactId>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -939,17 +968,17 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
           </exclusion>
+          <!-- Reaches the servlet API again through websocket-servlet. -->
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-client</artifactId>
         <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.servlet.jsp</groupId>
-        <artifactId>jakarta.servlet.jsp-api</artifactId>
-        <version>2.3.6</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>

--- a/hadoop-tools/hadoop-resourceestimator/pom.xml
+++ b/hadoop-tools/hadoop-resourceestimator/pom.xml
@@ -71,8 +71,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/hadoop-tools/hadoop-resourceestimator/pom.xml
+++ b/hadoop-tools/hadoop-resourceestimator/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jetty</artifactId>
+            <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -189,6 +189,53 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-alpn-client</artifactId>
                 </exclusion>
+                <!--
+                  Solr reaches these tests only through EmbeddedSolrServer, which
+                  runs no servlet container, so Solr's own Jetty stack is dead
+                  weight. It also lags Hadoop's managed Jetty by several releases,
+                  which is what put two Jetty releases on this module's test
+                  classpath. Excluding it leaves only ${jetty.version}.
+                -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-java-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-continuation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-deploy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-jmx</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-rewrite</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlets</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.http2</groupId>
+                    <artifactId>http2-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
@@ -241,6 +288,53 @@
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-alpn-client</artifactId>
+                </exclusion>
+                <!--
+                  Solr reaches these tests only through EmbeddedSolrServer, which
+                  runs no servlet container, so Solr's own Jetty stack is dead
+                  weight. It also lags Hadoop's managed Jetty by several releases,
+                  which is what put two Jetty releases on this module's test
+                  classpath. Excluding it leaves only ${jetty.version}.
+                -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-java-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-continuation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-deploy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-jmx</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-rewrite</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlets</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.http2</groupId>
+                    <artifactId>http2-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>commons-collections</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/pom.xml
@@ -136,8 +136,8 @@
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/main/java/org/apache/hadoop/yarn/service/client/ApiServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/main/java/org/apache/hadoop/yarn/service/client/ApiServiceClient.java
@@ -21,6 +21,8 @@ import static org.apache.hadoop.yarn.service.utils.ServiceApiUtil.jsonSerDeser;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +64,6 @@ import org.apache.hadoop.yarn.service.api.records.ServiceStatus;
 import org.apache.hadoop.yarn.service.conf.RestApiConstants;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.util.RMHAUtils;
-import org.eclipse.jetty.util.UrlEncoded;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,8 +227,8 @@ public class ApiServiceClient extends AppAdminClient {
         .equalsIgnoreCase("simple")) {
       String username = UserGroupInformation.getCurrentUser()
             .getShortUserName();
-      builder.append("?user.name=").append(UrlEncoded
-          .encodeString(username));
+      builder.append("?user.name=").append(
+          URLEncoder.encode(username, StandardCharsets.UTF_8));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/main/java/org/apache/hadoop/yarn/service/client/ApiServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/main/java/org/apache/hadoop/yarn/service/client/ApiServiceClient.java
@@ -227,6 +227,11 @@ public class ApiServiceClient extends AppAdminClient {
         .equalsIgnoreCase("simple")) {
       String username = UserGroupInformation.getCurrentUser()
             .getShortUserName();
+      // Not byte-for-byte what Jetty's UrlEncoded produced: it left '~'
+      // literal and escaped '*', and URLEncoder does the opposite. Both forms
+      // decode to the same user name, so what the server reads is unchanged;
+      // every other character a short user name can hold, '@' and non-ASCII
+      // among them, encodes identically.
       builder.append("?user.name=").append(
           URLEncoder.encode(username, StandardCharsets.UTF_8));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -65,8 +65,8 @@
       <artifactId>commons-compress</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -148,7 +148,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -38,8 +38,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -107,7 +107,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -53,6 +53,21 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-annotations</artifactId>
     </dependency>
+
+    <!-- ApplicationHistoryServer uses org.eclipse.jetty.webapp.WebAppContext and
+         org.eclipse.jetty.servlet.FilterHolder. Declared provided, matching the
+         scope they already resolve at through the provided hadoop-common above. -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
@@ -119,8 +119,8 @@
       <artifactId>leveldbjni-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.cache</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
@@ -124,8 +124,8 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
 
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
@@ -119,7 +119,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -70,8 +70,8 @@
       <artifactId>jettison</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -203,7 +203,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
@@ -33,8 +33,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
@@ -244,7 +244,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
@@ -60,6 +60,20 @@
       <artifactId>hadoop-yarn-server-common</artifactId>
     </dependency>
 
+    <!-- Router serves the UI2 war through org.eclipse.jetty.webapp.WebAppContext.
+         Declared at compile scope, since a test scope would override the
+         compile-scoped copy inherited here and take it off the Router's own
+         runtime classpath. jetty-server, jetty-servlet and jetty-util are named
+         by the tests but deliberately left undeclared: they already arrive
+         through jetty-webapp at the same version and scope, and declaring
+         jetty-server directly moves the javax.servlet-api it carries behind
+         jakarta.servlet-api on the classpath, which silently changes which
+         servlet API the module resolves. -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-common</artifactId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -222,7 +222,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-          <artifactId>jersey-test-framework-provider-jetty</artifactId>
+          <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.glassfish.jersey.test-framework</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/pom.xml
@@ -88,8 +88,8 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
     </dependency>
 
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
@@ -123,7 +123,7 @@
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
@@ -33,8 +33,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->


### PR DESCRIPTION
### Description of PR

Stacked on #8699 (HADOOP-19970). **The first two commits belong to that PR — review the last five.**

Hadoop will eventually move from `javax.servlet` to `jakarta.servlet`. When it does, every class that mentions a servlet type has to be revisited, and every class that mentions a Jetty type has to be revisited again when the Jetty API changes underneath it.

Several of those classes have no real connection to either. A component that generates signing secrets was handed the web server's context even though it only wanted somewhere to stash an object. A certificate parser reported a bad certificate as a web server error. A file-transfer handler built on Netty borrowed two header names from Jetty.

This clears those cases out, so the later migration is smaller and the classes concerned stop being part of it.

| | before | after |
|---|---|---|
| modules using Jetty in main sources | 13 | 12 |
| main-source files using Jetty | 25 | 23 |
| hadoop-auth main classes naming a servlet | 14 | 11 |

The MapReduce shuffle module stops depending on Jetty altogether, in code and in its build file. In hadoop-auth, the secret providers and the authentication token no longer mention the servlet API; they are initialised instead against a small two-method store that holds whatever needs sharing, which is all the one provider that used the servlet context was ever doing with it. One new class does mention the servlet API, and exists solely to keep the old path working. The YARN services client and the shuffle handler each replaced a small Jetty utility with the equivalent from the JDK or from Netty.

**Nothing breaks.** No public signature is removed or changed, and no dependency, version or setting changes. Code built against today's release keeps compiling and keeps running without being rebuilt. `SignerSecretProvider.init` and `CertificateUtil.parseRSAPublicKey` stay, deprecated, and stay the entry points callers use; a cleaner alternative sits alongside each. Both deprecated methods go with the namespace change, where they have to change anyway.

The shuffle protocol is untouched, byte for byte.

Deliberately out of scope: no namespace change, no Jetty upgrade, no Jersey change, no EE environments — the tree stays on Jetty 9.4, Jersey 2 and `javax.servlet` throughout. The authentication handler classes still mention the servlet API, because they sit on the extension point HBase, Hive, Spark, Ozone and Knox build against; changing that is precisely the break this avoids, and it belongs with the namespace change.

This works whether HADOOP-19912 goes through Jetty 12's ee8 environment or straight to ee10, and commits the project to neither.

### How was this patch tested?

`TestSignerSecretProviderCompatibility` is new and exists to prove the deprecated path still behaves — a provider written against the old entry point is still called, still receives the real `ServletContext`, and a provider extending `RolloverSignerSecretProvider` that chains to `super` still has its rollover scheduler started. `TestCertificateUtil` asserts the deprecated method still reports the exception it always did.

`AuthenticationFilter`, `TestAuthenticationFilter` and `TestZKSignerSecretProvider` are unchanged from trunk, which is the clearest evidence the change is compatible.

hadoop-auth: 52 tests, 0 failures. `TestShuffleChannelHandler`: 8 tests, 0 failures.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

No dependencies are added or removed; one is dropped from the shuffle module's pom.

### AI Tooling

Contains content generated by Claude.

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html