### PR TITLE
HADOOP-19977. winutils: GetFileInformationByName collides with Windows SDK 10.0.26100

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/winutils/chmod.c
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/chmod.c
@@ -367,10 +367,10 @@ static BOOL ParseCommandLineArguments(
       // Check if the given path name is a file or directory
       // Only set recursive flag if the given path is a directory
       //
-      dwRtnCode = GetFileInformationByName(*path, FALSE, &fileInfo);
+      dwRtnCode = GetFileInformationByPathName(*path, FALSE, &fileInfo);
       if (dwRtnCode != ERROR_SUCCESS)
       {
-        ReportErrorCode(L"GetFileInformationByName", dwRtnCode);
+        ReportErrorCode(L"GetFileInformationByPathName", dwRtnCode);
         return FALSE;
       }
 

--- a/hadoop-common-project/hadoop-common/src/main/winutils/hardlink.c
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/hardlink.c
@@ -94,7 +94,8 @@ static DWORD HardlinkStat(__in LPCWSTR fileName, __out DWORD *puHardLinkCount)
 
   // Get file information which contains the hard link count
   //
-  dwErrorCode = GetFileInformationByName(longFileName, FALSE, &fileInformation);
+  dwErrorCode = GetFileInformationByPathName(
+    longFileName, FALSE, &fileInformation);
   if (dwErrorCode != ERROR_SUCCESS)
   {
     goto HardlinkStatExit;

--- a/hadoop-common-project/hadoop-common/src/main/winutils/include/winutils.h
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/include/winutils.h
@@ -126,7 +126,7 @@ void ReadlinkUsage();
 int SystemInfo();
 void SystemInfoUsage();
 
-DWORD GetFileInformationByName(__in LPCWSTR pathName,  __in BOOL followLink,
+DWORD GetFileInformationByPathName(__in LPCWSTR pathName,  __in BOOL followLink,
   __out LPBY_HANDLE_FILE_INFORMATION lpFileInformation);
 
 DWORD CheckAccessForCurrentUser(

--- a/hadoop-common-project/hadoop-common/src/main/winutils/libwinutils.c
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/libwinutils.c
@@ -71,7 +71,7 @@ const ACCESS_MASK WinMasks[WIN_MASKS_TOTAL] =
 };
 
 //----------------------------------------------------------------------------
-// Function: GetFileInformationByName
+// Function: GetFileInformationByPathName
 //
 // Description:
 //  To retrieve the by handle file information given the file name
@@ -85,7 +85,7 @@ const ACCESS_MASK WinMasks[WIN_MASKS_TOTAL] =
 //  or junction point to get the target file information. Otherwise, the
 //  information for the symbolic link or junction point is retrieved.
 //
-DWORD GetFileInformationByName(
+DWORD GetFileInformationByPathName(
   __in LPCWSTR pathName,
   __in BOOL followLink,
   __out LPBY_HANDLE_FILE_INFORMATION lpFileInformation)
@@ -888,7 +888,7 @@ DWORD FindFileOwnerAndPermission(
 
   if (pMask == NULL) goto FindFileOwnerAndPermissionEnd;
 
-  dwRtnCode = GetFileInformationByName(pathName,
+  dwRtnCode = GetFileInformationByPathName(pathName,
     followLink, &fileInformation);
   if (dwRtnCode != ERROR_SUCCESS)
   {

--- a/hadoop-common-project/hadoop-common/src/main/winutils/ls.c
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/ls.c
@@ -280,11 +280,11 @@ int Ls(__in int argc, __in_ecount(argc) wchar_t *argv[])
     goto LsEnd;
   }
 
-  dwErrorCode = GetFileInformationByName(
+  dwErrorCode = GetFileInformationByPathName(
     longPathName, optionsMask & CmdLineOptionFollowSymlink, &fileInformation);
   if (dwErrorCode != ERROR_SUCCESS)
   {
-    ReportErrorCode(L"GetFileInformationByName", dwErrorCode);
+    ReportErrorCode(L"GetFileInformationByPathName", dwErrorCode);
     goto LsEnd;
   }
 


### PR DESCRIPTION
### Description of PR

Building `hadoop-common` with `-Pnative-win` fails on Windows against a current
Windows 11 SDK:

```
winutils.h(129,7): error C2733: 'GetFileInformationByName': you cannot overload
a function with 'extern "C"' linkage [libwinutils.vcxproj]
```

Windows SDK 10.0.26100.0 introduced its own `GetFileInformationByName` in
`WinBase.h` (guarded by `#if (NTDDI_VERSION >= NTDDI_WIN11_ZN)`). It collides
with the winutils helper of the same name that Hadoop has carried for years:

```c
/* Windows SDK 10.0.26100.0 - WinBase.h */
BOOL WINAPI GetFileInformationByName(PCWSTR, FILE_INFO_BY_NAME_CLASS, PVOID, ULONG);

/* hadoop - winutils.h */
DWORD GetFileInformationByName(LPCWSTR pathName, BOOL followLink,
                               LPBY_HANDLE_FILE_INFORMATION lpFileInformation);
```

The two differ in signature, so in C++ they would ordinarily overload. But
overloading requires C++ linkage and both have **C** linkage — `winutils.h`
wraps its declarations in `extern "C"`, and so does the SDK header — so the
compiler rejects the pair. It surfaces in `libwinutils.vcxproj`, which compiles
`config.cpp` as C++. SDK 10.0.22621.0 does not declare the symbol, which is why
this only now breaks.

The SDK name cannot be changed, so this renames the Hadoop helper to
`GetFileInformationByPathName`. That also reads as the by-path counterpart to
the SDK's existing `GetFileInformationByHandle`.

This is a pure rename of one internal helper plus its call sites. No behaviour
change, and no change to any public or JNI-visible surface.

### How was this patch tested?

**Environment**

Windows 11, Visual Studio 2022 (platform toolset v143), Windows SDK 10.0.26100.0,
JDK 17.0.20.1, Maven 3.9.16.

**Compilation**

`hadoop-common` builds with `-Pnative-win -Duse.platformToolsetVersion=v143`;
`libwinutils` and `winutils` compile with no `C2733`, producing
`libwinutils.lib` and `winutils.exe`. Without this patch the same build fails at
`winutils.h(129,7)`.

**TestWinUtils — before/after comparison**

To confirm the rename is behaviour-neutral, the suite was run twice against the
same build tree: once with `winutils.exe` built from this patch, and once with a
`winutils.exe` built from the unmodified source prior to the rename. The second
run used `-P'!native-win'` so that the profile, which auto-activates on Windows,
did not rebuild over the substituted binary.

|                   | before rename | with this patch |
| ----------------- | ------------- | --------------- |
| Tests run         | 11            | 11              |
| Failures / Errors | 4 / 2         | 4 / 2           |

Both runs fail the same six tests, with identical assertion messages and
identical line numbers. Those six fail for reasons unrelated to this change and
pre-date it:

- `testChown` — `ChangeFileOwnerBySid error (5): Access is denied` (requires elevation).
- `testReadLink` — `CreateSymbolicLink error (1314): A required privilege is not
  held by the client`. BUILDING.txt notes that several tests require the Create
  Symbolic Links privilege.
- `testChmod` / `testLs` — `expected: <-rwx------> but was: <---------->`. On this
  host the account's owner and primary group SIDs are identical, so files
  carrying only inherited ACEs read back with no permission bits.
- `testTaskCreate` / `testTaskCreateWithLimits` — job-object creation. `task.c`
  contains no reference to the renamed function and is not touched by this patch.

The remaining five tests pass in both runs.

**Coverage of the changed lines**

Every changed line was executed, and its output compared against a pre-rename
binary:

| Changed line | Exercised by |
| ------------ | ------------ |
| `winutils.h:129` (declaration) | compiles; all call sites link through it |
| `libwinutils.c:88` (definition) | every check below |
| `libwinutils.c:891` (`FindFileOwnerAndPermission`) | `winutils ls`, `winutils chmod`, `hadoop fs -ls`/`-chmod` on `file://` |
| `ls.c:283` (call) | `winutils ls` |
| `ls.c:287` (error string) | `winutils ls` on a nonexistent path |
| `chmod.c:370` (call) | `winutils chmod -R` on a directory tree |
| `chmod.c:373` (error string) | `winutils chmod -R` on a nonexistent path |
| `hardlink.c:97` (call) | `winutils hardlink stat` (link count 1 → 2 → 3) |

Output is identical between the pre-rename and patched binaries in every case.
The only observable difference is in the two diagnostic strings, which now name
the renamed function while reporting the same error code and message:

```
before: GetFileInformationByName     error (2): The system cannot find the file specified.
after:  GetFileInformationByPathName error (2): The system cannot find the file specified.
```

**Functional checks**

A pseudo-distributed cluster (NameNode, DataNode, ResourceManager) was brought up
against a build containing the patch. `hadoop checknative -a` loads `hadoop.dll`
and `winutils.exe`; `hadoop fs` `-mkdir`, `-put`, `-ls`, `-cat` and `-copyToLocal`
work against HDFS; `-ls` and `-chmod` work against `file://`, which routes through
the renamed code; and a MapReduce wordcount job completed successfully with
correct output. A full reactor build (`mvn install -Pdist,src,yarn-ui -Dtar
-DskipTests`) also completed, producing a tarball containing `bin/winutils.exe`,
`bin/hadoop.dll` and `bin/hdfs.dll` — though that run predates the recent JDK 17
requirement and was made on a 3.5.0-SNAPSHOT base.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id
      (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in
      a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
