### PR TITLE
YARN-11963. Retain all deletion tasks in rolling log aggregation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
@@ -332,7 +332,7 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
     LOG.debug("Cycle #{} of log aggregator", logAggregationTimes);
     String diagnosticMessage = "";
     boolean logAggregationSucceedInThisCycle = true;
-    DeletionTask deletionTask = null;
+    List<DeletionTask> deletionTasks = new ArrayList<>();
     try {
       try {
         logAggregationFileController.initializeWriter(logControllerContext);
@@ -374,8 +374,9 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
                 }
               }
             }
-            deletionTask = new FileDeletionTask(delService, this.userUgi.getShortUserName(), null,
-                uploadedFilePathsInThisCycleList);
+            deletionTasks.add(new FileDeletionTask(delService,
+                this.userUgi.getShortUserName(), null,
+                uploadedFilePathsInThisCycleList));
           }
         }
 
@@ -411,8 +412,10 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
         logAggregationSucceedInThisCycle = false;
         exc = e;
       }
-      if (logAggregationSucceedInThisCycle && deletionTask != null) {
-        delService.delete(deletionTask);
+      if (logAggregationSucceedInThisCycle) {
+        for (DeletionTask deletionTask : deletionTasks) {
+          delService.delete(deletionTask);
+        }
       }
       if (diagnosticMessage != null && !diagnosticMessage.isEmpty()) {
         LOG.debug("Sending log aggregation report along with the " +

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestAppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestAppLogAggregatorImpl.java
@@ -69,6 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -178,6 +179,112 @@ public class TestAppLogAggregatorImpl {
     verifyLogAggregationWithExpectedFiles2DeleteAndUpload(
         applicationId, containerId, week, recoveredLogInitedTimeMillis,
         logFiles, new HashSet<File>());
+  }
+
+  /**
+   * Regression test for YARN-11963. A single aggregation cycle that covers
+   * more than one container must schedule the deletion of the uploaded log
+   * files of every container in the cycle, not just those of the container
+   * that happened to be processed last.
+   */
+  @Test
+  public void testAggregatorDeletesUploadedLogsOfEveryContainerInACycle()
+      throws Exception {
+    final ApplicationId applicationId =
+        ApplicationId.newInstance(System.currentTimeMillis(), 0);
+    final ApplicationAttemptId attemptId =
+        ApplicationAttemptId.newInstance(applicationId, 0);
+    final ContainerId firstContainerId =
+        ContainerId.newContainerId(attemptId, 1);
+    final ContainerId secondContainerId =
+        ContainerId.newContainerId(attemptId, 2);
+
+    // create artificial log files for two distinct containers
+    final File appLogDir = new File(LOCAL_LOG_DIR, applicationId.toString());
+    final File firstContainerLogDir =
+        new File(appLogDir, firstContainerId.toString());
+    final File secondContainerLogDir =
+        new File(appLogDir, secondContainerId.toString());
+    firstContainerLogDir.mkdirs();
+    secondContainerLogDir.mkdirs();
+    final Set<File> firstContainerLogFiles =
+        createContainerLogFiles(firstContainerLogDir, 3);
+    final Set<File> secondContainerLogFiles =
+        createContainerLogFiles(secondContainerLogDir, 3);
+
+    final Set<String> filesExpected2Delete = new HashSet<>();
+    for (File file: firstContainerLogFiles) {
+      filesExpected2Delete.add(file.getAbsolutePath());
+    }
+    for (File file: secondContainerLogFiles) {
+      filesExpected2Delete.add(file.getAbsolutePath());
+    }
+
+    // Collect the paths of every deletion task scheduled during the cycle.
+    // Checking only the first invocation of delete() would not catch the
+    // bug: the buggy implementation kept a single DeletionTask reference
+    // that each container overwrote, so it still issued one delete() call -
+    // just with the wrong, and incomplete, set of paths.
+    final Set<String> filesActually2Delete = new HashSet<>();
+    final DeletionService deletionService =
+        createDeletionServiceCapturingAllDeletions(filesActually2Delete);
+
+    final YarnConfiguration config = new YarnConfiguration();
+    config.setLong(YarnConfiguration.LOG_AGGREGATION_RETAIN_SECONDS, 10000);
+
+    LogAggregationTFileController format =
+        spy(new LogAggregationTFileController());
+    format.initialize(config, "TFile");
+
+    final Context context = createContext(config);
+    final AppLogAggregatorInTest appLogAggregator =
+        createAppLogAggregator(applicationId, LOCAL_LOG_DIR.getAbsolutePath(),
+            config, context, -1, deletionService, format);
+
+    appLogAggregator.startContainerLogAggregation(
+        new ContainerLogContext(firstContainerId, ContainerType.TASK, 0));
+    appLogAggregator.startContainerLogAggregation(
+        new ContainerLogContext(secondContainerId, ContainerType.TASK, 0));
+    // set app finished flag first
+    appLogAggregator.finishLogAggregation();
+    appLogAggregator.run();
+
+    // Assert containment rather than set equality: on top of the per
+    // container deletion tasks, the aggregator also schedules the
+    // application log directory itself for cleanup once the application
+    // has finished.
+    for (String file: filesExpected2Delete) {
+      assertTrue(filesActually2Delete.contains(file),
+          "Expected the uploaded log file " + file + " to be scheduled for "
+              + "deletion, but the scheduled paths were "
+              + filesActually2Delete);
+    }
+  }
+
+  /**
+   * Create a DeletionService that records the paths of every FileDeletionTask
+   * handed to its delete method, across all invocations, into the given set.
+   * @param deletedPaths the set collecting the absolute paths seen
+   * @return the recording DeletionService mock
+   */
+  private static DeletionService createDeletionServiceCapturingAllDeletions(
+      final Set<String> deletedPaths) {
+    DeletionService recordingDeletionService = mock(DeletionService.class);
+    doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocationOnMock) {
+          for (Object taskArgument: invocationOnMock.getArguments()) {
+            FileDeletionTask task = (FileDeletionTask) taskArgument;
+            for (Path path: task.getBaseDirs()) {
+              deletedPaths.add(
+                  new File(path.toUri().getRawPath()).getAbsolutePath());
+            }
+          }
+          return null;
+        }
+      }).when(recordingDeletionService).delete(any(FileDeletionTask.class));
+
+    return recordingDeletionService;
   }
 
   /**


### PR DESCRIPTION
### Description of PR

Fixes YARN-11963. Rolling log aggregation leaked local container log files
because `AppLogAggregatorImpl` reused a single `DeletionTask` variable inside
the per-container loop, overwriting it on each iteration. Only the last
container's log directory was ever scheduled for deletion, so files for every
earlier container in the same aggregation cycle were left on disk.

The fix collects one `FileDeletionTask` per container into a
`List<DeletionTask>` and, when aggregation succeeds, submits every task in the
list from the `finally` block instead of a single overwritten reference.

### How was this patch tested?

Added `testAggregatorDeletesUploadedLogsOfEveryContainerInACycle` to
`TestAppLogAggregatorImpl`. It starts two containers with distinct log files in
a single aggregation cycle and asserts that the uploaded files of both are
scheduled for deletion. The test uses a recording `DeletionService` that
accumulates `FileDeletionTask#getBaseDirs()` across every invocation. It asserts
containment rather than set equality, because the aggregator also schedules the
application log directory itself for cleanup once the application finishes.

Against the single-variable implementation the test fails:

```
Expected the uploaded log file .../container_..._000001/logfile2 to be
scheduled for deletion, but the scheduled paths were
[.../application_..., .../container_..._000002/logfile0,
 .../container_..._000002/logfile1, .../container_..._000002/logfile2]
```

With the patch the full class passes, 5/5. Checkstyle on the module reports no
new violations. CI: `test4tests` is +1 and `unit` passed the
`hadoop-yarn-server-nodemanager` module.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0? (no new dependencies)
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? (not applicable)
