### PR TITLE
HDFS-17971. Fix RAT check failure for vendored JSON.java in hadoop-hdfs-rbf.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -332,6 +332,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <exclude>.gitattributes</exclude>
             <exclude>.idea/**</exclude>
             <exclude>dev-support/findbugsExcludeFile.xml</exclude>
+            <exclude>src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/JSON.java</exclude>
             <exclude>src/main/webapps/router/robots.txt</exclude>
             <exclude>src/site/resources/images/*</exclude>
           </excludes>


### PR DESCRIPTION
### Description of PR

HDFS-17971. Fix RAT check failure for vendored JSON.java in hadoop-hdfs-rbf.

The Apache RAT check fails in the `hadoop-hdfs-rbf` module 
because `src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/JSON.java`
is reported as an unapproved license file.

This class was copied from Jetty and intentionally retains its original dual EPL/Apache license header. It is already documented in `LICENSE.txt` and excluded from the root-level RAT check. 
However, `hadoop-hdfs-rbf` defines its own RAT exclusion list, which did not include this file.

This patch adds `JSON.java` to the module-level RAT exclusion list. It does not modify the source file or its original license header.

This is a follow-up to HADOOP-19951 and apache/hadoop#8654.

### How was this patch tested?

The failure was reproduced before applying the patch:

```text
Unapproved: 1, unknown: 1
BUILD FAILURE
```

The following command was run after applying the patch:

```
./mvnw -pl hadoop-hdfs-project/hadoop-hdfs-rbf \
  -DskipTests apache-rat:check
```

Result:

```
Unapproved: 0, unknown: 0
BUILD SUCCESS
```

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
