### PR TITLE
HDFS-17973. Add DataNode write-memory batching to improve write IO pattern throughput and latency

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -152,6 +152,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final boolean DFS_DATANODE_SYNC_BEHIND_WRITES_IN_BACKGROUND_DEFAULT = false;
   public static final String  DFS_DATANODE_DROP_CACHE_BEHIND_READS_KEY = "dfs.datanode.drop.cache.behind.reads";
   public static final boolean DFS_DATANODE_DROP_CACHE_BEHIND_READS_DEFAULT = false;
+  public static final String  DFS_DATANODE_READ_AHEAD_CACHE_BYTES_THRESHOLD_KEY =
+      "dfs.datanode.read.ahead.cache.bytes.threshold";
+  public static final long    DFS_DATANODE_READ_AHEAD_CACHE_BYTES_THRESHOLD_DEFAULT =
+      256 * 1024;
   public static final String  DFS_DATANODE_USE_DN_HOSTNAME = "dfs.datanode.use.datanode.hostname";
   public static final boolean DFS_DATANODE_USE_DN_HOSTNAME_DEFAULT = false;
   public static final String  DFS_DATANODE_MAX_LOCKED_MEMORY_KEY = "dfs.datanode.max.locked.memory";
@@ -1658,6 +1662,41 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final int
       DFS_DATANODE_TRANSFER_SOCKET_RECV_BUFFER_SIZE_DEFAULT =
       HdfsConstants.DEFAULT_DATA_SOCKET_SIZE;
+
+  // Write buffer optimization
+  public static final String
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED =
+      "dfs.datanode.write.memory.buffer.enabled";
+  public static final boolean
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED_DEFAULT = false;
+  public static final String
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY =
+      "dfs.datanode.write.memory.buffer.last-replica-only";
+  public static final boolean
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY_DEFAULT = true;
+  public static final String
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_MAX_CAPACITY_MB =
+      "dfs.datanode.write.memory.buffer.max.capacity.mb";
+  public static final int
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_MAX_CAPACITY_MB_DEFAULT = -1;
+  public static final String
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES =
+      "dfs.datanode.write.memory.buffer.min.volumes";
+  public static final int
+      DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES_DEFAULT = 0;
+  public static final String
+      DFS_DATANODE_CONCURRENT_FLUSH_MB_PER_VOLUME =
+      "dfs.datanode.concurrent.flush.mb.per.volume";
+  public static final int
+      DFS_DATANODE_CONCURRENT_FLUSH_MB_PER_VOLUME_DEFAULT = 0;
+  public static final String DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES =
+      "dfs.datanode.write.buffer.size.bytes";
+  public static final int DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES_DEFAULT =
+      8 * 1024 * 1024;
+  public static final String DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS =
+      "dfs.datanode.write.buffer.idle.flush.timeout.ms";
+  public static final long
+      DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS_DEFAULT = 0;
 
   public static final String
       DFS_DATA_TRANSFER_SERVER_TCPNODELAY =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStreamWriter;
@@ -33,12 +34,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.zip.Checksum;
 
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.fs.FSOutputSummer;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSPacket;
 import org.apache.hadoop.hdfs.DFSUtilClient;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -51,6 +57,7 @@ import org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.BlockOpResponseP
 import org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.Status;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.ReplicaInputStreams;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.ReplicaOutputStreams;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.apache.hadoop.hdfs.server.datanode.metrics.DataNodePeerMetrics;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
@@ -148,6 +155,16 @@ class BlockReceiver implements Closeable {
   private boolean pinning;
   private final AtomicLong lastSentTime = new AtomicLong(0L);
   private long maxSendIdleTime;
+  private final BufferedBlockWriter buffer;
+  private final FsVolumeImpl volume;
+  private final long bufferFlushIdleTimeoutMs;
+  private volatile ScheduledFuture<?> flushTask;
+  private volatile long lastPacketReceivedTime = System.currentTimeMillis();
+
+  private static final AtomicLongFieldUpdater<BlockReceiver>
+      LAST_PACKET_RECEIVED_TIME_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(BlockReceiver.class,
+          "lastPacketReceivedTime");
 
   BlockReceiver(final ExtendedBlock block, final StorageType storageType,
       final DataInputStream in,
@@ -159,7 +176,8 @@ class BlockReceiver implements Closeable {
       CachingStrategy cachingStrategy,
       final boolean allowLazyPersist,
       final boolean pinning,
-      final String storageId) throws IOException {
+      final String storageId,
+      final boolean isLastInPipeline) throws IOException {
     try{
       this.block = block;
       this.in = in;
@@ -192,6 +210,9 @@ class BlockReceiver implements Closeable {
       // the interval of 0.5*readTimeout. Here, we set 0.9*readTimeout to be
       // the threshold for detecting congestion.
       this.maxSendIdleTime = (long) (readTimeout * 0.9);
+      this.bufferFlushIdleTimeoutMs = datanode.getConf().getLong(
+          DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS,
+          DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS_DEFAULT);
       if (LOG.isDebugEnabled()) {
         LOG.debug(getClass().getSimpleName() + ": " + block
             + "\n storageType=" + storageType + ", inAddr=" + inAddr
@@ -209,6 +230,7 @@ class BlockReceiver implements Closeable {
         );
       }
 
+      boolean isNewRbw = false;
       //
       // Open local disk out
       //
@@ -225,6 +247,7 @@ class BlockReceiver implements Closeable {
           }
           datanode.notifyNamenodeReceivingBlock(
               block, replicaHandler.getReplica().getStorageUuid());
+          isNewRbw = true;
           break;
         case PIPELINE_SETUP_STREAMING_RECOVERY:
           replicaHandler = datanode.data.recoverRbw(
@@ -276,10 +299,25 @@ class BlockReceiver implements Closeable {
       this.checksumOut = new DataOutputStream(new BufferedOutputStream(
           streams.getChecksumOut(), DFSUtilClient.getSmallBufferSize(
           datanode.getConf())));
+      this.volume = (replicaInfo.getReplicaInfo() != null
+          && replicaInfo.getReplicaInfo().getVolume() instanceof FsVolumeImpl)
+              ? (FsVolumeImpl) replicaInfo.getReplicaInfo().getVolume()
+              : null;
+      boolean isLocalReplica = replicaInfo instanceof LocalReplica;
+      File blockFile = isLocalReplica
+          ? ((LocalReplica) replicaInfo).getBlockFile()
+          : null;
+      boolean isWriteMemoryBufferEnabled =
+          datanode.isWriteMemoryBufferEnabled() && isNewRbw
+              && (!datanode.isWriteMemoryBufferLastReplicaOnly()
+                  || isLastInPipeline);
+      this.buffer = createWriteBuffer(isWriteMemoryBufferEnabled, blockFile,
+          volume, datanode);
       // write data chunk header if creating a new replica
       if (isCreate) {
         BlockMetadataHeader.writeHeader(checksumOut, diskChecksum);
       } 
+      startBufferFlushTimer();
     } catch (ReplicaAlreadyExistsException | ReplicaNotFoundException
         | DiskOutOfSpaceException e) {
       throw e;
@@ -304,6 +342,24 @@ class BlockReceiver implements Closeable {
     }
   }
 
+  private BufferedBlockWriter createWriteBuffer(
+      boolean isWriteMemoryBufferEnabled, File blockFile, FsVolumeImpl volume,
+      DataNode datanode) {
+    if (volume == null || blockFile == null) {
+      return null;
+    }
+    if (isWriteMemoryBufferEnabled) {
+      try {
+        return new BufferedBlockWriterImpl(this, blockFile, volume,
+            datanode.getMaxConcurrentWriteBuffers());
+      } catch (Exception e) {
+        LOG.error("Failed to create pooled write buffer; falling back to "
+            + "the unbuffered write path", e);
+      }
+    }
+    return null;
+  }
+
   /** Return the datanode object. */
   DataNode getDataNode() {return datanode;}
 
@@ -322,11 +378,74 @@ class BlockReceiver implements Closeable {
     }
   }
 
+  private synchronized void startBufferFlushTimer() {
+    if (bufferFlushIdleTimeoutMs <= 0 || buffer == null) {
+      return;
+    }
+    scheduleBufferFlush();
+  }
+
+  private void scheduleBufferFlush() {
+    ScheduledExecutorService executorService = datanode.getBufferFlushService();
+    if (executorService == null) {
+      LOG.warn("Idle buffer flush is configured ({} ms) but the scheduler is "
+          + "not initialized for block {}. Idle flush will not run.",
+          bufferFlushIdleTimeoutMs, block.getBlockName());
+      return;
+    }
+    flushTask = executorService.schedule(this::handleBufferFlushTimeout,
+        bufferFlushIdleTimeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  private synchronized void cancelBufferFlushTimer() {
+    if (flushTask != null) {
+      flushTask.cancel(false);
+      flushTask = null;
+    }
+  }
+
+  private synchronized void handleBufferFlushTimeout() {
+    if (flushTask == null) {
+      return;
+    }
+    try {
+      if (buffer != null && buffer.hasPendingData()) {
+        long idleMs = System.currentTimeMillis()
+            - LAST_PACKET_RECEIVED_TIME_UPDATER.get(this);
+        if (idleMs >= bufferFlushIdleTimeoutMs) {
+          buffer.flush();
+          // Only persist the buffered bytes here for durability / memory
+          // relief. Do NOT advance the RBW visible length (bytesAcked) from
+          // this scheduler thread: bytesAcked is otherwise written solely by
+          // the PacketResponder ack path, and ReplicaInPipeline.setBytesAcked
+          // applies a (bytesAcked - prev) delta to the volume's reserved-space
+          // accounting. A second, unsynchronized writer here could race that
+          // path, make bytesAcked non-monotonic and apply a negative
+          // reserved-space delta. It would also risk exposing a chunk whose
+          // checksum is not yet in the meta file. Leaving visibility to the
+          // ack path keeps vanilla RBW semantics (streaming, not-yet-acked
+          // bytes are simply not visible until the next ack/hsync/close).
+          LOG.info("Idle-flushed write buffer for block {} after {} ms with "
+              + "no packet from client {}", block.getBlockName(), idleMs,
+              clientname);
+        }
+      }
+    } catch (Throwable t) {
+      flushTask = null;
+      LOG.warn("Idle buffer flush failed for block {}", block.getBlockName(), t);
+    }
+    if (flushTask != null) {
+      scheduleBufferFlush();
+    }
+  }
+
   /**
    * close files and release volume reference.
    */
   @Override
   public void close() throws IOException {
+    cancelBufferFlushTimer();
+
     Span span = Tracer.getCurrentSpan();
     if (span != null) {
       span.addKVAnnotation("maxWriteToDiskMs",
@@ -362,6 +481,20 @@ class BlockReceiver implements Closeable {
     finally {
       IOUtils.closeStream(checksumOut);
     }
+    if (buffer != null) {
+      // Guard the mandatory final buffer flush/sync: syncData()/flush() now
+      // propagate IOException, so a failure here MUST NOT skip the buffered
+      // resource cleanup in the finally below (buffer.release()) -- otherwise
+      // the memory-cap permit, pooled Netty buffer and FileChannel would leak,
+      // and repeated close-time disk errors would exhaust the permit pool and
+      // wedge future buffered writers. Record the error and fall through so
+      // cleanup still runs; it is rethrown at the end of close().
+      try {
+        buffer.flushOrSync(true, true, true);
+      } catch (IOException e) {
+        ioe = (ioe == null) ? e : ioe;
+      }
+    }
     // close block file
     try {
       if (streams.getDataOut() != null) {
@@ -382,6 +515,9 @@ class BlockReceiver implements Closeable {
     }
     finally{
       streams.close();
+      if (buffer != null) {
+        buffer.release();
+      }
     }
     if (replicaHandler != null) {
       IOUtils.cleanupWithLogger(null, replicaHandler);
@@ -425,6 +561,25 @@ class BlockReceiver implements Closeable {
    * @throws IOException
    */
   void flushOrSync(boolean isSync, long seqno) throws IOException {
+    flushOrSync(isSync, isSync, false, false, seqno);
+  }
+
+  void flushOrSync(boolean isSync) throws IOException {
+    flushOrSync(isSync, -1);
+  }
+
+  public void flushOrSync(boolean isSync, boolean bufferFlush)
+      throws IOException {
+    flushOrSync(isSync, isSync, bufferFlush, false);
+  }
+
+  public void flushOrSync(boolean isSync, boolean isChecksumSync,
+      boolean bufferFlush, boolean isClosed) throws IOException {
+    flushOrSync(isSync, isChecksumSync, bufferFlush, isClosed, -1);
+  }
+
+  private void flushOrSync(boolean isSync, boolean isChecksumSync,
+      boolean bufferFlush, boolean isClosed, long seqno) throws IOException {
     long flushTotalNanos = 0;
     long begin = Time.monotonicNow();
     DataNodeFaultInjector.get().delay();
@@ -432,11 +587,17 @@ class BlockReceiver implements Closeable {
       long flushStartNanos = System.nanoTime();
       checksumOut.flush();
       long flushEndNanos = System.nanoTime();
-      if (isSync) {
+      if (isChecksumSync) {
         streams.syncChecksumOut();
         datanode.metrics.addFsyncNanos(System.nanoTime() - flushEndNanos);
       }
       flushTotalNanos += flushEndNanos - flushStartNanos;
+    }
+    if (buffer != null && !isSync && !bufferFlush) {
+      return;
+    }
+    if (buffer != null) {
+      buffer.flush();
     }
     if (streams.getDataOut() != null) {
       long flushStartNanos = System.nanoTime();
@@ -444,7 +605,11 @@ class BlockReceiver implements Closeable {
       long flushEndNanos = System.nanoTime();
       if (isSync) {
         long fsyncStartNanos = flushEndNanos;
-        streams.syncDataOut();
+        if (buffer != null) {
+          buffer.syncData(block.getBlockName(), isClosed);
+        } else {
+          streams.syncDataOut();
+        }
         datanode.metrics.addFsyncNanos(System.nanoTime() - fsyncStartNanos);
       }
       flushTotalNanos += flushEndNanos - flushStartNanos;
@@ -552,6 +717,9 @@ class BlockReceiver implements Closeable {
   private int receivePacket() throws IOException {
     // read the next packet
     packetReceiver.receiveNextPacket(in);
+    if (bufferFlushIdleTimeoutMs > 0) {
+      LAST_PACKET_RECEIVED_TIME_UPDATER.set(this, System.currentTimeMillis());
+    }
 
     PacketHeader header = packetReceiver.getHeader();
     long seqno = header.getSeqno();
@@ -741,6 +909,21 @@ class BlockReceiver implements Closeable {
                   + ": previous write did not end at the chunk boundary."
                   + " onDiskLen=" + onDiskLen);
             }
+            if (buffer != null) {
+              // Defensive guard for the partial-chunk CRC recalculation path.
+              // computePartialChunkCrc re-reads the last partial chunk from the
+              // physical block file, so those tail bytes must be on disk and
+              // not still sitting in the write buffer. In the current design
+              // this branch is effectively unreachable while buffering is
+              // active: doCrcRecalc only becomes true when the packet start
+              // offset disagrees with the on-disk chunk boundary (append /
+              // pipeline-recovery), and buffering is enabled only for a brand
+              // new RBW (PIPELINE_SETUP_CREATE, isNewRbw) -- append/recovery
+              // BlockReceivers run with buffer == null. Flushing here keeps the
+              // "never read past physical EOF" invariant intact if that gating
+              // is ever relaxed, and costs nothing on the normal path.
+              buffer.flush();
+            }
             long offsetInChecksum = BlockMetadataHeader.getHeaderSize() +
                 onDiskLen / bytesPerChecksum * checksumSize;
             partialCrc = computePartialChunkCrc(onDiskLen, offsetInChecksum);
@@ -757,8 +940,12 @@ class BlockReceiver implements Closeable {
           
           // Write data to disk.
           long begin = Time.monotonicNow();
-          streams.writeDataToDisk(dataBuf.array(),
-              startByteToDisk, numBytesToDisk);
+          if (buffer != null) {
+            buffer.writeData(dataBuf, startByteToDisk, numBytesToDisk);
+          } else {
+            streams.writeDataToDisk(dataBuf.array(),
+                startByteToDisk, numBytesToDisk);
+          }
           // no-op in prod
           DataNodeFaultInjector.get().delayWriteToDisk();
           long duration = Time.monotonicNow() - begin;
@@ -1054,6 +1241,13 @@ class BlockReceiver implements Closeable {
     } finally {
       // Clear the previous interrupt state of this thread.
       Thread.interrupted();
+      flushBufferSafelyIfEnabled();
+      if (buffer != null) {
+        LOG.info("[{}] During closing buffer, on-disk-bytes={}, "
+            + "buffer-flushed-bytes={}, interrupted={}", block.getBlockName(),
+            replicaInfo.getBytesOnDisk(), buffer.getFlushedBytes(),
+            Thread.currentThread().isInterrupted());
+      }
 
       // If a shutdown for restart was initiated, upstream needs to be notified.
       // There is no need to do anything special if the responder was closed
@@ -1084,14 +1278,14 @@ class BlockReceiver implements Closeable {
               // It is already going down. Ignore this.
             }
           }
-          responder.interrupt();
+          interrupt(responder);
         }
         IOUtils.closeStream(this);
         cleanupBlock();
       }
       if (responder != null) {
         try {
-          responder.interrupt();
+          interrupt(responder);
           // join() on the responder should timeout a bit earlier than the
           // configured deadline. Otherwise, the join() on this thread will
           // likely timeout as well.
@@ -1105,13 +1299,28 @@ class BlockReceiver implements Closeable {
             throw new IOException(msg);
           }
         } catch (InterruptedException e) {
-          responder.interrupt();
+          interrupt(responder);
           // do not throw if shutting down for restart.
           if (!datanode.isRestarting()) {
             throw new InterruptedIOException("Interrupted receiveBlock");
           }
         }
         responder = null;
+      }
+    }
+  }
+
+  private void interrupt(Thread thread) {
+    flushBufferSafelyIfEnabled();
+    thread.interrupt();
+  }
+
+  private void flushBufferSafelyIfEnabled() {
+    if (buffer != null) {
+      try {
+        buffer.flush();
+      } catch (IOException e) {
+        LOG.warn("Failed to flush write buffer for {}", block.getBlockName(), e);
       }
     }
   }
@@ -1533,14 +1742,14 @@ class BlockReceiver implements Closeable {
             LOG.info(myString, e);
             running = false;
             if (!Thread.interrupted()) { // failure not caused by interruption
-              receiverThread.interrupt();
+              BlockReceiver.this.interrupt(receiverThread);
             }
           }
         } catch (Throwable e) {
           if (running) {
             LOG.info(myString, e);
             running = false;
-            receiverThread.interrupt();
+            BlockReceiver.this.interrupt(receiverThread);
           }
         }
       }
@@ -1671,7 +1880,24 @@ class BlockReceiver implements Closeable {
           totalAckTimeNanos);
       if (replyAck.isSuccess()
           && offsetInBlock > replicaInfo.getBytesAcked()) {
-        replicaInfo.setBytesAcked(offsetInBlock);
+        long ackedLen = offsetInBlock;
+        if (buffer != null) {
+          // With DataNode write buffering, a packet's bytes may still reside
+          // in the in-memory buffer and NOT yet be in the block file. Acked
+          // bytes become the RBW replica's visible length, which a concurrent
+          // reader (BlockSender / short-circuit) reads directly from the block
+          // file -- so never advance the visible/acked length past what has
+          // actually been flushed to disk, otherwise the reader would read
+          // past the physical end of the file. The remaining buffered bytes
+          // become visible on the next buffer flush (or on hsync/close, which
+          // flush fully). Buffering is only enabled for brand-new RBW blocks
+          // (block start offset 0), so getFlushedBytes() equals the on-disk
+          // data length here.
+          ackedLen = Math.min(ackedLen, buffer.getFlushedBytes());
+        }
+        if (ackedLen > replicaInfo.getBytesAcked()) {
+          replicaInfo.setBytesAcked(ackedLen);
+        }
       }
       // send my ack back to upstream datanode
       long begin = Time.monotonicNow();
@@ -1747,5 +1973,9 @@ class BlockReceiver implements Closeable {
         + ", ackStatus=" + ackStatus
         + ")";
     }
+  }
+
+  public ExtendedBlock getBlock() {
+    return block;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -176,7 +176,7 @@ class BlockSender implements java.io.Closeable {
   /**
    * See {{@link BlockSender#isLongRead()}
    */
-  private static final long LONG_READ_THRESHOLD_BYTES = 256 * 1024;
+  private long readAheadCacheBytesThreshold;
 
   // The number of bytes per checksum here determines the alignment
   // of reads: we always start reading at a checksum chunk boundary,
@@ -229,6 +229,8 @@ class BlockSender implements java.io.Closeable {
             this.dropCacheBehindLargeReads =
                  cachingStrategy.getDropBehind().booleanValue();
       }
+      this.readAheadCacheBytesThreshold =
+          datanode.getDnConf().readAheadCacheBytesThreshold;
       /*
        * Similarly, if readahead was explicitly requested, we always do it.
        * Otherwise, we read ahead based on the DataNode settings, and only
@@ -892,7 +894,7 @@ class BlockSender implements java.io.Closeable {
    * posix_fadvise(POSIX_FADV_SEQUENTIAL).
    */
   private boolean isLongRead() {
-    return (endOffset - initialOffset) > LONG_READ_THRESHOLD_BYTES;
+    return (endOffset - initialOffset) > readAheadCacheBytesThreshold;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BufferedBlockWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BufferedBlockWriter.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * {@code BufferedBlockWriter} defines an abstraction for a reusable, memory-backed
+ * buffer used in the DataNode write pipeline.
+ *
+ * Implementations may use off-heap (e.g., Netty) or direct I/O buffers to
+ * reduce IOPs and improve disk write performance.
+ *
+ * <p>
+ * This interface defines essential operations to manage the lifecycle of a
+ * pooled write buffer, including writing data, flushing to disk, syncing for
+ * durability, and releasing resources back to the pool.
+ * </p>
+ */
+public interface BufferedBlockWriter {
+
+  /**
+   * Writes a range of data from the provided {@link ByteBuffer}
+   * into the target buffer.
+   *
+   * @param dataBuf           the data buffer containing bytes to be written
+   * @param startByteToDisk   starting byte offset within the buffer
+   * @param numBytesToDisk    number of bytes to write
+   * @throws IOException      if a write error occurs
+   *
+   * <p>Implementations are responsible for handling alignment and
+   * ensuring that data is written atomically where required.</p>
+   */
+  void writeData(ByteBuffer dataBuf, int startByteToDisk, int numBytesToDisk)
+      throws IOException;
+
+  /**
+   * Performs a data sync operation for the given block.
+   *
+   * @param blockName the HDFS block name associated with this buffer
+   * @param isClosed whether the block file is being closed as part of sync
+   *
+   *          <p>
+   *          Implementations may use this to ensure any pending writes are
+   *          persisted to disk before marking the block as complete.
+   *          </p>
+   */
+  void syncData(String blockName, boolean isClosed) throws IOException;
+
+  /**
+   * Flushes any in-memory data to the underlying storage target (e.g., disk or
+   * channel), ensuring that buffered content is physically written but not
+   * necessarily fsynced.
+   *
+   * @throws IOException if the flush operation fails
+   */
+  void flush() throws IOException;
+
+  /**
+   * Flushes or syncs data depending on the specified flags.
+   *
+   * @param fsync if {@code true}, ensures data is physically persisted using
+   *          fsync or fdatasync
+   * @param bufferFlush if {@code true}, flushes in-memory data buffers to disk
+   * @param isClosed indicates if the underlying file is being closed
+   * @throws IOException if any I/O error occurs during flush or sync
+   *
+   *           <p>
+   *           This method provides a unified entry point for conditional buffer
+   *           management, depending on whether only a memory flush, a full
+   *           fsync, or a close operation is required.
+   *           </p>
+   */
+  void flushOrSync(boolean fsync, boolean bufferFlush, boolean isClosed)
+      throws IOException;
+
+  /**
+   * Releases this buffer and returns any associated resources (such as memory,
+   * file descriptors, or concurrency permits) back to the pool.
+   *
+   * <p>
+   * Once released, the buffer should not be used again.
+   * </p>
+   */
+  void release();
+
+  /**
+   * Get total flushed bytes to disk.
+   *
+   * @return total flushed bytes.
+   */
+  long getFlushedBytes();
+
+  /**
+   * @return {@code true} if the buffer may hold data not yet flushed to disk.
+   *
+   *         <p>
+   *         Used by the DataNode's idle buffer-flush task to cheaply skip a
+   *         flush when nothing is pending. The default is a conservative
+   *         {@code true}; a spurious {@code true} only costs an extra no-op
+   *         {@link #flush()}.
+   *         </p>
+   */
+  default boolean hasPendingData() {
+    return true;
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BufferedBlockWriterImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BufferedBlockWriterImpl.java
@@ -1,0 +1,404 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import static org.apache.hadoop.io.nativeio.NativeIO.POSIX.POSIX_FADV_DONTNEED;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
+import org.apache.hadoop.io.nativeio.NativeIO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+
+/**
+ * {@code BufferedBlockWriterImpl} is a concrete implementation of {@link BufferedBlockWriter}
+ * that manages buffered block writes to disk using DSYNC-enabled
+ * {@link FileChannel}.
+ *
+ * <p>
+ * This class provides a mechanism for memory-efficient, concurrent, and
+ * fsync-safe writes from Netty's off-heap buffers to disk files (used by
+ * {@link BlockReceiver} in the DataNode write pipeline).
+ *
+ * <p>
+ * Key features:
+ * <ul>
+ * <li>Limits concurrent memory buffer usage via semaphores</li>
+ * <li>Uses DSYNC mode to ensure data durability on flush</li>
+ * <li>Drops page cache after completion to free kernel memory</li>
+ * </ul>
+ */
+public class BufferedBlockWriterImpl implements BufferedBlockWriter {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(BufferedBlockWriterImpl.class);
+
+  private ByteBuf nettyBuf;
+  private volatile FileChannel fc;
+  private final File file;
+  private final FsVolumeImpl volume;
+  private final BlockReceiver blockReceiver;
+  private final Semaphore writeMemoryBufferMaxConcurrentWrites;
+  private final Semaphore flushWritesSemaphore;
+  private final ExecutorService volumeExecutor;
+  private volatile long totalFlushedBytes;
+  private AtomicBoolean isClosed = new AtomicBoolean(false);
+  private long lastFilePos = 0; // capture last written file position
+  private String blockName;
+
+  /**
+   * Initializes a new {@code BufferedBlockWriterImpl} for buffered writes.
+   *
+   * @param blockReceiver the associated {@link BlockReceiver} handling the
+   *          block stream
+   * @param file the file representing the target block
+   * @param volume the backing {@link FsVolumeImpl}
+   * @param writeMemoryBufferMaxConcurrentWrites semaphore to limit total memory
+   *          usage
+   * @throws IOException if file channel initialization fails
+   */
+  public BufferedBlockWriterImpl(BlockReceiver blockReceiver, File file,
+      FsVolumeImpl volume, Semaphore writeMemoryBufferMaxConcurrentWrites)
+      throws IOException {
+    this.file = file;
+    this.volume = volume;
+    this.blockReceiver = blockReceiver;
+    this.blockName = blockReceiver.getBlock().getBlockName();
+    this.writeMemoryBufferMaxConcurrentWrites =
+        writeMemoryBufferMaxConcurrentWrites;
+    this.flushWritesSemaphore =
+        volume.getBufferResources().getFlushPermitSemaphore().orElse(null);
+    this.volumeExecutor = volume.getBufferResources().getVolumeExecutor();
+
+    // Enforce the DataNode-wide write-buffer memory cap BEFORE allocating the
+    // off-heap buffer. If we allocated first, many concurrent writers could
+    // each grab a buffer before blocking, blowing past the configured cap.
+    acquirePermit();
+    boolean initialized = false;
+    try {
+      this.nettyBuf = PooledByteBufAllocator.DEFAULT
+          .buffer(volume.getMaxWriteBufferCapacityBytes());
+      try {
+        fc = FileChannel.open(file.toPath(), StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE, StandardOpenOption.DSYNC);
+      } catch (IOException e) {
+        // Release the pooled buffer so a channel-open failure does not leak
+        // pooled/direct memory.
+        nettyBuf.release();
+        nettyBuf = null;
+        throw e;
+      }
+      initialized = true;
+    } finally {
+      if (!initialized) {
+        // Give back the memory-cap permit acquired above; release() will not
+        // be called because construction failed.
+        writeMemoryBufferMaxConcurrentWrites.release();
+      }
+    }
+  }
+
+  /**
+   * Writes data from the given {@link ByteBuffer} into the internal Netty
+   * buffer. Automatically flushes when the buffer becomes full.
+   */
+  public synchronized void writeData(ByteBuffer dataBuf, int startByteToDisk,
+      int numBytesToDisk) throws IOException {
+    int size = 0;
+    int len = numBytesToDisk;
+    byte[] data = dataBuf.array();
+    while (size < len) {
+      int writable = Math.min(nettyBuf.writableBytes(), numBytesToDisk);
+      size += writable;
+      nettyBuf.writeBytes(data, startByteToDisk, writable);
+      startByteToDisk += writable;
+      numBytesToDisk -= writable;
+
+      if (nettyBuf.writableBytes() == 0) {
+        flushOrSync(true, true, false);
+      }
+    }
+  }
+
+  /**
+   * Flushes buffered data to disk, limiting concurrent flush operations per
+   * volume to prevent excessive I/O contention.
+   *
+   * <p>This method is {@code synchronized} so that the buffer monitor is always
+   * taken <em>before</em> the per-volume flush permit ({@code M -> P}). The
+   * full-buffer flush path also runs under the buffer monitor
+   * ({@code writeData} is synchronized and calls back into this flush), so
+   * enforcing the same {@code M -> P} order in every flush caller (idle-flush
+   * scheduler, hsync, close, responder) removes the lock-ordering inversion
+   * that could otherwise deadlock when {@code flushWritesSemaphore} is enabled
+   * (a receiver thread holding the monitor and waiting for the permit while a
+   * flusher thread holds the permit and waits for the monitor).</p>
+   */
+  @Override
+  public synchronized void flush() throws IOException {
+    boolean acquired = aquireFlushPermit();
+    try {
+      flushInternal();
+    } finally {
+      if (acquired) {
+        releaseFlushPermit();
+      }
+    }
+  }
+
+  public void flushOrSync(boolean fsync, boolean bufferFlush,
+      boolean blockClosed)
+      throws IOException {
+    blockReceiver.flushOrSync(fsync,
+        false /* fsync checksum during closing the block */, bufferFlush,
+        blockClosed);
+  }
+
+  /**
+   * Releases the allocated buffer, semaphore permits, and closes the
+   * underlying file channel.
+   */
+  @Override
+  public synchronized void release() {
+    if (!isClosed.compareAndSet(false, true)) {
+      return;
+    }
+    writeMemoryBufferMaxConcurrentWrites.release();
+    closeFileChannelAndDropPageCache();
+    if (nettyBuf != null) {
+      nettyBuf.release();
+      nettyBuf = null;
+    }
+  }
+
+  /**
+   * Attempts to acquire a permit for flush concurrency, ensuring only a limited
+   * number of flush operations run per volume at a time.
+   *
+   * @return {@code true} if a permit was actually acquired (and must be
+   *         released by the caller); {@code false} if there is no flush
+   *         semaphore or the wait was interrupted (in which case NO permit is
+   *         held, so the caller must NOT release one -- otherwise the permit
+   *         count would inflate and defeat the flush-concurrency limit).
+   */
+  private boolean aquireFlushPermit() {
+    if (flushWritesSemaphore == null) {
+      return false;
+    }
+    if (flushWritesSemaphore.availablePermits() <= 0) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Restricting flush concurrency on {}", volume.getBaseURI());
+      }
+    }
+    try {
+      flushWritesSemaphore.acquire();
+      return true;
+    } catch (InterruptedException e) {
+      LOG.info("Interrupted while acquiring flush concurrency on disk= {}",
+          volume.getBaseURI());
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  /** Releases the flush concurrency permit. */
+  private void releaseFlushPermit() {
+    if (flushWritesSemaphore != null) {
+      flushWritesSemaphore.release();
+    }
+  }
+
+  /**
+   * Writes buffered Netty data to the file channel. Uses DSYNC to ensure
+   * durability while maintaining performance.
+   */
+  public synchronized void flushInternal() throws IOException {
+    if (nettyBuf == null || nettyBuf.readableBytes() == 0) {
+      return;
+    }
+    nettyBuf.markReaderIndex(); // mark start of unread data
+
+    boolean success = false;
+
+    try {
+      writeBufferToChannel();
+      success = true;
+    } catch (ClosedByInterruptException e) {
+      boolean isInterrupted = Thread.currentThread().isInterrupted();
+      // This happens when upstream fails and receiver thread is interrupted in
+      // that case, clear the flag and retry to complete the write
+      LOG.warn("Flush failed, retrying once from file position {} for block "
+              + "{}, interrupted={}",
+          lastFilePos, blockName, isInterrupted, e);
+
+      // restore interrupt flag if thread was interrupted
+      Thread.interrupted();
+
+      fc.close();
+
+      // Retry once
+      try {
+        fc = FileChannel.open(file.toPath(), StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE, StandardOpenOption.DSYNC);
+
+        fc.position(lastFilePos); // resume from last position
+        writeBufferToChannel();
+        success = true;
+      } catch (IOException ex) {
+        LOG.error("Retry flush failed for block {}",
+            blockName, ex);
+        throw ex;
+      }
+      // re-interrupt to restore the state
+      if (isInterrupted) {
+        Thread.currentThread().interrupt();
+      }
+    } finally {
+      if (success) {
+        nettyBuf.clear(); // fully flushed
+      } else {
+        nettyBuf.resetReaderIndex(); // keep buffer for next attempt
+      }
+    }
+  }
+
+  private synchronized void writeBufferToChannel() throws IOException {
+    int readableBytes = nettyBuf.readableBytes();
+    if (nettyBuf.hasArray()) {
+      ByteBuffer[] nioBufs = nettyBuf.nioBuffers(
+          nettyBuf.readerIndex(), readableBytes);
+      long remaining = readableBytes;
+      while (remaining > 0) {
+        long written = fc.write(nioBufs);
+        remaining -= written;
+      }
+    } else {
+      ByteBuffer nioBuf = nettyBuf.nioBuffer(
+          nettyBuf.readerIndex(), nettyBuf.readableBytes());
+      while (nioBuf.hasRemaining()) {
+        fc.write(nioBuf);
+      }
+    }
+    lastFilePos = fc.position();
+    totalFlushedBytes += readableBytes;
+  }
+
+  /**
+   * Sync data for a block to disk if the block is closed.
+   *
+   * <p>Propagates fsync failures to the caller so that an hsync or block close
+   * is not reported as successful (and its bytes are not acked as durable) when
+   * the underlying {@code fsync} actually failed.
+   */
+  @Override
+  public void syncData(String ignoredBlockName, boolean blockClosed)
+      throws IOException {
+    fc.force(false);
+  }
+
+  /**
+   * Closes the file channel and schedules a page cache drop to release
+   * kernel-level disk cache after block completion.
+   */
+  private void closeFileChannelAndDropPageCache() {
+    try {
+      fc.close();
+      // drop the page cache
+      volumeExecutor.execute(() -> {
+        // Open read-only ("r"). This task runs asynchronously and may fire
+        // after the block has been finalized (the RBW block file is renamed to
+        // its finalized location on close). "rw" would RE-CREATE the moved-away
+        // path as a zero-byte blk_* file (inode leak + a stale replica artifact
+        // the directory/block scanner would trip over). "r" never creates: if
+        // the file is gone it throws FileNotFoundException, which we treat as a
+        // no-op (nothing left to advise). posix_fadvise(DONTNEED) does not need
+        // write access.
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+          FileDescriptor fd = raf.getFD();
+          NativeIO.POSIX.getCacheManipulator().posixFadviseIfPossible(blockName,
+              fd, 0, 0, POSIX_FADV_DONTNEED);
+        } catch (java.io.FileNotFoundException e) {
+          // Block file already finalized/removed; nothing to drop.
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Skipping page-cache drop for {}; block file {} no longer "
+                + "present (already finalized/removed).", blockName, file);
+          }
+        } catch (Exception e) {
+          LOG.warn("Failed to drop the cache", e);
+        }
+      });
+    } catch (Exception e) {
+      LOG.warn("Failed to close file channel", e);
+    }
+  }
+
+  /**
+   * Acquires a permit to use the write buffer, blocking if the system has
+   * reached its memory buffer concurrency limit.
+   *
+   * @throws InterruptedIOException if interrupted while waiting for a permit;
+   *         in that case NO permit is held, so the caller must abort
+   *         construction (avoids an over-release later in {@link #release()}).
+   */
+  private void acquirePermit() throws InterruptedIOException {
+    try {
+      if (writeMemoryBufferMaxConcurrentWrites.availablePermits() <= 0) {
+        LOG.info(
+            "Max concurrent write reached (increase size of {}).. blocking incoming requests..",
+            DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MAX_CAPACITY_MB);
+      }
+      writeMemoryBufferMaxConcurrentWrites.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new InterruptedIOException(
+          "Interrupted while acquiring write-buffer permit for block "
+              + blockName);
+    }
+  }
+
+  @Override
+  public long getFlushedBytes() {
+    return totalFlushedBytes;
+  }
+
+  /**
+   * Best-effort, lock-free check used by the idle buffer-flush task. A racy
+   * read of the buffer is fine here: it only gates whether to attempt a
+   * flush, and {@link #flushInternal()} re-checks under the monitor.
+   */
+  @Override
+  public boolean hasPendingData() {
+    ByteBuf buf = nettyBuf;
+    return buf != null && buf.isReadable();
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
@@ -98,6 +98,7 @@ public class DNConf {
   final boolean syncBehindWrites;
   final boolean syncBehindWritesInBackground;
   final boolean dropCacheBehindReads;
+  final long readAheadCacheBytesThreshold;
   final boolean syncOnClose;
   final boolean encryptDataTransfer;
   final boolean connectToDnViaHostname;
@@ -186,6 +187,9 @@ public class DNConf {
     dropCacheBehindReads = getConf().getBoolean(
         DFSConfigKeys.DFS_DATANODE_DROP_CACHE_BEHIND_READS_KEY,
         DFSConfigKeys.DFS_DATANODE_DROP_CACHE_BEHIND_READS_DEFAULT);
+    readAheadCacheBytesThreshold = getConf().getLong(
+        DFSConfigKeys.DFS_DATANODE_READ_AHEAD_CACHE_BYTES_THRESHOLD_KEY,
+        DFSConfigKeys.DFS_DATANODE_READ_AHEAD_CACHE_BYTES_THRESHOLD_DEFAULT);
     connectToDnViaHostname = getConf().getBoolean(
         DFSConfigKeys.DFS_DATANODE_USE_DN_HOSTNAME,
         DFSConfigKeys.DFS_DATANODE_USE_DN_HOSTNAME_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -144,7 +144,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -178,6 +180,7 @@ import org.apache.hadoop.hdfs.client.BlockReportOptions;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.net.DomainPeerServer;
 import org.apache.hadoop.hdfs.net.TcpPeerServer;
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.BlockLocalPathInfo;
 import org.apache.hadoop.hdfs.protocol.ClientDatanodeProtocol;
@@ -470,6 +473,8 @@ public class DataNode extends ReconfigurableBase
   private DataSetLockManager dataSetLockManager;
 
   private final ExecutorService xferService;
+  @Nullable
+  private volatile ScheduledExecutorService bufferFlushService;
 
   @Nullable
   private final StorageLocationChecker storageLocationChecker;
@@ -492,6 +497,9 @@ public class DataNode extends ReconfigurableBase
 
   private DataTransferThrottler ecReconstuctReadThrottler;
   private DataTransferThrottler ecReconstuctWriteThrottler;
+  private volatile boolean writeMemoryBufferEnabled;
+  private boolean writeMemoryBufferLastReplicaOnly;
+  private volatile Semaphore maxConcurrentWriteBuffersSemaphore;
 
   /**
    * Creates a dummy DataNode for testing purpose.
@@ -518,6 +526,8 @@ public class DataNode extends ReconfigurableBase
     volumeChecker = new DatasetVolumeChecker(conf, new Timer());
     this.xferService =
         HadoopExecutors.newCachedThreadPool(new Daemon.DaemonFactory());
+    initBufferFlushService(conf);
+    initMemoryBufferConfig(conf);
     double congestionRationTmp = conf.getDouble(DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO,
         DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT);
     this.congestionRatio = congestionRationTmp > 0 ?
@@ -566,6 +576,7 @@ public class DataNode extends ReconfigurableBase
     this.volumeChecker = new DatasetVolumeChecker(conf, new Timer());
     this.xferService =
         HadoopExecutors.newCachedThreadPool(new Daemon.DaemonFactory());
+    initBufferFlushService(conf);
 
     // Determine whether we should try to pass file descriptors to clients.
     if (conf.getBoolean(HdfsClientConfigKeys.Read.ShortCircuit.KEY,
@@ -610,6 +621,7 @@ public class DataNode extends ReconfigurableBase
             });
 
     initOOBTimeout();
+    initMemoryBufferConfig(conf);
     this.storageLocationChecker = storageLocationChecker;
     long ecReconstuctReadBandwidth = conf.getLongBytes(
         DFSConfigKeys.DFS_DATANODE_EC_RECONSTRUCT_READ_BANDWIDTHPERSEC_KEY,
@@ -625,6 +637,91 @@ public class DataNode extends ReconfigurableBase
         DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT);
     this.congestionRatio = congestionRationTmp > 0 ?
         congestionRationTmp : DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT;
+  }
+
+  private void initBufferFlushService(Configuration conf) {
+    long idleFlushMs = conf.getLong(
+        DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS,
+        DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS_DEFAULT);
+    if (idleFlushMs > 0) {
+      LOG.info("Initializing idle buffer-flush service (idle-flush={} ms)",
+          idleFlushMs);
+      this.bufferFlushService =
+          newRemoveOnCancelScheduler("IdleBufferFlush-%d");
+    } else {
+      this.bufferFlushService = null;
+    }
+  }
+
+  /**
+   * Create a daemon {@link ScheduledExecutorService} that removes cancelled
+   * tasks from its delay queue immediately.
+   */
+  private static ScheduledExecutorService newRemoveOnCancelScheduler(
+      String nameFormat) {
+    ScheduledThreadPoolExecutor svc = new ScheduledThreadPoolExecutor(2,
+        new ThreadFactoryBuilder().setNameFormat(nameFormat)
+            .setDaemon(true).build());
+    svc.setRemoveOnCancelPolicy(true);
+    return svc;
+  }
+
+  private void initMemoryBufferConfig(Configuration conf) {
+    boolean configEnabled =
+        conf.getBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED,
+            DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED_DEFAULT);
+    int minVolumes = conf.getInt(
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES,
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES_DEFAULT);
+    int volsConfigured = dnConf.getVolsConfigured();
+
+    this.writeMemoryBufferEnabled = configEnabled &&
+        (minVolumes <= 0 || volsConfigured > minVolumes);
+    this.writeMemoryBufferLastReplicaOnly = conf.getBoolean(
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY,
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY_DEFAULT);
+
+    if (configEnabled && !writeMemoryBufferEnabled) {
+      LOG.info(
+          "Write memory buffer is disabled because number of configured "
+              + "volumes ({}) is not greater than minimum required volumes "
+              + "({})",
+          volsConfigured, minVolumes);
+      return;
+    }
+
+    if (writeMemoryBufferEnabled) {
+      initWriteBufferSemaphore(conf);
+      if (writeMemoryBufferLastReplicaOnly) {
+        LOG.info(
+            "{} is enabled; the buffered-write path will only run when this "
+                + "DataNode is the last in the pipeline.",
+            DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY);
+      }
+    }
+  }
+
+  private void initWriteBufferSemaphore(Configuration conf) {
+    int writeMemoryBufferMaxCapacityMB = conf.getInt(
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MAX_CAPACITY_MB,
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MAX_CAPACITY_MB_DEFAULT);
+    int maxWriteBufferCapacity = conf.getInt(
+        DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES,
+        DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES_DEFAULT);
+    maxWriteBufferCapacity = Math.max(maxWriteBufferCapacity, 1024 * 1024);
+    writeMemoryBufferMaxCapacityMB = writeMemoryBufferMaxCapacityMB > 0
+        ? writeMemoryBufferMaxCapacityMB
+        : (int) ((Runtime.getRuntime().maxMemory() / (1024 * 1024)) / 10);
+    long writeMemoryBufferMaxCapacityBytes =
+        writeMemoryBufferMaxCapacityMB * 1024L * 1024L;
+    int maxConcurrentWrites = Math.max(
+        (int) (writeMemoryBufferMaxCapacityBytes / maxWriteBufferCapacity),
+        1);
+    this.maxConcurrentWriteBuffersSemaphore = new Semaphore(maxConcurrentWrites);
+    LOG.info(
+        "Configuring pooled write buffer with max-concurrent buffers = {}, "
+            + "max-buffer capacity={}MB",
+        maxConcurrentWrites, writeMemoryBufferMaxCapacityMB);
   }
 
   @Override  // ReconfigurableBase
@@ -2596,6 +2693,11 @@ public class DataNode extends ReconfigurableBase
     LOG.info("Waiting up to 30 seconds for transfer threads to complete");
     HadoopExecutors.shutdown(this.xferService, LOG, 15L, TimeUnit.SECONDS);
 
+    if (this.bufferFlushService != null) {
+      HadoopExecutors.shutdown(this.bufferFlushService, LOG, 5L,
+          TimeUnit.SECONDS);
+    }
+
     // wait for all data receiver threads to exit
     if (this.threadGroup != null) {
       int sleepMs = 2;
@@ -4218,6 +4320,14 @@ public class DataNode extends ReconfigurableBase
   }
 
   /**
+   * Returns the DataNode scheduler used by buffered block writers to flush
+   * idle buffers, or null if idle flush is disabled.
+   */
+  public ScheduledExecutorService getBufferFlushService() {
+    return bufferFlushService;
+  }
+
+  /**
    * Allows submission of a disk balancer Job.
    * @param planID  - Hash value of the plan.
    * @param planVersion - Plan version, reserved for future use. We have only
@@ -4387,5 +4497,17 @@ public class DataNode extends ReconfigurableBase
   @VisibleForTesting
   public BlockPoolManager getBlockPoolManager() {
     return blockPoolManager;
+  }
+
+  public boolean isWriteMemoryBufferEnabled() {
+    return writeMemoryBufferEnabled;
+  }
+
+  public boolean isWriteMemoryBufferLastReplicaOnly() {
+    return writeMemoryBufferLastReplicaOnly;
+  }
+
+  public Semaphore getMaxConcurrentWriteBuffers() {
+    return maxConcurrentWriteBuffersSemaphore;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -777,7 +777,8 @@ class DataXceiver extends Receiver implements Runnable {
             peer.getLocalAddressString(),
             stage, latestGenerationStamp, minBytesRcvd, maxBytesRcvd,
             clientname, srcDataNode, datanode, requestedChecksum,
-            cachingStrategy, allowLazyPersist, pinning, storageId));
+            cachingStrategy, allowLazyPersist, pinning, storageId,
+            targets.length == 0));
         replica = blockReceiver.getReplica();
       } else {
         replica = datanode.data.recoverClose(
@@ -1253,7 +1254,7 @@ class DataXceiver extends Receiver implements Runnable {
             proxyReply, proxySock.getRemoteSocketAddress().toString(),
             proxySock.getLocalSocketAddress().toString(),
             null, 0, 0, 0, "", null, datanode, remoteChecksum,
-            CachingStrategy.newDropBehind(), false, false, storageId));
+            CachingStrategy.newDropBehind(), false, false, storageId, true));
         
         // receive a block
         blockReceiver.receiveBlock(null, null, replyOut, null, 
@@ -1327,11 +1328,13 @@ class DataXceiver extends Receiver implements Runnable {
       CachingStrategy cachingStrategy,
       final boolean allowLazyPersist,
       final boolean pinning,
-      final String storageId) throws IOException {
+      final String storageId,
+      final boolean isLastInPipeline) throws IOException {
     return new BlockReceiver(block, storageType, in,
         inAddr, myAddr, stage, newGs, minBytesRcvd, maxBytesRcvd,
         clientname, srcDataNode, dn, requestedChecksum,
-        cachingStrategy, allowLazyPersist, pinning, storageId);
+        cachingStrategy, allowLazyPersist, pinning, storageId,
+        isLastInPipeline);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
 import java.io.BufferedWriter;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -35,10 +36,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -147,6 +151,34 @@ public class FsVolumeImpl implements FsVolumeSpi {
    * contention.
    */
   protected ThreadPoolExecutor cacheExecutor;
+  private BufferWriteResource bufferResources;
+  private int maxWriteBufferCapacityBytes;
+
+  public static class BufferWriteResource implements Closeable {
+    private final Semaphore flushPermitSemaphore;
+    private ExecutorService volumeExecutor = new ThreadPoolExecutor(1, 1,
+        Long.MAX_VALUE, TimeUnit.NANOSECONDS, new LinkedBlockingQueue<>(64000));
+
+    public BufferWriteResource(Semaphore flushPermitSemaphore) {
+      this.flushPermitSemaphore = flushPermitSemaphore;
+    }
+
+    public Optional<Semaphore> getFlushPermitSemaphore() {
+      return Optional.ofNullable(flushPermitSemaphore);
+    }
+
+    public ExecutorService getVolumeExecutor() {
+      return volumeExecutor;
+    }
+
+    @Override
+    public void close() {
+      if (volumeExecutor != null) {
+        volumeExecutor.shutdown();
+        volumeExecutor = null;
+      }
+    }
+  }
 
   FsVolumeImpl(FsDatasetImpl dataset, String storageID, StorageDirectory sd,
       FileIoProvider fileIoProvider, Configuration conf) throws IOException {
@@ -196,6 +228,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
     }
     this.conf = conf;
     this.fileIoProvider = fileIoProvider;
+    initBufferWriteResource(conf);
     this.enableSameDiskTiering =
         conf.getBoolean(DFSConfigKeys.DFS_DATANODE_ALLOW_SAME_DISK_TIERING,
             DFSConfigKeys.DFS_DATANODE_ALLOW_SAME_DISK_TIERING_DEFAULT);
@@ -204,6 +237,32 @@ public class FsVolumeImpl implements FsVolumeSpi {
     } else {
       mount = "";
     }
+  }
+
+  private void initBufferWriteResource(Configuration conf) {
+    int configuredCapacityBytes = conf.getInt(
+        DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES,
+        DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES_DEFAULT);
+    final int minBufferBytes = 1024 * 1024;
+    if (configuredCapacityBytes < minBufferBytes) {
+      LOG.warn(
+          "Configured {}={} is below the safe minimum of {} bytes; clamping "
+              + "to the minimum.",
+          DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES,
+          configuredCapacityBytes, minBufferBytes);
+      configuredCapacityBytes = minBufferBytes;
+    }
+    this.maxWriteBufferCapacityBytes = configuredCapacityBytes;
+
+    int concurrentFlushWritesMB = conf.getInt(
+        DFSConfigKeys.DFS_DATANODE_CONCURRENT_FLUSH_MB_PER_VOLUME,
+        DFSConfigKeys.DFS_DATANODE_CONCURRENT_FLUSH_MB_PER_VOLUME_DEFAULT);
+    int concurrentFlushWrites = concurrentFlushWritesMB
+        / (maxWriteBufferCapacityBytes / (1024 * 1024));
+    Semaphore flushPermitSemaphore = concurrentFlushWrites > 0
+        ? new Semaphore(concurrentFlushWrites, true)
+        : null;
+    bufferResources = new BufferWriteResource(flushPermitSemaphore);
   }
 
   String getMount() {
@@ -1111,6 +1170,9 @@ public class FsVolumeImpl implements FsVolumeSpi {
     if (metrics != null) {
       metrics.unRegister();
     }
+    if (bufferResources != null) {
+      bufferResources.close();
+    }
   }
 
   void addBlockPool(String bpid, Configuration c) throws IOException {
@@ -1598,5 +1660,13 @@ public class FsVolumeImpl implements FsVolumeSpi {
       ReplicaInfo replicaInfo, RamDiskReplica replicaState) throws IOException {
     return getBlockPoolSlice(bpid).activateSavedReplica(replicaInfo,
         replicaState);
+  }
+
+  public BufferWriteResource getBufferResources() {
+    return bufferResources;
+  }
+
+  public int getMaxWriteBufferCapacityBytes() {
+    return maxWriteBufferCapacityBytes;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1745,6 +1745,16 @@
 </property>
 
 <property>
+  <name>dfs.datanode.read.ahead.cache.bytes.threshold</name>
+  <value>262144</value>
+  <description>
+        Minimum read length, in bytes, for applying DataNode-wide read-ahead
+        and drop-cache defaults to block reads. Client-specified caching
+        strategies continue to take precedence for shorter reads.
+  </description>
+</property>
+
+<property>
   <name>dfs.datanode.drop.cache.behind.writes</name>
   <value>false</value>
   <description>
@@ -3954,6 +3964,76 @@
     If it is set to zero or negative value, no buffer size will be set
     explicitly, thus enable tcp auto-tuning on some system.
     The default value is 0.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.write.memory.buffer.enabled</name>
+  <value>false</value>
+  <description>
+    Enables an in-memory DataNode write buffer for new replica-being-written
+    block files. When enabled, packet data is accumulated in a per-block buffer
+    and flushed to disk in larger batches.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.write.memory.buffer.last-replica-only</name>
+  <value>true</value>
+  <description>
+    When the in-memory DataNode write buffer is enabled, restrict the buffered
+    write path to the final DataNode in the write pipeline. Earlier replicas
+    continue to use the standard write path.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.write.memory.buffer.max.capacity.mb</name>
+  <value>-1</value>
+  <description>
+    Maximum DataNode heap-derived capacity, in megabytes, that may be used for
+    active write buffers. A value less than or equal to zero uses a small
+    fraction of the DataNode JVM maximum memory.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.write.memory.buffer.min.volumes</name>
+  <value>0</value>
+  <description>
+    Enables the write-memory-buffer path only when the DataNode has more than
+    this many configured storage volumes. A value of zero disables this volume
+    count gate.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.concurrent.flush.mb.per.volume</name>
+  <value>0</value>
+  <description>
+    Per-volume limit, in megabytes, used to derive the number of concurrent
+    write-buffer flushes allowed on a volume. A value of zero disables the
+    flush concurrency limit.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.write.buffer.size.bytes</name>
+  <value>8388608</value>
+  <description>
+    Size, in bytes, of each DataNode in-memory block write buffer. Values below
+    one megabyte are clamped to one megabyte when buffer resources are
+    initialized.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.write.buffer.idle.flush.timeout.ms</name>
+  <value>0</value>
+  <description>
+    If greater than zero, a DataNode using the write-memory-buffer path flushes
+    buffered block data to disk when no packet has been received for this many
+    milliseconds.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverIdleBufferFlush.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverIdleBufferFlush.java
@@ -1,0 +1,351 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for the DataNode idle buffer-flush task
+ * ({@code dfs.datanode.write.buffer.idle.flush.timeout.ms}).
+ *
+ * <p>
+ * Scenario exercised (the data-loss window this feature closes): the
+ * write-memory-buffer is enabled. A client writes data, the DataNode buffers
+ * it in memory,
+ * and then the client stalls without sending the final packet. Without this
+ * feature the buffered bytes would never reach disk until close, so a DataNode
+ * crash would lose them. With the feature, an idle period triggers a flush of
+ * just the in-memory buffer to the (DSYNC) block file.
+ * </p>
+ *
+ * <p>
+ * The test asserts both that the flush actually persists bytes to the on-disk
+ * block file mid-write, and that interleaving more writes after a flush does
+ * not corrupt the block: after close, the file reads back byte-for-byte and
+ * HDFS read-path checksum verification passes.
+ * </p>
+ */
+public class TestBlockReceiverIdleBufferFlush {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestBlockReceiverIdleBufferFlush.class);
+
+  // Large enough that the "buffered bytes are not on disk yet" check right
+  // after hflush cannot race a premature idle flush (the timer only fires this
+  // long after the last packet), while still well under the 120s test timeout.
+  private static final long IDLE_FLUSH_MS = 10000;
+  private static final int CHUNK = 256 * 1024; // 256 KB, well under 8 MB buffer
+  private static final String FLUSH_MARKER = "Idle-flushed write buffer";
+
+  private MiniDFSCluster cluster;
+  private DistributedFileSystem fs;
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (fs != null) {
+      fs.close();
+      fs = null;
+    }
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  /**
+   * End-to-end: stalled write -> idle flush persists data -> resume write ->
+   * idle flush again -> close -> read back and validate integrity.
+   */
+  @Test
+  @Timeout(120)
+  public void testIdleFlushPersistsBufferedDataWithoutCorruption()
+      throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    // Feature under test: buffer ON and idle-flush ON.
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS,
+        IDLE_FLUSH_MS);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 512);
+    // Keep all data in a single block so one buffer/replica is exercised.
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16 * 1024 * 1024);
+
+    // Single DataNode => deterministic single replica; replication 1.
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+    fs = cluster.getFileSystem();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer must be enabled for this test");
+
+    LogCapturer logs = LogCapturer.captureLogs(DataNode.LOG);
+    final Path path = new Path("/testIdleBufferFlush");
+
+    final byte[] data1 = newPattern(CHUNK, 0);
+    final byte[] data2 = newPattern(CHUNK, 7);
+
+    FSDataOutputStream out = null;
+    try {
+      out = fs.create(path, (short) 1);
+
+      // --- Phase 1: write data1, push it to the DN, then stall. ---
+      // hflush guarantees the packets are received and processed by the DN
+      // (acked) into the in-memory buffer. The buffered-write path returns
+      // early on a non-sync flush, so the data is NOT yet on the block file.
+      out.write(data1);
+      out.hflush();
+
+      final ExtendedBlock block = firstBlock(path);
+      assertTrue(block != null, "Block should be allocated after hflush");
+
+      // Right after hflush, before the idle window elapses, the bytes are in
+      // memory only: the on-disk block file is still empty.
+      long beforeFlush = onDiskLength(dn, block);
+      assertTrue(beforeFlush < data1.length,
+          "Buffered data must not be on disk before the idle flush "
+              + "(on-disk length was " + beforeFlush + ")");
+
+      // --- Phase 2: wait for the idle flush to persist data1. ---
+      GenericTestUtils.waitFor(() -> {
+        try {
+          return onDiskLength(dn, block) >= data1.length;
+        } catch (IOException e) {
+          return false;
+        }
+      }, 100, 30000);
+      assertEquals(data1.length, onDiskLength(dn, block),
+          "Idle flush must persist exactly the buffered bytes");
+      assertTrue(countOccurrences(logs.getOutput(), FLUSH_MARKER) >= 1,
+          "Idle-flush log marker must be present after first flush");
+
+      // --- Phase 3: resume writing data2 to confirm no corruption. ---
+      // Writing more after an off-thread flush must not throw or corrupt the
+      // stream/checksum state.
+      out.write(data2);
+      out.hflush();
+
+      // --- Phase 4: wait for a second idle flush covering data1 + data2. ---
+      GenericTestUtils.waitFor(() -> {
+        try {
+          return onDiskLength(dn, block) >= (long) data1.length + data2.length;
+        } catch (IOException e) {
+          return false;
+        }
+      }, 100, 30000);
+      assertEquals((long) data1.length + data2.length,
+          onDiskLength(dn, block),
+          "Second idle flush must persist all buffered bytes");
+      assertTrue(countOccurrences(logs.getOutput(), FLUSH_MARKER) >= 2,
+          "Idle-flush log marker must appear at least twice");
+
+      // --- Phase 5: close the stream normally. ---
+      out.close();
+      out = null;
+    } finally {
+      if (out != null) {
+        try {
+          out.close();
+        } catch (IOException e) {
+          LOG.warn("Error closing output stream", e);
+        }
+      }
+      logs.stopCapturing();
+    }
+
+    // --- Phase 6: read back and validate integrity + checksums. ---
+    // fs.open + readFully runs the HDFS read path, which verifies CRCs against
+    // the meta file; a corrupt block would throw ChecksumException here.
+    final byte[] expected = new byte[data1.length + data2.length];
+    System.arraycopy(data1, 0, expected, 0, data1.length);
+    System.arraycopy(data2, 0, expected, data1.length, data2.length);
+
+    assertEquals(expected.length, fs.getFileStatus(path).getLen(),
+        "File length must equal total bytes written");
+
+    final byte[] readBack = new byte[expected.length];
+    try (FSDataInputStream in = fs.open(path)) {
+      in.readFully(readBack);
+      // EOF expected right after the last byte.
+      assertEquals(-1, in.read(), "No extra bytes expected beyond written data");
+    }
+    assertArrayEquals(expected, readBack, "Read-back data must match written data exactly "
+        + "(checksums verified by the read path)");
+  }
+
+  /**
+   * Regression: the one-shot flush timer must rearm on EVERY firing, not only
+   * after a successful flush. If it only rescheduled after flushing, a tick
+   * that fires while the client is still actively writing (idle &lt; timeout)
+   * would return without rearming and permanently disable idle-flush for the
+   * block — so a later stall would never be caught.
+   *
+   * <p>
+   * This drives a phase of active writes spaced shorter than the idle timeout
+   * (forcing no-op ticks), then stalls and asserts the accumulated buffer is
+   * still flushed to disk. With the "rearm only after flush" bug the timer
+   * dies during the active phase and this flush never happens.
+   * </p>
+   */
+  @Test
+  @Timeout(120)
+  public void testTimerRearmsAfterNoOpTickThenStall() throws Exception {
+    final long idleMs = 1000;
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS,
+        idleMs);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 512);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16 * 1024 * 1024);
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+    fs = cluster.getFileSystem();
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled());
+
+    final Path path = new Path("/testTimerRearm");
+    final byte[] data1 = newPattern(CHUNK, 0);
+    final int smallSize = 64 * 1024;
+
+    FSDataOutputStream out = null;
+    long totalWritten = 0;
+    try {
+      out = fs.create(path, (short) 1);
+      out.write(data1);
+      out.hflush();
+      totalWritten += data1.length;
+      final ExtendedBlock block = firstBlock(path);
+      assertTrue(block != null, "Block should be allocated");
+
+      // First idle flush persists data1 (timer rearms after this success).
+      final long afterData1 = totalWritten;
+      GenericTestUtils.waitFor(() -> safeOnDisk(dn, block) >= afterData1,
+          100, 30000);
+
+      // Active phase: write every idleMs/2 for several timer intervals. Each
+      // timer firing sees idle < idleMs => a no-op tick that must still rearm.
+      for (int i = 0; i < 6; i++) {
+        byte[] small = newPattern(smallSize, i + 1);
+        out.write(small);
+        out.hflush();
+        totalWritten += smallSize;
+        Thread.sleep(idleMs / 2);
+      }
+
+      // Now stall. If the timer is still armed it fires within idleMs and
+      // flushes the buffered bytes accumulated during the active phase.
+      final long expectedOnDisk = totalWritten;
+      GenericTestUtils.waitFor(() -> safeOnDisk(dn, block) >= expectedOnDisk,
+          100, 30000);
+      assertEquals(expectedOnDisk, onDiskLength(dn, block),
+          "Idle flush must persist all buffered bytes after a stall "
+              + "that follows no-op timer ticks");
+
+      out.close();
+      out = null;
+    } finally {
+      if (out != null) {
+        try {
+          out.close();
+        } catch (IOException e) {
+          LOG.warn("Error closing output stream", e);
+        }
+      }
+    }
+
+    // Integrity check on the full file.
+    assertEquals(totalWritten, fs.getFileStatus(path).getLen());
+    final byte[] readBack = new byte[(int) totalWritten];
+    try (FSDataInputStream in = fs.open(path)) {
+      in.readFully(readBack);
+    }
+    final byte[] prefix = new byte[data1.length];
+    System.arraycopy(readBack, 0, prefix, 0, data1.length);
+    assertArrayEquals(data1, prefix, "data1 prefix must round-trip intact");
+  }
+
+  /** {@link #onDiskLength} swallowing IOException, for use in waitFor lambdas. */
+  private static long safeOnDisk(DataNode dn, ExtendedBlock block) {
+    try {
+      return onDiskLength(dn, block);
+    } catch (IOException e) {
+      return -1;
+    }
+  }
+
+  /** On-disk length of the block data file for {@code block} on {@code dn}. */
+  private static long onDiskLength(DataNode dn, ExtendedBlock block)
+      throws IOException {
+    ReplicaInfo r = DataNodeTestUtils.fetchReplicaInfo(
+        dn, block.getBlockPoolId(), block.getBlockId());
+    return r == null ? -1 : r.getBlockDataLength();
+  }
+
+  /** First located block of an (open-for-write) file. */
+  private ExtendedBlock firstBlock(Path path) throws IOException {
+    LocatedBlocks lbs =
+        fs.getClient().getLocatedBlocks(path.toString(), 0L);
+    if (lbs == null || lbs.getLocatedBlocks().isEmpty()) {
+      return null;
+    }
+    return lbs.getLocatedBlocks().get(0).getBlock();
+  }
+
+  /** Deterministic, position-dependent byte pattern with a per-chunk offset. */
+  private static byte[] newPattern(int size, int seed) {
+    byte[] b = new byte[size];
+    for (int i = 0; i < size; i++) {
+      b[i] = (byte) ((i + seed) % 251);
+    }
+    return b;
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeWriteMemoryBuffer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeWriteMemoryBuffer.java
@@ -1,0 +1,611 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for DataNode write memory buffer configuration based on number of volumes.
+ */
+public class TestDataNodeWriteMemoryBuffer {
+
+  private MiniDFSCluster cluster;
+
+  @AfterEach
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  /**
+   * Test that write memory buffer is enabled when config is true and minVolumes is 0.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferEnabledWithMinVolumesZero() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+
+    // Create cluster with 2 volumes
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(2)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be enabled when minVolumes is 0");
+  }
+
+  /**
+   * Test that write memory buffer is disabled when config is false regardless of volumes.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferDisabledWhenConfigFalse() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, false);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+
+    // Create cluster with 3 volumes
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(3)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertFalse(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be disabled when config is false");
+  }
+
+  /**
+   * Test that write memory buffer is enabled when volumes > minVolumes.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferEnabledWhenVolumesGreaterThanMin() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 2);
+
+    // Create cluster with 3 volumes (3 > 2)
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(3)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be enabled when volumes (3) > "
+            + "minVolumes (2)");
+  }
+
+  /**
+   * Test that write memory buffer is disabled when volumes <= minVolumes.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferDisabledWhenVolumesEqualToMin() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 2);
+
+    // Create cluster with 2 volumes (2 == 2, not greater than)
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(2)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertFalse(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be disabled when volumes (2) == "
+            + "minVolumes (2)");
+  }
+
+  /**
+   * Test that write memory buffer is disabled when volumes < minVolumes.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferDisabledWhenVolumesLessThanMin() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 3);
+
+    // Create cluster with 2 volumes (2 < 3)
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(2)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertFalse(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be disabled when volumes (2) < "
+            + "minVolumes (3)");
+  }
+
+  /**
+   * Test that write memory buffer is enabled when minVolumes is negative (ignored).
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferEnabledWithNegativeMinVolumes() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, -1);
+
+    // Create cluster with 1 volume
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(1)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be enabled when minVolumes is negative "
+            + "(ignored)");
+  }
+
+  /**
+   * Test edge case: exactly one more volume than minimum.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBufferEnabledWithOneMoreVolume() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 4);
+
+    // Create cluster with 5 volumes (5 > 4 by exactly 1)
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(5)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(),
+        "Write memory buffer should be enabled when volumes (5) > "
+            + "minVolumes (4)");
+  }
+
+  /**
+   * Regression for codex review on PR #2012 (DataNode.java line 660):
+   * {@code initWriteBufferSemaphore} must apply the same 1 MB floor to
+   * {@code dfs.datanode.write.buffer.size.bytes} that
+   * {@code FsVolumeImpl.initBufferWriteResource} already applies before
+   * computing the permit count. Otherwise sub-1 MB configs cause the
+   * semaphore to over-issue permits relative to the actual (clamped)
+   * per-buffer allocation, blowing past the configured memory budget.
+   *
+   * <p>Scenario:
+   * <ul>
+   *   <li>{@code dfs.datanode.write.memory.buffer.max.capacity.mb=100}
+   *       → total budget 100 MB.</li>
+   *   <li>{@code dfs.datanode.write.buffer.size.bytes=524288} (512 KB,
+   *       sub-1 MB) → FsVolumeImpl clamps the per-buffer allocation to
+   *       1 MB.</li>
+   *   <li>Permit count must be {@code 100 MB / 1 MB = 100} — NOT
+   *       {@code 100 MB / 512 KB = 200} which would correspond to
+   *       200 × 1 MB = 200 MB actual memory, twice the configured
+   *       budget.</li>
+   * </ul>
+   */
+  @Test
+  @Timeout(60)
+  public void testSemaphorePermitsMatchClampedBufferSizeForSubMbConfig()
+      throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    // 100 MB total memory budget for buffers.
+    conf.setInt(
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MAX_CAPACITY_MB, 100);
+    // Per-buffer config = 512 KB, sub-1 MB. FsVolumeImpl clamps to 1 MB.
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_SIZE_BYTES,
+        512 * 1024);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled());
+    assertEquals(100, dn.getMaxConcurrentWriteBuffers().availablePermits(),
+        "initWriteBufferSemaphore must apply the same 1 MB floor as "
+            + "FsVolumeImpl. With max-capacity=100 MB and a sub-1 MB "
+            + "per-buffer config, permits must be 100 (=100 MB / 1 MB), "
+            + "not 200 (=100 MB / 512 KB) which would correspond to "
+            + "200 MB of actual memory.");
+  }
+
+  /**
+   * Safe-rollout: with
+   * {@link DFSConfigKeys#DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY}=true
+   * and replication 3, the buffered-write path must run on exactly one
+   * DataNode per block — the terminal (last) replica in the pipeline. The
+   * earlier two replicas must use the legacy non-buffered path. This bounds
+   * blast radius to a single replica if the buffered code regresses.
+   *
+   * <p>BlockReceiver emits "During closing buffer" on {@code DataNode.LOG}
+   * only when {@code useWriteBuffer} is true for that block. With 3 DNs in
+   * one JVM (MiniDFSCluster), all writes share a single logger — so a count
+   * of 1 across the cluster equals "exactly the last DN used the buffer".</p>
+   */
+  @Test
+  @Timeout(120)
+  public void testWriteBufferOnlyLastReplicaInPipeline() throws Exception {
+    final String bufferedPathMarker = "During closing buffer";
+
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setBoolean(
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY,
+        true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(3)
+        .build();
+    cluster.waitActive();
+
+    for (DataNode dn : cluster.getDataNodes()) {
+      assertTrue(dn.isWriteMemoryBufferEnabled(),
+          "Each DataNode must have writeMemoryBufferEnabled = true");
+      assertTrue(dn.isWriteMemoryBufferLastReplicaOnly(),
+          "Each DataNode must have writeMemoryBufferLastReplicaOnly = true");
+    }
+
+    LogCapturer logCapturer = LogCapturer.captureLogs(DataNode.LOG);
+    try {
+      FileSystem fs = cluster.getFileSystem();
+      Path p = new Path("/test/last-replica-only.txt");
+      byte[] payload =
+          "safe rollout: only last replica uses buffered path"
+              .getBytes(StandardCharsets.UTF_8);
+      try (FSDataOutputStream out = fs.create(p, (short) 3)) {
+        out.write(payload);
+      }
+      byte[] read = new byte[payload.length];
+      try (FSDataInputStream in = fs.open(p)) {
+        in.readFully(read);
+      }
+      assertArrayEquals(payload, read, "Write/read must succeed across the pipeline");
+
+      int bufferedCloses = countOccurrences(
+          logCapturer.getOutput(), bufferedPathMarker);
+      assertEquals(1, bufferedCloses, "With last-replica-only=true and replication 3, exactly one "
+              + "DataNode (the terminal replica) must exercise the buffered "
+              + "path; got " + bufferedCloses + " '"
+              + bufferedPathMarker + "' log lines");
+    } finally {
+      logCapturer.stopCapturing();
+    }
+  }
+
+  /**
+   * Control test: with the master flag on and
+   * last-replica-only=false (default), ALL three replicas use the buffered
+   * path. Confirms the gating in
+   * {@code testWriteBufferOnlyLastReplicaInPipeline} is the new flag's
+   * behaviour, not an unrelated bug.
+   */
+  @Test
+  @Timeout(120)
+  public void testWriteBufferAllReplicasWhenLastReplicaOnlyDisabled()
+      throws Exception {
+    final String bufferedPathMarker = "During closing buffer";
+
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    // Explicitly disable last-replica-only (its default is true) so all
+    // replicas exercise the buffered path.
+    conf.setBoolean(
+        DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_LAST_REPLICA_ONLY, false);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(3)
+        .build();
+    cluster.waitActive();
+
+    for (DataNode dn : cluster.getDataNodes()) {
+      assertFalse(dn.isWriteMemoryBufferLastReplicaOnly(),
+          "last-replica-only must be off for this test");
+    }
+
+    LogCapturer logCapturer = LogCapturer.captureLogs(DataNode.LOG);
+    try {
+      FileSystem fs = cluster.getFileSystem();
+      Path p = new Path("/test/all-replicas-buffered.txt");
+      byte[] payload =
+          "all replicas use the buffered path".getBytes(StandardCharsets.UTF_8);
+      try (FSDataOutputStream out = fs.create(p, (short) 3)) {
+        out.write(payload);
+      }
+
+      int bufferedCloses = countOccurrences(
+          logCapturer.getOutput(), bufferedPathMarker);
+      assertEquals(3, bufferedCloses, "With last-replica-only=false and replication 3, all three "
+              + "DataNodes must exercise the buffered path; got "
+              + bufferedCloses + " '" + bufferedPathMarker + "' log lines");
+    } finally {
+      logCapturer.stopCapturing();
+    }
+  }
+
+  /**
+   * Guards the rolled-out default: {@code last-replica-only} now defaults to
+   * {@code true}, so when the feature is enabled without explicitly setting it,
+   * only the terminal DataNode in a pipeline takes the buffered-write path.
+   */
+  @Test
+  @Timeout(60)
+  public void testLastReplicaOnlyDefaultsToTrue() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+    // Intentionally do NOT set last-replica-only: rely on the default.
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(), "Write memory buffer should be enabled");
+    assertTrue(dn.isWriteMemoryBufferLastReplicaOnly(), "last-replica-only must default to true");
+  }
+
+  /**
+   * Refactor guard: when the write-memory-buffer feature does not produce a
+   * buffer for a block, {@code BlockReceiver.buffer} is left {@code null} (the
+   * old {@code NO_OP_INSTANCE} was removed) and the receiver must fall back to
+   * the direct stream write path. Here the master flag is ON but the feature is
+   * gated OFF at the DataNode (configured volumes do not exceed min.volumes),
+   * so no buffer is initialized. The write/read round-trip — including read-path
+   * checksum verification — must still succeed, and the buffered-write marker
+   * must never appear (proving the buffer was not used).
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteReadWorksWhenBufferNotInitialized() throws Exception {
+    final String bufferedPathMarker = "During closing buffer";
+
+    Configuration conf = new HdfsConfiguration();
+    // Master flag ON ...
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    // ... but gated OFF: require more volumes than are configured (1 storage).
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 5);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 512);
+
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .storagesPerDatanode(1)
+        .build();
+    cluster.waitActive();
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertFalse(dn.isWriteMemoryBufferEnabled(),
+        "Feature must be gated off at the DN (volumes <= min.volumes), so the "
+            + "buffer is never initialized");
+
+    // Deterministic, multi-packet payload to exercise receivePacket's
+    // null-buffer branch repeatedly.
+    final byte[] payload = new byte[512 * 1024];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) ((i * 31 + 7) % 251);
+    }
+
+    LogCapturer logs = LogCapturer.captureLogs(DataNode.LOG);
+    final Path p = new Path("/test/buffer-not-initialized.dat");
+    try {
+      FileSystem fs = cluster.getFileSystem();
+      try (FSDataOutputStream out = fs.create(p, (short) 1)) {
+        out.write(payload);
+      }
+
+      // Read back through the HDFS read path (verifies CRCs against the meta
+      // file; a corrupt/mismatched block would throw here).
+      byte[] readBack = new byte[payload.length];
+      try (FSDataInputStream in = fs.open(p)) {
+        in.readFully(readBack);
+        assertEquals(-1, in.read(),
+            "No bytes expected beyond the written payload");
+      }
+      assertArrayEquals(payload, readBack,
+          "Data must round-trip intact through the non-buffered write path");
+      assertEquals(payload.length, fs.getFileStatus(p).getLen(),
+          "File length must match what was written");
+
+      assertEquals(0, countOccurrences(logs.getOutput(), bufferedPathMarker),
+          "Buffer must not be used when it is not initialized; the buffered "
+              + "close marker must not appear");
+    } finally {
+      logs.stopCapturing();
+    }
+  }
+
+  /**
+   * Regression test for the hflush visibility break: with write buffering,
+   * bytes still sitting in the in-memory buffer must NOT be exposed as the RBW
+   * replica's visible/acked length. Otherwise a concurrent reader (BlockSender,
+   * short-circuit, replica-pinned) would read past the physical end of the
+   * block file and hit a short read / checksum mismatch / stale bytes.
+   *
+   * <p>The invariant asserted here: the replica's acked (visible) length is
+   * never greater than the number of bytes actually flushed to the block file.
+   * A sub-buffer write followed by hflush (which does not fill or fsync the
+   * buffer, and with the idle flush disabled) leaves the data purely in memory,
+   * so the visible length must stay at or below the on-disk length.
+   */
+  @Test
+  @Timeout(60)
+  public void testAckedLengthNeverExceedsOnDiskLength() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+    // Disable the idle flush so buffered data is not persisted behind our back.
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS, 0);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 512);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16 * 1024 * 1024);
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+    FileSystem fs = cluster.getFileSystem();
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(), "Write memory buffer must be enabled");
+
+    // 256 KB: well under the 8 MB buffer, so it stays in memory after hflush.
+    final int size = 256 * 1024;
+    final byte[] payload = new byte[size];
+    for (int i = 0; i < size; i++) {
+      payload[i] = (byte) (i % 251);
+    }
+
+    final Path path = new Path("/testAckedVsOnDisk");
+    try (FSDataOutputStream out = fs.create(path, (short) 1)) {
+      out.write(payload);
+      out.hflush();
+
+      org.apache.hadoop.hdfs.protocol.LocatedBlocks lbs =
+          cluster.getFileSystem().getClient()
+              .getLocatedBlocks(path.toString(), 0L);
+      assertFalse(lbs.getLocatedBlocks().isEmpty(),
+          "Block must be allocated after hflush");
+      org.apache.hadoop.hdfs.protocol.ExtendedBlock block =
+          lbs.getLocatedBlocks().get(0).getBlock();
+
+      ReplicaInfo r = DataNodeTestUtils.fetchReplicaInfo(
+          dn, block.getBlockPoolId(), block.getBlockId());
+      assertTrue(r instanceof ReplicaInPipeline,
+          "Replica must be a ReplicaInPipeline while being written");
+      long ackedLen = ((ReplicaInPipeline) r).getBytesAcked();
+      long onDiskLen = r.getBlockDataLength();
+
+      // The core invariant: never expose more than what is physically on disk.
+      assertTrue(ackedLen <= onDiskLen,
+          "Acked/visible length (" + ackedLen + ") must not exceed the "
+              + "on-disk block file length (" + onDiskLen + ") for buffered, "
+              + "un-synced data");
+    }
+
+    // After close everything is flushed and finalized: full data reads back.
+    final byte[] readBack = new byte[size];
+    try (FSDataInputStream in = fs.open(path)) {
+      in.readFully(readBack);
+    }
+    assertArrayEquals(payload, readBack, "Data must round-trip intact after close");
+    assertEquals(size, fs.getFileStatus(path).getLen(),
+        "Finalized file length must equal bytes written");
+  }
+
+  /**
+   * Correctness test for buffered writes across a non-chunk-aligned hflush.
+   * A client writes an unaligned amount, hflushes (which does NOT flush the
+   * write buffer), then keeps writing across the next chunk boundary. This
+   * exercises {@code BufferedBlockWriter.writeData} with unaligned on-disk
+   * offsets and the checksum-rewrite path, and verifies the data round-trips
+   * intact after close.
+   */
+  @Test
+  @Timeout(60)
+  public void testBufferedWriteRoundTripAcrossUnalignedHflush() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_ENABLED, true);
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_WRITE_MEMORY_BUFFER_MIN_VOLUMES, 0);
+    // Disable the idle flush so buffered data is not persisted behind our back.
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_WRITE_BUFFER_IDLE_FLUSH_TIMEOUT_MS, 0);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 512);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16 * 1024 * 1024);
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+    FileSystem fs = cluster.getFileSystem();
+    DataNode dn = cluster.getDataNodes().get(0);
+    assertTrue(dn.isWriteMemoryBufferEnabled(), "Write memory buffer must be enabled");
+
+    // 700 bytes: not a multiple of bytesPerChecksum (512), so the on-disk tail
+    // is a partial chunk after the first hflush.
+    final int firstLen = 700;
+    // 1300 more bytes: continues past the partial chunk and across the next
+    // chunk boundary, forcing the DataNode to recompute the partial-chunk CRC.
+    final int secondLen = 1300;
+    final int total = firstLen + secondLen;
+    final byte[] payload = new byte[total];
+    for (int i = 0; i < total; i++) {
+      payload[i] = (byte) (i % 251);
+    }
+
+    final Path path = new Path("/testBufferedUnalignedHflush");
+    try (FSDataOutputStream out = fs.create(path, (short) 1)) {
+      out.write(payload, 0, firstLen);
+      // hflush at an unaligned offset. With buffering, this does NOT flush the
+      // buffer, so the partial chunk stays in memory even though bytesOnDisk
+      // advances.
+      out.hflush();
+      // Continue writing across the next chunk boundary. The buffered writer
+      // must handle the unaligned on-disk tail and checksum rewrite correctly.
+      out.write(payload, firstLen, secondLen);
+      out.hflush();
+    }
+
+    final byte[] readBack = new byte[total];
+    try (FSDataInputStream in = fs.open(path)) {
+      in.readFully(readBack);
+    }
+    assertArrayEquals(payload, readBack, "Data must round-trip intact across an unaligned hflush "
+        + "followed by more writes");
+    assertEquals(total, fs.getFileStatus(path).getLen(),
+        "Finalized file length must equal bytes written");
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverBackwardsCompat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverBackwardsCompat.java
@@ -164,7 +164,7 @@ public class TestDataXceiverBackwardsCompat {
         anyString(), any(DatanodeInfo.class), any(DataNode.class),
         any(DataChecksum.class), any(CachingStrategy.class),
         ArgumentCaptor.forClass(Boolean.class).capture(),
-        anyBoolean(), any());
+        anyBoolean(), any(), anyBoolean());
 
     Token<BlockTokenIdentifier> token = (Token<BlockTokenIdentifier>)mock(
         Token.class);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverLazyPersistHint.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverLazyPersistHint.java
@@ -155,7 +155,7 @@ public class TestDataXceiverLazyPersistHint {
         any(), any(), any(), anyString(), anyString(),
         any(), anyLong(), anyLong(), anyLong(),
         anyString(), any(), any(), any(), any(),
-        captor.capture(), anyBoolean(), any());
+        captor.capture(), anyBoolean(), any(), anyBoolean());
     doReturn(mock(DataOutputStream.class)).when(xceiverSpy)
         .getBufferedOutputStream();
     return xceiverSpy;


### PR DESCRIPTION
### Description of PR

HDFS blocks are processed as smaller packets. Concurrent writes across multiple blocks/files can interleave these packets, creating non-sequential disk I/O.

This is particularly expensive on HDDs, resulting in:

* Small and fragmented writes
* Higher IOPS and seek overhead
* Page-cache pressure from dirty pages
* Read/write contention
* Higher read and write tail latency
* Lower disk and DataNode throughput

**Goal:** Improve DataNode vertical efficiency and provide more predictable performance for mixed read/write workloads.

---

## Proposed Solution

Introduce a DataNode-managed in-memory write buffer:

```text
Small Packets
    |
    v
In-Memory Buffer
    |
    v
Large Batched Writes
    |
    v
 O_DIRECT
    |
    v
   Disk
```

### Key Design

1. **Large write buffers**

  * Accumulate small packets before flushing.
  * Reduce I/O operations and physical I/O fragmentation.
  * Improve sequential writes and disk bandwidth utilization.

2. **Direct I/O**

  * Use `O_DIRECT` for buffered flushes.
  * Avoid dirty-page pressure and preserve OS page cache for reads and read-ahead.

3. **Controlled flush concurrency**

  * Limit concurrent flush bytes per volume.
  * Balance disk parallelism, sequential I/O, and read latency.

4. **Last-replica-only mode**

  * Optionally enable buffering only on the last DataNode in the replication pipeline.

5. **Bounded memory**

  * Configurable limits for total buffer capacity, per-block buffer size, and flush concurrency.

6. **Idle flush**

  * Flush partially filled buffers after a configurable timeout.

---

## Read Path Benefit

By bypassing the OS page cache for DataNode writes, system memory can be used more effectively for:

* Read cache
* Read-ahead
* Other filesystem activity

Expected benefits:

* Lower read latency
* Better read-ahead effectiveness
* Reduced eviction of useful read pages
* Less read/write contention
* More stable mixed-workload performance

---

## Key Configuration

| Property                                             | Description                                  |
| ---------------------------------------------------- | -------------------------------------------- |
| `dfs.datanode.write.memory.buffer.enabled`           | Enable write buffering                       |
| `dfs.datanode.write.memory.buffer.last-replica-only` | Buffer only the last replica                 |
| `dfs.datanode.write.memory.buffer.max.capacity.mb`   | Maximum total buffer capacity                |
| `dfs.datanode.write.buffer.size.bytes`               | Per-block buffer size                        |
| `dfs.datanode.write.buffer.idle.flush.timeout.ms`    | Idle flush timeout                           |
| `dfs.datanode.concurrent.flush.mb.per.volume`        | Maximum concurrent flush capacity per volume |

The feature is **disabled by default**.

---

## Implementation

The change introduces:

* `BufferedBlockWriter`
* `BufferedBlockWriterImpl`

Integrated with:

* `BlockReceiver`
* `DataXceiver`
* `FsVolumeImpl`

When disabled, the existing DataNode write path remains unchanged.

---

## Benchmark Results

| Metric                                |           Improvement |
| ------------------------------------- | --------------------: |
| Mixed 80/20 read/write throughput     |           ~30% higher |
| Read-only throughput                  |     Up to ~45% higher |
| Large-block P99 write latency         |            ~80% lower |
| Read latency during concurrent writes | Significant reduction |

Disk-level results also show:

* `r_await`: Reduced from frequently >100 ms to consistently <50 ms
* `w_await`: Reduced from frequently >200 ms to <90 ms
* Per-disk throughput: Improved from ~120 MB/s to >170 MB/s under mixed workloads


---

## Expected Impact

For I/O-bound workloads:

* **25-40% higher throughput** for write-heavy workloads
* **Up to ~45% higher throughput** for read-heavy workloads
* **~80% lower large-block P99 write latency**
* Lower read latency during concurrent writes
* Reduced random I/O and disk contention
* Better disk bandwidth utilization
* More predictable mixed read/write performance

Actual gains depend on workload characteristics and storage hardware. CPU-, network-, or metadata-bound workloads are expected to see limited benefit.

### Performance impact and IO Stats
IO stats for a single disk: Before the change, the disk achieved around 120 MBps for certain read-heavy workloads, but the throughput was bursty and inconsistent. After the change, the disk consistently achieved around 170 MBps, as shown in Image 1.
Image 2 compares the read_await time before and after the change. After the change, r_await consistently remains low, enabling higher and more stable read throughput compared to the previous results.
#### Read, Write, Total Throughput
<img width="2314" height="1372" alt="Image" src="https://github.com/user-attachments/assets/f1179190-5c39-4375-99b1-f34b5009871c" />

#### Read await_time and RPS 
<img width="2328" height="1312" alt="Image" src="https://github.com/user-attachments/assets/905044a2-32e6-48ce-84ab-52389b75283e" />
---

## Rollout

* Disabled by default
* Enable selectively for benchmarking and validation
* Monitor throughput, disk utilization, IOPS, `await`, read latency, write P99, CPU, and memory
* Validate sustained mixed read/write workloads before broad rollout
* Tune buffer size and flush concurrency based on workload and storage characteristics

### Recommended Kernel tuning with this change
The following kernel settings can complement the DataNode optimization:

```
Read-ahead and larger block-layer requests
 /sys/block/sd${disk}/queue/read_ahead_kb => >4096
/sys/block/sd${disk}/queue/max_sectors_kb => 4096
```



<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->


### How was this patch tested?

Tested by newly added unit test

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html


