### PR TITLE
HDFS-17975. HDFS Client-Side Block Prefetch to Improve Large Sequential Read Throughput

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/BlockPrefetcher.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/BlockPrefetcher.java
@@ -1,0 +1,798 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.VisibleForTesting;
+
+/**
+ * Parallel, chunked sequential read-ahead prefetcher for a single
+ * {@link DFSInputStream}.
+ *
+ * <p>The file is divided into HDFS blocks. The prefetcher keeps a sliding
+ * window of up to {@code N = prefetch.size / maxBlockSize} reusable per-block
+ * buffers and fetches up to {@code dfs.client.prefetch.threads} blocks
+ * <em>concurrently</em> (each a {@link CacheBlock} with its own
+ * {@code byte[maxBlockSize]}). Each block is filled in
+ * {@code dfs.client.prefetch.chunk.size} pieces; after every chunk the fetch
+ * publishes how many bytes are ready via an {@link AtomicLong}, so the reader
+ * can consume a block's prefix before the whole block has landed.
+ *
+ * <p>The reader never blocks on a prefetch. When it reaches an offset that the
+ * block's fetch has not yet reached (i.e. the reader has out-run the prefetch),
+ * that prefetch is <em>cancelled</em> and the reader falls back to a direct
+ * DataNode read for the remainder — the already-fetched prefix is served from
+ * cache and the suffix is read remotely, so no byte is fetched twice.
+ *
+ * <p>The block the reader first lands on (after open or seek) is always read
+ * through the normal path; only blocks ahead of the cursor are prefetched.
+ * Single-block files never prefetch.
+ *
+ * <p>Thread-safety: window/buffer bookkeeping is guarded by {@link #lock}. A
+ * block's data array has exactly one writer (its fetch thread) and one reader
+ * (the foreground); they synchronize lock-free through {@link CacheBlock#
+ * bytesReady} (the reader only ever touches bytes below {@code bytesReady},
+ * all of which were written before that value was published). Fetch threads
+ * perform their (blocking) I/O outside {@link #lock} and never acquire the
+ * {@code DFSInputStream} monitor.
+ */
+@InterfaceAudience.Private
+class BlockPrefetcher {
+
+  private static final int SUCCESS = 0;
+  private static final int CANCELLED = 1;
+  private static final int FAILED = 2;
+
+  /** One HDFS block held in memory, filled incrementally. */
+  static final class CacheBlock {
+    final byte[] data;            // length == maxBlockSize, reused
+    final long blockIndex;
+    final long startOffset;       // absolute file offset of block start
+    final long endOffset;         // exclusive
+    final AtomicLong bytesReady = new AtomicLong(0); // [start, start+ready)
+    volatile boolean cancelled;
+    volatile boolean done;
+    volatile boolean failed;
+    // Locality of the reader that filled this block, recorded before any bytes
+    // are published (so a reader that observes bytesReady > 0 also observes
+    // these). Used to attribute cache-served bytes to the correct
+    // local/remote/short-circuit bucket in the read statistics.
+    volatile boolean shortCircuit;
+    volatile int networkDistance;    // 0 == local, > 0 == remote
+    long lastAccessNanos;
+
+    CacheBlock(byte[] data, long blockIndex, long startOffset, long endOffset,
+        long nowNanos) {
+      this.data = data;
+      this.blockIndex = blockIndex;
+      this.startOffset = startOffset;
+      this.endOffset = endOffset;
+      this.lastAccessNanos = nowNanos;
+    }
+
+    /** Record the filling reader's locality (called by the fetch thread). */
+    void recordLocality(boolean sc, int distance) {
+      this.shortCircuit = sc;
+      this.networkDistance = distance;
+    }
+
+    int length() {
+      return (int) (endOffset - startOffset);
+    }
+  }
+
+  /** Lightweight counters for observability/testing. */
+  static final class Metrics {
+    long hits;            // reads served from cache
+    long misses;          // reads that fell back to the direct/sync path
+    long bytesServed;     // bytes copied out of the cache
+    long bytesReadDirect; // bytes read straight from a DataNode (cache miss)
+    long prefetchSubmitted;
+    long prefetchRejected;
+    long prefetchOk;
+    long prefetchFailed;
+    long cancellations;   // prefetches cancelled because the reader caught up
+    long bytesPrefetched;
+    long evictions;
+  }
+
+  private final DFSInputStream in;
+  private final DFSClient dfsClient;
+  private final long blockSize;      // file's uniform block size (indexing)
+  private final int maxBlockSize;    // per-block buffer size
+  private final int numBuffers;      // N
+  private final int threads;         // max concurrent fetches for this stream
+  private final int chunkSize;
+  private final long reservedBytes;
+  private final long ttlNanos;
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Map<Long, CacheBlock> window = new HashMap<>(8);
+  // Block indices already counted as a prefetch failure. schedule() re-submits a
+  // block whose locations are not yet cached on every foreground read, so the
+  // same block can fail thousands of times; deduping here makes prefetchFailed
+  // count DISTINCT blocks that failed to prefetch (comparable to prefetchOk)
+  // instead of per-attempt retries. A failed block leaves the window as it fails,
+  // so evictStale() prunes this set by index range to the active read-ahead range
+  // [curIdx, curIdx + numBuffers) on every foreground read and evictAll() clears
+  // it on unbuffer()/close(); it therefore stays bounded by numBuffers and never
+  // grows with stream length. Dedup is thus per window residency: a backward seek
+  // that re-approaches an already-pruned failed block may count it again, which is
+  // acceptable since the retry storm this fixes happens within one window while the
+  // reader is stalled. If a previously-failed block is later prefetched
+  // successfully, complete()'s success path removes it here and decrements
+  // prefetchFailed, so a recovered block is attributed to prefetchOk rather than
+  // counted in both. Never contacts the NameNode.
+  private final Set<Long> failedBlockIdx = new HashSet<>();
+  private final Deque<byte[]> freeBuffers = new ArrayDeque<>();
+  private int allocatedBuffers;
+  private int inFlight;
+
+  // Locality of the block that served the most recent cache hit. Written and
+  // read on the foreground thread only (serve runs on the caller's thread and
+  // consumePrefetched reads these immediately afterwards), so plain fields are
+  // sufficient here; the cross-thread visibility of the underlying CacheBlock
+  // fields is handled by their volatile declarations.
+  private boolean lastServedShortCircuit;
+  private int lastServedNetworkDistance;
+
+  private boolean closed;
+  private boolean budgetReleased;    // ensures reservedBytes is returned once
+  // After close()/onUnbuffer() the pool has been dropped and (for close) the
+  // reservation returned; buffers of still-in-flight fetches that return via
+  // complete() must NOT be re-pooled or they would pin heap past the released
+  // budget. While draining, complete() drops such arrays and decrements
+  // allocatedBuffers instead. A subsequent read re-enables pooling (schedule()).
+  private boolean draining;
+  private final Metrics metrics = new Metrics();
+  private ScheduledFuture<?> metricsTask;
+
+  private BlockPrefetcher(DFSInputStream in, DFSClient dfsClient, long blockSize,
+      int numBuffers, int threads, int chunkSize, long reservedBytes,
+      long ttlNanos) {
+    this.in = in;
+    this.dfsClient = dfsClient;
+    this.blockSize = blockSize;
+    this.maxBlockSize = (int) Math.min(blockSize, (long) Integer.MAX_VALUE);
+    this.numBuffers = numBuffers;
+    this.threads = threads;
+    this.chunkSize = chunkSize;
+    this.reservedBytes = reservedBytes;
+    this.ttlNanos = ttlNanos;
+  }
+
+  /** Start periodic metric logging if configured. */
+  private void startMetricsLogging() {
+    long intervalMs = dfsClient.getConf().getPrefetchMetricsLogIntervalMs();
+    if (intervalMs <= 0) {
+      return;
+    }
+    metricsTask = DFSClient.getPrefetchMetricsExecutor().scheduleAtFixedRate(
+        new Runnable() {
+          @Override
+          public void run() {
+            logMetrics();
+          }
+        }, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+  }
+
+  /** Add bytes that were read directly from a DataNode (cache miss/catch-up). */
+  void recordDirectRead(int n) {
+    if (n <= 0) {
+      return;
+    }
+    lock.lock();
+    try {
+      metrics.bytesReadDirect += n;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Bytes currently resident in the cache (sum of fetched-so-far per block). */
+  private long residentBytesLocked() {
+    long sum = 0;
+    for (CacheBlock cb : window.values()) {
+      sum += cb.bytesReady.get();
+    }
+    return sum;
+  }
+
+  private static long mb(long bytes) {
+    return bytes / (1024 * 1024);
+  }
+
+  /** Emit one read-cache metrics line for this stream. */
+  private void logMetrics() {
+    long cacheBytes;
+    long directBytes;
+    long resident;
+    int buffers;
+    long prefetchOk;
+    long failed;
+    long cancels;
+    lock.lock();
+    try {
+      cacheBytes = metrics.bytesServed;
+      directBytes = metrics.bytesReadDirect;
+      resident = residentBytesLocked();
+      buffers = allocatedBuffers;
+      prefetchOk = metrics.prefetchOk;
+      failed = metrics.prefetchFailed;
+      cancels = metrics.cancellations;
+    } finally {
+      lock.unlock();
+    }
+    long totalRead = cacheBytes + directBytes;
+    double hitPct = totalRead == 0 ? 0.0 : (100.0 * cacheBytes / totalRead);
+    DFSClient.LOG.info(
+        "HDFS read-cache metrics src={} caching=ENABLED cacheReadBytes={} ({} MB) "
+            + "directReadBytes={} ({} MB) cacheHitRatio={}% cacheResidentBytes={} "
+            + "({} MB) buffers={}/{} bufferCapacityMB={} prefetchOk={} "
+            + "prefetchFailed={} cancellations={}",
+        in.getSrc(), cacheBytes, mb(cacheBytes), directBytes, mb(directBytes),
+        String.format("%.1f", hitPct), resident, mb(resident), buffers,
+        numBuffers, mb((long) numBuffers * maxBlockSize), prefetchOk, failed,
+        cancels);
+  }
+
+  /**
+   * Create a prefetcher for {@code in}, or return {@code null} if prefetch is
+   * disabled, the file has a single block, the budget is too small to hold two
+   * blocks, or the global byte budget is exhausted.
+   */
+  static BlockPrefetcher maybeCreate(DFSInputStream in, DFSClient dfsClient) {
+    if (!dfsClient.getConf().isPrefetchEnabled()
+        || dfsClient.getConf().getPrefetchThreadpoolSize() <= 0
+        || !dfsClient.isPrefetchEnabled()
+        || !in.prefetchEligible()) {
+      // The static thread pool is process-wide and is created by the first
+      // client that enables prefetch, so dfsClient.isPrefetchEnabled() alone
+      // is a JVM-wide signal. Also honour this client's own configuration so a
+      // client with prefetch disabled never prefetches, even after another
+      // client in the same JVM has enabled it.
+      return null;
+    }
+    long blockSize = in.getBlockSizeForPrefetch();
+    if (blockSize <= 0 || blockSize > Integer.MAX_VALUE) {
+      return null;
+    }
+    long size = dfsClient.getConf().getPrefetchTotalSize();
+    long fileLen = in.getFileLength();
+    // Cap the read-ahead depth (and thus the reservation) by the number of
+    // blocks the file actually has, so a small file does not reserve the whole
+    // per-stream budget and needlessly starve other concurrent streams out of
+    // the shared prefetch byte budget.
+    long blocksInFile = (fileLen + blockSize - 1) / blockSize;
+    long depth = Math.min(size / blockSize, blocksInFile);
+    int n = (int) Math.min(depth, (long) Integer.MAX_VALUE);
+    if (n < 2) {
+      return null; // need room for at least the current block + one ahead
+    }
+    long reserve = (long) n * blockSize;
+    if (!dfsClient.tryReservePrefetchBytes(reserve)) {
+      return null;
+    }
+    int threads = Math.max(1, dfsClient.getConf().getPrefetchThreads());
+    int chunkSize = Math.max(64 * 1024,
+        dfsClient.getConf().getPrefetchChunkSize());
+    long ttl = TimeUnit.MILLISECONDS.toNanos(
+        dfsClient.getConf().getPrefetchTtlMs());
+    try {
+      BlockPrefetcher p = new BlockPrefetcher(in, dfsClient, blockSize, n,
+          threads, chunkSize, reserve, ttl);
+      if (dfsClient.getConf().isPrefetchMetricsLogEnabled()) {
+        p.startMetricsLogging();
+      }
+      return p;
+    } catch (RuntimeException | Error e) {
+      // The global byte budget was already reserved above. If constructing the
+      // prefetcher or starting its metrics task fails, the prefetcher is never
+      // assigned to the stream and thus never close()d, so return the
+      // reservation here to avoid permanently leaking it from the JVM-wide
+      // prefetch budget.
+      dfsClient.releasePrefetchBytes(reserve);
+      throw e;
+    }
+  }
+
+  private static long now() {
+    return System.nanoTime();
+  }
+
+  /** Locality of the most recent cache hit; valid only on the foreground
+   * thread immediately after a successful {@link #read}. */
+  boolean lastServedShortCircuit() {
+    return lastServedShortCircuit;
+  }
+
+  int lastServedNetworkDistance() {
+    return lastServedNetworkDistance;
+  }
+
+  /**
+   * Serve {@code len} bytes at file offset {@code pos} from the cache (possibly
+   * a short read up to the fetched-so-far boundary), after scheduling read
+   * ahead. Returns the number of bytes copied, or 0 if the caller should read
+   * directly from the DataNode (block not prefetched, or reader has caught up).
+   */
+  int read(long pos, byte[] buf, int off, int len) {
+    schedule(pos);
+    lock.lock();
+    try {
+      return serveLocked(pos, buf, off, len);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** ByteBuffer variant of {@link #read(long, byte[], int, int)}. */
+  int read(long pos, ByteBuffer dst) {
+    int len = dst.remaining();
+    if (len == 0) {
+      return 0;
+    }
+    schedule(pos);
+    lock.lock();
+    try {
+      if (closed) {
+        return 0;
+      }
+      long idx = pos / blockSize;
+      CacheBlock cb = window.get(idx);
+      if (cb == null || cb.failed) {
+        if (cb != null) {
+          removeAndRecycle(idx, cb);
+        }
+        metrics.misses++;
+        return 0;
+      }
+      long availEnd = cb.startOffset + cb.bytesReady.get();
+      if (pos < availEnd) {
+        int n = (int) Math.min((long) len, Math.min(availEnd, cb.endOffset) - pos);
+        dst.put(cb.data, (int) (pos - cb.startOffset), n);
+        cb.lastAccessNanos = now();
+        lastServedShortCircuit = cb.shortCircuit;
+        lastServedNetworkDistance = cb.networkDistance;
+        metrics.hits++;
+        metrics.bytesServed += n;
+        return n;
+      }
+      if (!cb.done) {
+        cb.cancelled = true;
+        metrics.cancellations++;
+      }
+      removeAndRecycle(idx, cb);
+      metrics.misses++;
+      return 0;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private int serveLocked(long pos, byte[] buf, int off, int len) {
+    if (closed) {
+      return 0;
+    }
+    long idx = pos / blockSize;
+    CacheBlock cb = window.get(idx);
+    if (cb == null || cb.failed) {
+      if (cb != null) {
+        removeAndRecycle(idx, cb);
+      }
+      metrics.misses++;
+      return 0;
+    }
+    long ready = cb.bytesReady.get();
+    long availEnd = cb.startOffset + ready;
+    if (pos < availEnd) {
+      long blockEnd = cb.endOffset;
+      int n = (int) Math.min((long) len, Math.min(availEnd, blockEnd) - pos);
+      System.arraycopy(cb.data, (int) (pos - cb.startOffset), buf, off, n);
+      cb.lastAccessNanos = now();
+      lastServedShortCircuit = cb.shortCircuit;
+      lastServedNetworkDistance = cb.networkDistance;
+      metrics.hits++;
+      metrics.bytesServed += n;
+      return n;
+    }
+    // Reader has caught up to (or passed) this block's fetch front: cancel the
+    // prefetch and let the caller read the remainder directly.
+    if (!cb.done) {
+      cb.cancelled = true;
+      metrics.cancellations++;
+    }
+    removeAndRecycle(idx, cb);
+    metrics.misses++;
+    return 0;
+  }
+
+  /**
+   * Recycle behind-cursor / stale blocks and top up the read-ahead window with
+   * up to {@code threads} concurrent fetches of the blocks ahead of the cursor.
+   */
+  private void schedule(long pos) {
+    lock.lock();
+    try {
+      if (closed) {
+        return;
+      }
+      draining = false;
+      long curIdx = pos / blockSize;
+      long fileLen = in.getFileLength();
+      if (fileLen <= 0) {
+        return;
+      }
+      long lastIdx = (fileLen - 1) / blockSize;
+      evictStale(curIdx);
+
+      long maxAhead = Math.min(curIdx + numBuffers - 1, lastIdx);
+      for (long idx = curIdx + 1; idx <= maxAhead; idx++) {
+        if (window.containsKey(idx)) {
+          continue;
+        }
+        if (inFlight >= threads) {
+          break;
+        }
+        byte[] backing = pollOrAllocateBuffer();
+        if (backing == null) {
+          break;
+        }
+        startPrefetch(idx, fileLen, backing);
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private void startPrefetch(long idx, long fileLen, byte[] backing) {
+    long start = idx * blockSize;
+    long end = Math.min(start + blockSize, fileLen);
+    final CacheBlock cb = new CacheBlock(backing, idx, start, end, now());
+    window.put(idx, cb);
+    inFlight++;
+    try {
+      dfsClient.getPrefetchThreadPool().submit(new Runnable() {
+        @Override
+        public void run() {
+          fillBlock(cb);
+        }
+      });
+      metrics.prefetchSubmitted++;
+    } catch (RejectedExecutionException ree) {
+      window.remove(idx);
+      inFlight--;
+      freeBuffers.offer(backing);
+      metrics.prefetchRejected++;
+    }
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private byte[] pollOrAllocateBuffer() {
+    byte[] b = freeBuffers.poll();
+    if (b == null && allocatedBuffers < numBuffers) {
+      b = new byte[maxBlockSize];
+      allocatedBuffers++;
+    }
+    return b;
+  }
+
+  /** Background worker: fill a block in chunks, publishing progress. */
+  private void fillBlock(CacheBlock cb) {
+    int outcome = FAILED;
+    try {
+      in.prefetchBlockChunked(cb, chunkSize, () -> cb.cancelled || closed);
+      outcome = (cb.cancelled || closed) ? CANCELLED : SUCCESS;
+    } catch (Exception e) {
+      // Only ordinary failures are treated as a prefetch miss; fatal VM errors
+      // (OutOfMemoryError, StackOverflowError, ...) propagate to the worker
+      // thread's uncaught handler instead of being silently swallowed. The
+      // finally block below still runs, releasing this block's buffer. The
+      // throwable is passed to the logger so the full stack trace is retained.
+      DFSClient.LOG.debug("Prefetch of block {} ({} bytes @ {}) failed",
+          cb.blockIndex, cb.length(), cb.startOffset, e);
+      outcome = FAILED;
+    } finally {
+      complete(cb, outcome);
+    }
+  }
+
+  private void complete(CacheBlock cb, int outcome) {
+    boolean releaseBudget = false;
+    lock.lock();
+    try {
+      cb.done = true;
+      inFlight--;
+      boolean keep = outcome == SUCCESS && !cb.cancelled && !closed
+          && window.get(cb.blockIndex) == cb;
+      if (keep) {
+        if (failedBlockIdx.remove(cb.blockIndex)) {
+          // This block failed an earlier prefetch attempt but has now been
+          // prefetched successfully; attribute it to prefetchOk instead of
+          // leaving it double-counted as a failure. The decrement balances the
+          // increment made when it was first added below (never goes negative).
+          metrics.prefetchFailed--;
+        }
+        metrics.prefetchOk++;
+        metrics.bytesPrefetched += cb.length();
+      } else {
+        cb.failed = outcome == FAILED;
+        if (window.get(cb.blockIndex) == cb) {
+          window.remove(cb.blockIndex);
+        }
+        if (draining) {
+          // close()/onUnbuffer() dropped the pool and (for close) returned the
+          // reservation; do not re-pool this late in-flight array. Drop it so
+          // it becomes GC-eligible and keep allocatedBuffers honest.
+          allocatedBuffers--;
+        } else {
+          freeBuffers.offer(cb.data);
+        }
+        if (outcome == FAILED && failedBlockIdx.add(cb.blockIndex)) {
+          metrics.prefetchFailed++;
+        }
+      }
+      // If the stream was closed while this fetch was in flight, its buffer is
+      // now reclaimed; return the global budget once the last in-flight fetch
+      // drains so the reservation outlives the buffers it accounts for.
+      if (closed && inFlight == 0 && !budgetReleased) {
+        budgetReleased = true;
+        releaseBudget = true;
+      }
+    } finally {
+      lock.unlock();
+    }
+    if (releaseBudget) {
+      dfsClient.releasePrefetchBytes(reservedBytes);
+    }
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private void evictStale(long curIdx) {
+    long nowNanos = now();
+    Iterator<Map.Entry<Long, CacheBlock>> it = window.entrySet().iterator();
+    while (it.hasNext()) {
+      CacheBlock cb = it.next().getValue();
+      boolean behind = cb.blockIndex < curIdx;
+      boolean expired = cb.blockIndex != curIdx
+          && (nowNanos - cb.lastAccessNanos) > ttlNanos;
+      if (behind || expired) {
+        it.remove();
+        recycle(cb);
+        metrics.evictions++;
+      }
+    }
+    // Failed blocks are removed from the window when they fail, so they are not
+    // reachable by the window loop above. schedule() only ever (re-)submits
+    // indices in (curIdx, curIdx + numBuffers), so drop any failure record
+    // outside that range; these can never be retried and would otherwise leak
+    // for the life of the stream. Keep the marker AT curIdx (idx == curIdx): an
+    // earlier retry fetch for the block the reader just entered may still be in
+    // flight, and if it recovers, complete()'s success path needs the marker
+    // present to move that block from prefetchFailed to prefetchOk. Anything
+    // strictly behind the cursor can no longer be retried or recovered. This
+    // bounds failedBlockIdx to at most numBuffers entries.
+    if (!failedBlockIdx.isEmpty()) {
+      failedBlockIdx.removeIf(idx -> idx < curIdx || idx >= curIdx + numBuffers);
+    }
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private void removeAndRecycle(long idx, CacheBlock cb) {
+    window.remove(idx);
+    recycle(cb);
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private void recycle(CacheBlock cb) {
+    if (cb.done) {
+      freeBuffers.offer(cb.data);
+    } else {
+      cb.cancelled = true; // in-flight fetch recycles on completion
+    }
+  }
+
+  /** Caller must hold {@link #lock}. */
+  private void evictAll() {
+    for (CacheBlock cb : window.values()) {
+      recycle(cb);
+    }
+    window.clear();
+    failedBlockIdx.clear();
+  }
+
+  /**
+   * Re-anchor the read-ahead window to a seek target. HDFS blocks are
+   * immutable (prefetch is disabled for under-construction files), so a
+   * buffered block that falls within the read-ahead window of the new landing
+   * block is still valid and is kept; blocks behind the new cursor, or beyond
+   * the new read-ahead horizon (e.g. now-far-ahead blocks after a large
+   * backward seek, which would otherwise starve the new window of buffers),
+   * are dropped. This preserves the read-ahead across intra-block, forward,
+   * and backward-within-block seeks instead of tearing it down and re-fetching
+   * from scratch.
+   */
+  void onSeek(long targetPos) {
+    lock.lock();
+    try {
+      if (closed) {
+        return;
+      }
+      long newIdx = targetPos / blockSize;
+      long maxKeep = newIdx + numBuffers - 1;
+      Iterator<Map.Entry<Long, CacheBlock>> it = window.entrySet().iterator();
+      while (it.hasNext()) {
+        CacheBlock cb = it.next().getValue();
+        if (cb.blockIndex < newIdx || cb.blockIndex > maxKeep) {
+          it.remove();
+          recycle(cb);
+          metrics.evictions++;
+        }
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Release cached buffers on unbuffer(). {@code unbuffer()} is an explicit
+   * request from the caller (typically a pooled/cached stream that stays open
+   * but goes idle) to give back client-side heap, so unlike normal window
+   * churn and {@link #onSeek} — where recycled arrays are deliberately kept in
+   * {@link #freeBuffers} for reuse — this also drops the pooled arrays and
+   * resets the allocation high-water mark so they become GC-eligible. Future
+   * reads re-allocate lazily up to {@code numBuffers} again. The global byte
+   * budget reservation is intentionally retained until {@link #close()}.
+   */
+  void onUnbuffer() {
+    lock.lock();
+    try {
+      if (!closed) {
+        evictAll();
+        freeBuffers.clear();
+        // evictAll() only cancels in-flight blocks; their buffers are still
+        // held by fetch threads and returned later by complete(). Keep the
+        // counter honest for those live arrays (set to inFlight, not 0) so
+        // resumed reads cannot allocate past the reserved numBuffers budget,
+        // and mark draining so those late returns are dropped (not re-pooled).
+        allocatedBuffers = inFlight;
+        draining = true;
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Free buffers and return the reserved global budget. */
+  void close() {
+    boolean releaseNow = false;
+    lock.lock();
+    try {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      evictAll();
+      // evictAll() recycles done blocks (and, later, cancelled in-flight
+      // blocks via complete()) into freeBuffers. Since close() hands the global
+      // budget back below, drop those pooled arrays too — mirroring
+      // onUnbuffer() — so a closed-but-still-referenced stream does not keep up
+      // to dfs.client.prefetch.size of heap pinned after its reservation has
+      // been returned. allocatedBuffers is set to inFlight (not 0) so any
+      // still-live in-flight arrays stay accounted for.
+      freeBuffers.clear();
+      allocatedBuffers = inFlight;
+      draining = true;
+      // evictAll() only cancels in-flight blocks; their buffers are still
+      // owned by fetch threads and returned later by complete(). Return the
+      // global budget now only if nothing is in flight; otherwise the last
+      // complete() that drains inFlight to 0 returns it, so live prefetch heap
+      // never transiently exceeds dfs.client.prefetch.max.bytes.
+      if (inFlight == 0 && !budgetReleased) {
+        budgetReleased = true;
+        releaseNow = true;
+      }
+    } finally {
+      lock.unlock();
+    }
+    if (metricsTask != null) {
+      metricsTask.cancel(false);
+    }
+    if (releaseNow) {
+      dfsClient.releasePrefetchBytes(reservedBytes);
+    }
+  }
+
+  @VisibleForTesting
+  int getNumBuffers() {
+    return numBuffers;
+  }
+
+  @VisibleForTesting
+  int getAllocatedBuffers() {
+    lock.lock();
+    try {
+      return allocatedBuffers;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  int getFreeBufferCount() {
+    lock.lock();
+    try {
+      return freeBuffers.size();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  int getInFlight() {
+    lock.lock();
+    try {
+      return inFlight;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  int getMaxBlockSize() {
+    return maxBlockSize;
+  }
+
+  @VisibleForTesting
+  Metrics getMetrics() {
+    lock.lock();
+    try {
+      Metrics s = new Metrics();
+      s.hits = metrics.hits;
+      s.misses = metrics.misses;
+      s.bytesServed = metrics.bytesServed;
+      s.bytesReadDirect = metrics.bytesReadDirect;
+      s.prefetchSubmitted = metrics.prefetchSubmitted;
+      s.prefetchRejected = metrics.prefetchRejected;
+      s.prefetchOk = metrics.prefetchOk;
+      s.prefetchFailed = metrics.prefetchFailed;
+      s.cancellations = metrics.cancellations;
+      s.bytesPrefetched = metrics.bytesPrefetched;
+      s.evictions = metrics.evictions;
+      return s;
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -246,6 +246,18 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
       new DFSHedgedReadMetrics();
   private static ThreadPoolExecutor HEDGED_READ_THREAD_POOL;
   private static volatile ThreadPoolExecutor STRIPED_READ_THREAD_POOL;
+  // Shared (per-JVM) infrastructure for sequential read-ahead prefetch.
+  private static volatile ThreadPoolExecutor PREFETCH_THREAD_POOL;
+  // Remaining global prefetch byte budget; initialized on first prefetch use.
+  private static final java.util.concurrent.atomic.AtomicLong
+      PREFETCH_BUDGET_REMAINING =
+          new java.util.concurrent.atomic.AtomicLong(0);
+  // Total global prefetch byte budget (high-water mark of max.bytes requested
+  // across all clients). Guarded by the initPrefetch class lock.
+  private static long PREFETCH_BUDGET_TOTAL;
+  // Lazily-created scheduler for periodic prefetch metric logging.
+  private static java.util.concurrent.ScheduledExecutorService
+      PREFETCH_METRICS_EXECUTOR;
   private final long serverDefaultsValidityPeriod;
 
   /**
@@ -405,6 +417,12 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     if (dfsClientConf.getHedgedReadThreadpoolSize() > 0) {
       this.initThreadsNumForHedgedReads(dfsClientConf.
           getHedgedReadThreadpoolSize());
+    }
+
+    if (dfsClientConf.isPrefetchEnabled()
+        && dfsClientConf.getPrefetchThreadpoolSize() > 0) {
+      initPrefetch(dfsClientConf.getPrefetchThreadpoolSize(),
+          dfsClientConf.getPrefetchMaxBytes());
     }
 
     this.initThreadsNumForStripedReads(dfsClientConf.
@@ -3161,6 +3179,124 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
 
   ThreadPoolExecutor getHedgedReadsThreadPool() {
     return HEDGED_READ_THREAD_POOL;
+  }
+
+  /**
+   * Create the shared prefetch thread pool and seed the global byte budget,
+   * if not already created. The pool uses a {@link SynchronousQueue} with an
+   * abort policy so that, when every worker is busy, a prefetch submission is
+   * rejected (and silently skipped by the caller) instead of running on — and
+   * thereby blocking — the foreground reader thread.
+   *
+   * <p>The pool and the byte budget are process-wide shared resources. When
+   * more than one {@link DFSClient} enables prefetch with different
+   * configurations, the shared resources grow (never shrink) to the largest
+   * value requested across all clients, so that no client is silently capped
+   * below its own configured {@code max.bytes} / {@code threadpool.size}.
+   * Shrinking is intentionally avoided because another client may already hold
+   * reservations that a smaller cap could not account for.
+   *
+   * @param num       Number of prefetch worker threads.
+   * @param maxBytes  Global cap on bytes held across all prefetch buffers.
+   */
+  private static synchronized void initPrefetch(int num, long maxBytes) {
+    if (num <= 0) {
+      return;
+    }
+    long normalizedMax = Math.max(0, maxBytes);
+    if (PREFETCH_THREAD_POOL != null) {
+      // Already initialized by an earlier client: honor a later client that
+      // asks for a larger budget or more workers by growing to it.
+      if (normalizedMax > PREFETCH_BUDGET_TOTAL) {
+        PREFETCH_BUDGET_REMAINING.addAndGet(normalizedMax - PREFETCH_BUDGET_TOTAL);
+        PREFETCH_BUDGET_TOTAL = normalizedMax;
+      }
+      if (num > PREFETCH_THREAD_POOL.getMaximumPoolSize()) {
+        PREFETCH_THREAD_POOL.setMaximumPoolSize(num);
+      }
+      return;
+    }
+    PREFETCH_BUDGET_TOTAL = normalizedMax;
+    PREFETCH_BUDGET_REMAINING.set(normalizedMax);
+    PREFETCH_THREAD_POOL = new ThreadPoolExecutor(0, num, 60,
+        TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
+        new Daemon.DaemonFactory() {
+          private final AtomicInteger threadIndex = new AtomicInteger(0);
+          @Override
+          public Thread newThread(Runnable r) {
+            Thread t = super.newThread(r);
+            t.setName("prefetch-" + threadIndex.getAndIncrement());
+            return t;
+          }
+        },
+        new ThreadPoolExecutor.AbortPolicy());
+    PREFETCH_THREAD_POOL.allowCoreThreadTimeOut(true);
+    LOG.debug("Using read-ahead prefetch; pool threads={}, maxBytes={}",
+        num, maxBytes);
+  }
+
+  ThreadPoolExecutor getPrefetchThreadPool() {
+    return PREFETCH_THREAD_POOL;
+  }
+
+  boolean isPrefetchEnabled() {
+    return PREFETCH_THREAD_POOL != null
+        && PREFETCH_THREAD_POOL.getMaximumPoolSize() > 0;
+  }
+
+  /**
+   * Try to reserve {@code n} bytes of the global prefetch budget.
+   * @return true if reserved; false if insufficient budget remains.
+   */
+  boolean tryReservePrefetchBytes(long n) {
+    if (n <= 0) {
+      return true;
+    }
+    while (true) {
+      long cur = PREFETCH_BUDGET_REMAINING.get();
+      if (cur < n) {
+        return false;
+      }
+      if (PREFETCH_BUDGET_REMAINING.compareAndSet(cur, cur - n)) {
+        return true;
+      }
+    }
+  }
+
+  /** Return {@code n} bytes to the global prefetch budget. */
+  void releasePrefetchBytes(long n) {
+    if (n > 0) {
+      PREFETCH_BUDGET_REMAINING.addAndGet(n);
+    }
+  }
+
+  /**
+   * Shared single-threaded scheduler used to periodically log per-stream
+   * read-cache metrics when {@code dfs.client.prefetch.metrics.log.enabled} is
+   * set. Created lazily; uses a daemon thread.
+   */
+  static synchronized java.util.concurrent.ScheduledExecutorService
+      getPrefetchMetricsExecutor() {
+    if (PREFETCH_METRICS_EXECUTOR == null) {
+      java.util.concurrent.ScheduledThreadPoolExecutor exec =
+          new java.util.concurrent.ScheduledThreadPoolExecutor(1,
+              new Daemon.DaemonFactory() {
+                @Override
+                public Thread newThread(Runnable runnable) {
+                  Thread t = super.newThread(runnable);
+                  t.setName("prefetch-metrics-logger");
+                  return t;
+                }
+              });
+      // Per-stream metrics tasks are cancelled when a stream closes; remove
+      // them from the delay queue immediately (instead of leaving cancelled
+      // nodes, and the stream state they reference, pinned until the next
+      // scheduled tick) and do not run any delayed tasks after shutdown.
+      exec.setRemoveOnCancelPolicy(true);
+      exec.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+      PREFETCH_METRICS_EXECUTOR = exec;
+    }
+    return PREFETCH_METRICS_EXECUTOR;
   }
 
   ThreadPoolExecutor getStripedReadsThreadPool() {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -57,6 +57,9 @@ public class DFSClientFaultInjector {
 
   public void startFetchFromDatanode() {}
 
+  /** Invoked when opening a BlockReader on any read path (sequential/pread). */
+  public void openBlockReaderDelay() {}
+
   public void fetchFromDatanodeException() {}
 
   public void readFromDatanodeDelay() {}

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -177,6 +177,10 @@ public class DFSInputStream extends FSInputStream
 
   private byte[] oneByteBuf; // used for 'int read()'
 
+  // Sequential read-ahead prefetcher; null when prefetch is disabled for this
+  // stream (feature off, single-block file, or global budget exhausted).
+  private BlockPrefetcher prefetcher;
+
   protected void addToLocalDeadNodes(DatanodeInfo dnInfo) {
     DFSClient.LOG.debug("Add {} to local dead nodes, previously was {}.",
             dnInfo, deadNodes);
@@ -210,6 +214,123 @@ public class DFSInputStream extends FSInputStream
     }
     this.locatedBlocks = locatedBlocks;
     openInfo(false);
+    this.prefetcher = BlockPrefetcher.maybeCreate(this, dfsClient);
+    if (dfsClient.getConf().isPrefetchMetricsLogEnabled()) {
+      DFSClient.LOG.debug("HDFS read caching for src={} : {}", src,
+          prefetcher != null ? "ENABLED" : "DISABLED");
+    }
+  }
+
+  /**
+   * @return true if this file is a candidate for sequential read-ahead
+   * prefetch: it spans more than one block, is not under construction, and is
+   * not erasure-coded. Multi-block status is derived from the total file length
+   * and block size rather than {@code locatedBlockCount()}, which at open time
+   * only reflects the initial block-location window
+   * ({@code dfs.client.read.prefetch.size}) and could otherwise make a genuine
+   * multi-block file look single-block. Erasure-coded (striped) files are
+   * excluded because {@link DFSStripedInputStream} inherits the prefetch
+   * fast-path in {@code read(byte[],int,int)} / {@code read(ByteBuffer)} but the
+   * prefetcher would read a striped block group from a single DataNode as if it
+   * were a contiguous replicated block, returning wrong bytes.
+   */
+  boolean prefetchEligible() {
+    synchronized (infoLock) {
+      if (locatedBlocks == null || locatedBlocks.isUnderConstruction()
+          || locatedBlocks.getErasureCodingPolicy() != null) {
+        return false;
+      }
+      return getFileLength() > getBlockSizeForPrefetch();
+    }
+  }
+
+  /** @return this file's (uniform) block size, used to index prefetch blocks. */
+  long getBlockSizeForPrefetch() {
+    synchronized (infoLock) {
+      if (locatedBlocks == null || locatedBlocks.locatedBlockCount() == 0) {
+        return 0;
+      }
+      return locatedBlocks.get(0).getBlockSize();
+    }
+  }
+
+  /**
+   * Stream {@code [0, cb.length())} of {@code cb}'s block into {@code cb.data},
+   * in {@code chunkSize} pieces, publishing the number of bytes fetched so far
+   * via {@code cb.bytesReady} after each chunk and stopping early if
+   * {@code cancelled} becomes true. Used by the prefetcher to fill a block
+   * incrementally so the reader can consume its prefix and so a fetch can be
+   * cancelled when the reader catches up.
+   *
+   * <p>This runs on a background prefetch thread that does <em>not</em> hold the
+   * {@link DFSInputStream} monitor, so it must never mutate the shared
+   * foreground retry state. It therefore selects a DataNode with
+   * {@code refetchIfRequired=false} and, on a node-selection miss, aborts the
+   * prefetch (best-effort) rather than invoking {@link #refetchLocations},
+   * which would bump {@link #failures}, clear the dead-node map and refresh the
+   * located blocks concurrently with a foreground read.
+   */
+  void prefetchBlockChunked(BlockPrefetcher.CacheBlock cb, int chunkSize,
+      java.util.function.BooleanSupplier cancelled) throws IOException {
+    LocatedBlock block = getCachedBlockAt(cb.startOffset);
+    if (block == null) {
+      // Locations for this block are not cached yet. Do not issue a NameNode
+      // RPC on the prefetch thread (it would hold infoLock and stall the
+      // foreground reader); fail this block so it falls back to a synchronous
+      // read, which resolves and caches the locations for a later prefetch.
+      throw new IOException(
+          "Block locations not cached for prefetch @ offset " + cb.startOffset);
+    }
+    if (block.getStartOffset() != cb.startOffset
+        || block.getBlockSize() < cb.length()) {
+      // The prefetcher indexes the file as a uniform grid of blockSize-sized
+      // slots (blockSize == block 0's size), reading each real block from its
+      // offset 0 into the slot. If the real block covering this slot does not
+      // start exactly at the slot offset, or is smaller than the slot, the file
+      // has non-uniform block sizes (e.g. concat, or append with a different
+      // dfs.blocksize). Filling the slot from the real block's start would then
+      // record bytes at the wrong file offset -> silent corruption. Fail the
+      // prefetch so this range falls back to a correct synchronous read.
+      throw new IOException("Non-uniform block size; skipping prefetch @ offset "
+          + cb.startOffset + " (real block start " + block.getStartOffset()
+          + ", size " + block.getBlockSize() + ", slot len " + cb.length() + ")");
+    }
+    DNAddrPair addr = chooseDataNode(block, null, false);
+    if (addr == null) {
+      // Best-effort prefetch found no live DataNode. Fail this block so
+      // fillBlock() treats it as FAILED (recycles the buffer, removes the
+      // block, allows a later re-attempt) instead of recording an empty
+      // "done" slot with inflated bytesPrefetched.
+      throw new IOException("No live DataNode available to prefetch block "
+          + block.getBlock());
+    }
+    block = addr.block;
+    int length = cb.length();
+    BlockReader reader = null;
+    try {
+      reader = getBlockReader(block, 0, length, addr.addr, addr.storageType,
+          addr.info);
+      cb.recordLocality(reader.isShortCircuit(), reader.getNetworkDistance());
+      int written = 0;
+      while (written < length) {
+        if (cancelled.getAsBoolean()) {
+          return;
+        }
+        int toRead = Math.min(chunkSize, length - written);
+        reader.readFully(cb.data, written, toRead);
+        written += toRead;
+        cb.bytesReady.set(written);
+      }
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+
+  @VisibleForTesting
+  BlockPrefetcher getPrefetcherForTesting() {
+    return prefetcher;
   }
 
   @VisibleForTesting
@@ -499,6 +620,28 @@ public class DFSInputStream extends FSInputStream
     return fetchBlockAt(offset, 0, false); // don't use cache
   }
 
+  /**
+   * Return the cached {@link LocatedBlock} covering {@code offset} without
+   * contacting the NameNode. Used by the background prefetcher so a prefetch
+   * never issues a blocking getBlockLocations RPC while holding
+   * {@link #infoLock} (which would stall the foreground reader that needs the
+   * same lock). Returns {@code null} when the block's locations are not already
+   * cached; the prefetch of that block is then skipped and the foreground read
+   * resolves the locations on demand (caching them for a later prefetch).
+   */
+  protected LocatedBlock getCachedBlockAt(long offset) {
+    synchronized (infoLock) {
+      if (locatedBlocks == null) {
+        return null;
+      }
+      int idx = locatedBlocks.findBlock(offset);
+      if (idx < 0) {
+        return null;
+      }
+      return locatedBlocks.get(idx);
+    }
+  }
+
   /** Fetch a block from namenode and cache it */
   private LocatedBlock fetchBlockAt(long offset, long length, boolean useCache)
       throws IOException {
@@ -695,6 +838,9 @@ public class DFSInputStream extends FSInputStream
   protected BlockReader getBlockReader(LocatedBlock targetBlock,
       long offsetInBlock, long length, InetSocketAddress targetAddr,
       StorageType storageType, DatanodeInfo datanode) throws IOException {
+    // Test hook: simulate per-block-open latency on every read path
+    // (sequential and positioned) since both open a reader here.
+    DFSClientFaultInjector.get().openBlockReaderDelay();
     ExtendedBlock blk = targetBlock.getBlock();
     Token<BlockTokenIdentifier> accessToken = targetBlock.getBlockToken();
     CachingStrategy curCachingStrategy;
@@ -754,6 +900,16 @@ public class DFSInputStream extends FSInputStream
       closeCurrentBlockReaders();
       super.close();
     } finally {
+      // Always return the prefetch buffers and the reserved JVM-wide byte
+      // budget, even if checkOpen() or super.close() above threw (e.g. the
+      // DFSClient was closed before this still-open stream, so checkOpen()
+      // raises "Filesystem closed"). close() is idempotent, so the early
+      // "already closed" return path runs this harmlessly too. Skipping it
+      // would permanently leak this stream's reservation from the shared
+      // prefetch budget and eventually disable prefetch for the whole JVM.
+      if (prefetcher != null) {
+        prefetcher.close();
+      }
       /**
        * If dfsInputStream is closed and datanode is in
        * DeadNodeDetector#dfsInputStreamNodes, we need remove the datanode from
@@ -955,16 +1111,83 @@ public class DFSInputStream extends FSInputStream
     if (len == 0) {
       return 0;
     }
+    if (prefetcher != null && !closed.get()) {
+      dfsClient.checkOpen();
+      int n = prefetcher.read(pos, buf, off, len);
+      if (n > 0) {
+        consumePrefetched(n);
+        return n;
+      }
+    }
     ReaderStrategy byteArrayReader =
         new ByteArrayStrategy(buf, off, len, readStatistics, dfsClient);
-    return readWithStrategy(byteArrayReader);
+    int result = readWithStrategy(byteArrayReader);
+    if (prefetcher != null && result > 0) {
+      prefetcher.recordDirectRead(result);
+    }
+    return result;
   }
 
   @Override
   public synchronized int read(final ByteBuffer buf) throws IOException {
+    if (prefetcher != null && !closed.get() && buf.hasRemaining()) {
+      dfsClient.checkOpen();
+      int n = prefetcher.read(pos, buf);
+      if (n > 0) {
+        consumePrefetched(n);
+        return n;
+      }
+    }
     ReaderStrategy byteBufferReader =
         new ByteBufferStrategy(buf, readStatistics, dfsClient);
-    return readWithStrategy(byteBufferReader);
+    int result = readWithStrategy(byteBufferReader);
+    if (prefetcher != null && result > 0) {
+      prefetcher.recordDirectRead(result);
+    }
+    return result;
+  }
+
+  /**
+   * Advance the stream position after serving {@code n} bytes from the
+   * prefetch cache and invalidate the stateful synchronous reader so that the
+   * next synchronous read (on a cache miss) re-seeks to {@link #pos} rather
+   * than reading from a now-stale reader position.
+   *
+   * <p>The cache may have advanced {@link #pos} across one or more block
+   * boundaries, so {@link #blockReader} and {@link #currentNode} no longer
+   * correspond to {@link #pos}. Besides closing the reader and clearing
+   * {@link #blockEnd}, {@link #currentNode} is cleared too so that
+   * node-selection logic run before the next re-seek (e.g.
+   * {@link #seekToNewSource(long)} or {@link #getCurrentDatanode()}) does not
+   * act on a DataNode that is no longer the current source.
+   *
+   * <p>Prefetch-served bytes are also accounted in the read statistics exactly
+   * like the direct read path, so cache hits are not invisible to
+   * {@code FileSystem.Statistics#getBytesRead()}, {@link ReadStatistics}, and
+   * any downstream monitoring/billing. The bytes are attributed to the
+   * local/remote/short-circuit bucket that matches the locality of the reader
+   * that actually prefetched the serving block (captured at fill time and
+   * surfaced by the prefetcher for the block that served this read); the
+   * foreground serve is an in-memory copy, hence zero read time.
+   */
+  private void consumePrefetched(int n) {
+    pos += n;
+    closeCurrentBlockReaders();
+    blockEnd = -1;
+    currentNode = null;
+    // A cache-served read can advance pos into a later block, so the previously
+    // read block is no longer current. Re-point currentLocatedBlock at the
+    // block covering the new pos using only the in-memory block cache (no
+    // NameNode RPC) so getCurrentBlock()/getCurrentBlockLocationsLength() keep
+    // returning the block for pos across cache-served reads instead of null.
+    // The prefetcher located every served block via getBlockAt(), so the
+    // covering block is normally cached; if it somehow is not, fall back to
+    // null and let the next synchronous access re-resolve it.
+    currentLocatedBlock = getCachedBlockAt(pos);
+    boolean shortCircuit = prefetcher.lastServedShortCircuit();
+    int networkDistance = prefetcher.lastServedNetworkDistance();
+    updateReadStatistics(readStatistics, n, shortCircuit, networkDistance);
+    dfsClient.updateFileSystemReadStats(networkDistance, n, 0);
   }
 
   private DNAddrPair chooseDataNode(LocatedBlock block,
@@ -1647,6 +1870,12 @@ public class DFSInputStream extends FSInputStream
     if (closed.get()) {
       throw new IOException("Stream is closed!");
     }
+    if (prefetcher != null) {
+      // Re-anchor the read-ahead window: behind-cursor blocks are dropped and
+      // at/ahead blocks are kept (HDFS blocks are immutable), so intra-block
+      // and forward seeks retain their prefetch instead of re-fetching.
+      prefetcher.onSeek(targetPos);
+    }
     boolean done = false;
     if (pos <= targetPos && targetPos <= blockEnd) {
       //
@@ -1987,6 +2216,9 @@ public class DFSInputStream extends FSInputStream
   @Override
   public synchronized void unbuffer() {
     closeCurrentBlockReaders();
+    if (prefetcher != null) {
+      prefetcher.onUnbuffer();
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -529,6 +529,60 @@ public interface HdfsClientConfigKeys {
     int     THREADPOOL_SIZE_DEFAULT = 0;
   }
 
+  /**
+   * dfs.client.prefetch configuration properties.
+   *
+   * Sequential read-ahead cache. When enabled (per file with more than one
+   * block), background workers fetch blocks ahead of the read cursor, in
+   * parallel, into reusable in-memory buffers so the foreground read can be
+   * served from memory instead of waiting on a per-block DataNode round trip.
+   * A stream keeps a sliding window of up to {@code N = SIZE / blockSize}
+   * per-block buffers (each holding one HDFS block); up to
+   * {@code THREADS} blocks are filled concurrently.
+   */
+  interface Prefetch {
+    String  PREFIX = HdfsClientConfigKeys.PREFIX + "prefetch.";
+
+    // Per-stream opt-in. Single-block files never prefetch.
+    String  ENABLED_KEY = PREFIX + "enabled";
+    boolean ENABLED_DEFAULT = false;
+
+    // Total per-stream prefetch memory in bytes. Holds N = SIZE / blockSize
+    // per-block buffers.
+    String  SIZE_KEY = PREFIX + "size";
+    long    SIZE_DEFAULT = 512L * 1024 * 1024; // 512 MB
+
+    // Evict a cached block this many millis after it was last accessed.
+    String  TTL_MS_KEY = PREFIX + "ttl.ms";
+    long    TTL_MS_DEFAULT = 60000;
+
+    // Global cap (across all prefetching streams of a DFSClient) on bytes held
+    // in prefetch buffers. Governs how many streams can prefetch concurrently
+    // (roughly MAX_BYTES / SIZE).
+    String  MAX_BYTES_KEY = PREFIX + "max.bytes";
+    long    MAX_BYTES_DEFAULT = 2L * 1024 * 1024 * 1024; // 2 GB
+
+    // Shared prefetch worker pool size. <= 0 disables prefetch.
+    String  THREADPOOL_SIZE_KEY = PREFIX + "threadpool.size";
+    int     THREADPOOL_SIZE_DEFAULT = 16;
+
+    // Max number of blocks a single stream prefetches concurrently.
+    String  THREADS_KEY = PREFIX + "threads";
+    int     THREADS_DEFAULT = 4;
+
+    // Granularity at which a block is filled and its readiness published, so
+    // the reader can consume a block's prefix before the whole block lands.
+    String  CHUNK_SIZE_KEY = PREFIX + "chunk.size";
+    int     CHUNK_SIZE_DEFAULT = 8 * 1024 * 1024; // 8 MB
+
+    // Periodically log per-stream read-cache metrics (cache vs direct bytes,
+    // cache usage) and whether caching is enabled for the stream.
+    String  METRICS_LOG_ENABLED_KEY = PREFIX + "metrics.log.enabled";
+    boolean METRICS_LOG_ENABLED_DEFAULT = false;
+    String  METRICS_LOG_INTERVAL_MS_KEY = PREFIX + "metrics.log.interval.ms";
+    long    METRICS_LOG_INTERVAL_MS_DEFAULT = 60000;
+  }
+
   /** dfs.client.read.striped configuration properties */
   interface StripedRead {
     String PREFIX = Read.PREFIX + "striped.";

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -155,6 +155,16 @@ public class DfsClientConf {
 
   private final long hedgedReadThresholdMillis;
   private final int hedgedReadThreadpoolSize;
+
+  private final boolean prefetchEnabled;
+  private final long prefetchTotalSize;
+  private final long prefetchTtlMs;
+  private final long prefetchMaxBytes;
+  private final int prefetchThreadpoolSize;
+  private final int prefetchThreads;
+  private final int prefetchChunkSize;
+  private final boolean prefetchMetricsLogEnabled;
+  private final long prefetchMetricsLogIntervalMs;
   private final List<Class<? extends ReplicaAccessorBuilder>>
       replicaAccessorBuilderClasses;
 
@@ -285,6 +295,34 @@ public class DfsClientConf {
     hedgedReadThreadpoolSize = conf.getInt(
         HdfsClientConfigKeys.HedgedRead.THREADPOOL_SIZE_KEY,
         HdfsClientConfigKeys.HedgedRead.THREADPOOL_SIZE_DEFAULT);
+
+    prefetchEnabled = conf.getBoolean(
+        HdfsClientConfigKeys.Prefetch.ENABLED_KEY,
+        HdfsClientConfigKeys.Prefetch.ENABLED_DEFAULT);
+    prefetchTotalSize = conf.getLong(
+        HdfsClientConfigKeys.Prefetch.SIZE_KEY,
+        HdfsClientConfigKeys.Prefetch.SIZE_DEFAULT);
+    prefetchTtlMs = Math.max(0L, conf.getLong(
+        HdfsClientConfigKeys.Prefetch.TTL_MS_KEY,
+        HdfsClientConfigKeys.Prefetch.TTL_MS_DEFAULT));
+    prefetchMaxBytes = conf.getLong(
+        HdfsClientConfigKeys.Prefetch.MAX_BYTES_KEY,
+        HdfsClientConfigKeys.Prefetch.MAX_BYTES_DEFAULT);
+    prefetchThreadpoolSize = conf.getInt(
+        HdfsClientConfigKeys.Prefetch.THREADPOOL_SIZE_KEY,
+        HdfsClientConfigKeys.Prefetch.THREADPOOL_SIZE_DEFAULT);
+    prefetchThreads = conf.getInt(
+        HdfsClientConfigKeys.Prefetch.THREADS_KEY,
+        HdfsClientConfigKeys.Prefetch.THREADS_DEFAULT);
+    prefetchChunkSize = conf.getInt(
+        HdfsClientConfigKeys.Prefetch.CHUNK_SIZE_KEY,
+        HdfsClientConfigKeys.Prefetch.CHUNK_SIZE_DEFAULT);
+    prefetchMetricsLogEnabled = conf.getBoolean(
+        HdfsClientConfigKeys.Prefetch.METRICS_LOG_ENABLED_KEY,
+        HdfsClientConfigKeys.Prefetch.METRICS_LOG_ENABLED_DEFAULT);
+    prefetchMetricsLogIntervalMs = conf.getLong(
+        HdfsClientConfigKeys.Prefetch.METRICS_LOG_INTERVAL_MS_KEY,
+        HdfsClientConfigKeys.Prefetch.METRICS_LOG_INTERVAL_MS_DEFAULT);
 
     deadNodeDetectionEnabled =
         conf.getBoolean(DFS_CLIENT_DEAD_NODE_DETECTION_ENABLED_KEY,
@@ -673,6 +711,56 @@ public class DfsClientConf {
    */
   public int getClientShortCircuitNum() {
     return clientShortCircuitNum;
+  }
+
+  /** @return whether sequential read-ahead prefetch is enabled. */
+  public boolean isPrefetchEnabled() {
+    return prefetchEnabled;
+  }
+
+  /** @return total per-stream prefetch memory in bytes. */
+  public long getPrefetchTotalSize() {
+    return prefetchTotalSize;
+  }
+
+  /** @return prefetch buffer time-to-live (millis) from last access. */
+  public long getPrefetchTtlMs() {
+    return prefetchTtlMs;
+  }
+
+  /**
+   * @return global cap on prefetch bytes shared by all prefetching streams in
+   *     the JVM (the prefetch budget and thread pool are process-wide, not
+   *     per-DFSClient; the first client to enable prefetch initializes them and
+   *     a later client only grows the budget to its own larger value).
+   */
+  public long getPrefetchMaxBytes() {
+    return prefetchMaxBytes;
+  }
+
+  /** @return shared prefetch worker pool size; {@code <= 0} disables prefetch. */
+  public int getPrefetchThreadpoolSize() {
+    return prefetchThreadpoolSize;
+  }
+
+  /** @return max blocks a single stream prefetches concurrently. */
+  public int getPrefetchThreads() {
+    return prefetchThreads;
+  }
+
+  /** @return chunk size (bytes) at which block readiness is published. */
+  public int getPrefetchChunkSize() {
+    return prefetchChunkSize;
+  }
+
+  /** @return whether to periodically log per-stream read-cache metrics. */
+  public boolean isPrefetchMetricsLogEnabled() {
+    return prefetchMetricsLogEnabled;
+  }
+
+  /** @return interval (millis) between read-cache metric log lines. */
+  public long getPrefetchMetricsLogIntervalMs() {
+    return prefetchMetricsLogIntervalMs;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4797,6 +4797,114 @@
 </property>
 
 <property>
+  <name>dfs.client.prefetch.enabled</name>
+  <value>false</value>
+  <description>
+    Enable sequential read-ahead prefetch in DFSClient. When enabled, for files
+    with more than one block, background workers fetch blocks ahead of the read
+    cursor, in parallel, into reusable in-memory buffers so that sequential
+    reads can be served from memory instead of waiting on a per-block DataNode
+    round trip. A stream keeps a sliding window of up to
+    N = dfs.client.prefetch.size / blockSize per-block buffers. Single-block
+    files never prefetch. Positioned reads (pread) are unaffected.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.size</name>
+  <value>536870912</value>
+  <description>
+    Total per-stream prefetch memory in bytes (default 512 MB). A stream holds
+    up to N = size / blockSize reusable per-block buffers, each sized to one
+    HDFS block; the read-ahead window slides forward as the reader advances.
+    Must be at least two blocks for prefetch to engage.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.ttl.ms</name>
+  <value>60000</value>
+  <description>
+    Soft time-to-live for a cached prefetch block. It is evaluated during
+    foreground reads as the read-ahead window slides: a buffered block not
+    accessed within this many milliseconds is dropped from the window and its
+    buffer returned to the per-stream pool (the block currently being read is
+    never evicted), so a reader that slows down stops holding read-ahead
+    buffers it is no longer keeping up with. This is a churn/reuse control, not
+    the memory cap: total per-stream prefetch memory is bounded up front by
+    dfs.client.prefetch.size, reserved against dfs.client.prefetch.max.bytes
+    when the stream starts prefetching and returned in full on close(). A
+    stream that goes fully idle (no further reads) releases its buffers when
+    the caller invokes unbuffer(); close() additionally returns the reserved
+    global budget. Because it is driven by read activity, this TTL does not fire
+    on a stream that stops reading without calling unbuffer()/close() -- such a
+    stream simply retains its already-reserved, bounded buffers until it is
+    unbuffered or closed.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.max.bytes</name>
+  <value>2147483648</value>
+  <description>
+    Global cap (shared by all prefetching streams in the JVM; the prefetch
+    budget and thread pool are process-wide, not per-DFSClient) on the
+    number of bytes held in prefetch buffers. Governs how many streams may
+    prefetch concurrently (roughly max.bytes / size); streams that cannot
+    reserve their budget fall back to the normal synchronous read path.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.threadpool.size</name>
+  <value>16</value>
+  <description>
+    Size of the shared (JVM-wide) worker thread pool used to fill prefetch
+    blocks in the background. A value &lt;= 0 disables prefetch regardless of
+    dfs.client.prefetch.enabled.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.threads</name>
+  <value>4</value>
+  <description>
+    Maximum number of blocks a single stream prefetches concurrently.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.chunk.size</name>
+  <value>8388608</value>
+  <description>
+    Granularity (bytes, default 8 MB) at which a prefetched block is filled and
+    its readiness published, so the reader can consume a block's prefix before
+    the whole block lands. Also the checkpoint at which an in-flight prefetch is
+    cancelled when the reader catches up.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.metrics.log.enabled</name>
+  <value>false</value>
+  <description>
+    When true, periodically log per-stream read-cache metrics (bytes served
+    from the prefetch cache vs. read directly from a DataNode, cache hit ratio,
+    and current cache usage), and log whether caching is enabled for each
+    opened stream.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.prefetch.metrics.log.interval.ms</name>
+  <value>60000</value>
+  <description>
+    Interval in milliseconds between read-cache metric log lines when
+    dfs.client.prefetch.metrics.log.enabled is true.
+  </description>
+</property>
+
+<property>
   <name>dfs.client.write.byte-array-manager.count-limit</name>
   <value>2048</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/PrefetchReadExample.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/PrefetchReadExample.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Example: how a client turns on and uses sequential read-ahead prefetch.
+ *
+ * <p>Prefetch is configured entirely through {@link Configuration} string keys
+ * (no new public API) and is transparent — the application reads the file with
+ * the normal {@code FileSystem.open(...).read(...)} loop and the bytes are
+ * served from the in-memory read-ahead cache when available, otherwise read
+ * directly from the DataNode. The feature is off by default and only engages
+ * for files with more than one block.
+ *
+ * <p>Run against a real cluster:
+ * <pre>
+ *   hadoop org.apache.hadoop.hdfs.PrefetchReadExample hdfs://nn:8020/path/to/bigfile
+ * </pre>
+ */
+public final class PrefetchReadExample {
+
+  private PrefetchReadExample() {
+  }
+
+  /**
+   * Build a Configuration with read-ahead prefetch enabled and tuned. Only
+   * {@code dfs.client.prefetch.enabled} is required; the rest have sensible
+   * defaults and are shown here for documentation.
+   */
+  public static Configuration prefetchConfig() {
+    Configuration conf = new Configuration();
+
+    // Required: turn the feature on for this client / FileSystem instance.
+    conf.setBoolean("dfs.client.prefetch.enabled", true);
+
+    // Optional tuning (defaults shown):
+    // Total prefetch memory per stream; split into N = size / blockSize
+    // per-block buffers. The main memory/parallelism knob.
+    conf.setLong("dfs.client.prefetch.size", 512L * 1024 * 1024);   // 512 MB
+    // Max blocks a single stream fetches concurrently.
+    conf.setInt("dfs.client.prefetch.threads", 4);
+    // Granularity of incremental fill / readiness (and cancel checkpoint).
+    conf.setInt("dfs.client.prefetch.chunk.size", 8 * 1024 * 1024); // 8 MB
+    // Shared (JVM-wide) prefetch worker pool size; <= 0 disables prefetch.
+    conf.setInt("dfs.client.prefetch.threadpool.size", 16);
+    // Global cap on prefetch bytes across all streams of this client.
+    conf.setLong("dfs.client.prefetch.max.bytes", 2L * 1024 * 1024 * 1024);
+
+    return conf;
+  }
+
+  /**
+   * Read {@code path} sequentially with prefetch enabled and return the number
+   * of bytes read. The read loop is exactly the same as a normal HDFS read —
+   * prefetch is transparent.
+   */
+  public static long readWithPrefetch(URI fsUri, Path path) throws IOException {
+    Configuration conf = prefetchConfig();
+    long total = 0;
+    byte[] buffer = new byte[1024 * 1024]; // 1 MB application buffer
+    try (FileSystem fs = FileSystem.get(fsUri, conf);
+         FSDataInputStream in = fs.open(path)) {
+      int n;
+      while ((n = in.read(buffer, 0, buffer.length)) > 0) {
+        total += n;
+      }
+    }
+    return total;
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 1) {
+      System.err.println(
+          "Usage: PrefetchReadExample <hdfs-uri-path>   e.g. hdfs://nn:8020/data/big");
+      System.exit(2);
+    }
+    Path path = new Path(args[0]);
+    URI fsUri = path.toUri();
+
+    long start = System.currentTimeMillis();
+    long bytes = readWithPrefetch(fsUri, path);
+    long ms = System.currentTimeMillis() - start;
+
+    System.out.printf("Read %d bytes from %s in %d ms (%.1f MB/s) with prefetch%n",
+        bytes, path, ms, (bytes / (1024.0 * 1024.0)) / Math.max(1, ms / 1000.0));
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStreamPrefetch.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStreamPrefetch.java
@@ -1,0 +1,700 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Functional and latency tests for sequential read-ahead prefetch
+ * ({@link BlockPrefetcher}) on {@link DFSInputStream}.
+ *
+ * <p>The latency tests simulate per-block DataNode latency with a fault
+ * injector on {@code getBlockReader} (which fires on every read path), since
+ * MiniDFSCluster reads are loopback. The heavyweight 2 GB tests allocate up to
+ * ~2 GB of reusable prefetch buffers and should be run with a large -Xmx.
+ */
+public class TestDFSInputStreamPrefetch {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDFSInputStreamPrefetch.class);
+
+  private MiniDFSCluster cluster;
+  private Configuration baseConf;
+
+  @BeforeEach
+  public void setUp() {
+    baseConf = new Configuration();
+    // Force remote (non short-circuit) reads so injected fetch latency applies.
+    baseConf.setBoolean(HdfsClientConfigKeys.Read.ShortCircuit.KEY, false);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    DFSClientFaultInjector.set(new DFSClientFaultInjector());
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  /**
+   * Inject a fixed sleep on every block-reader open to simulate per-block
+   * DataNode/network latency. Fires on both the sequential and the prefetch
+   * read paths (both open a reader via getBlockReader), so the baseline and
+   * the prefetched read are charged the same per-block latency.
+   */
+  private static final class LatencyInjector extends DFSClientFaultInjector {
+    private final long millis;
+    LatencyInjector(long millis) {
+      this.millis = millis;
+    }
+    @Override
+    public void openBlockReaderDelay() {
+      try {
+        Thread.sleep(millis);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private byte[] writeFile(FileSystem fs, Path p, int blockSize, int numBlocks)
+      throws IOException {
+    final long len = (long) blockSize * numBlocks;
+    byte[] data = new byte[(int) len];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) (i * 31 + 7);
+    }
+    try (org.apache.hadoop.fs.FSDataOutputStream out =
+             fs.create(p, true, 4096, (short) 1, blockSize)) {
+      out.write(data);
+    }
+    return data;
+  }
+
+  /** Stream a file of {@code totalLen} bytes to {@code p} in 4 MB chunks. */
+  private void writeLargeFile(FileSystem fs, Path p, int blockSize, long totalLen)
+      throws IOException {
+    try (org.apache.hadoop.fs.FSDataOutputStream out =
+             fs.create(p, true, 4096, (short) 1, blockSize)) {
+      byte[] chunk = new byte[4 * 1024 * 1024];
+      for (int i = 0; i < chunk.length; i++) {
+        chunk[i] = (byte) i;
+      }
+      for (long w = 0; w < totalLen; w += chunk.length) {
+        out.write(chunk);
+      }
+    }
+  }
+
+  /** Fully read a stream in 1 MB chunks, returning all bytes. */
+  private static byte[] readFully(InputStream in, int totalLen)
+      throws IOException {
+    byte[] out = new byte[totalLen];
+    byte[] chunk = new byte[1024 * 1024];
+    int filled = 0;
+    int n;
+    while (filled < totalLen && (n = in.read(chunk, 0, chunk.length)) > 0) {
+      System.arraycopy(chunk, 0, out, filled, n);
+      filled += n;
+    }
+    assertEquals(totalLen, filled, "did not read whole file");
+    return out;
+  }
+
+  /** Time a streaming full read (bytes discarded). */
+  private static long timeRead(FileSystem fs, Path p, long totalLen)
+      throws IOException {
+    byte[] chunk = new byte[4 * 1024 * 1024];
+    long start = System.nanoTime();
+    long read = 0;
+    try (FSDataInputStream in = fs.open(p)) {
+      int n;
+      while ((n = in.read(chunk, 0, chunk.length)) > 0) {
+        read += n;
+      }
+    }
+    assertEquals(totalLen, read);
+    return (System.nanoTime() - start) / 1_000_000L;
+  }
+
+  private static Configuration prefetchConf(Configuration base, long size,
+      int threads, long maxBytes) {
+    Configuration c = new Configuration(base);
+    c.setBoolean(HdfsClientConfigKeys.Prefetch.ENABLED_KEY, true);
+    c.setLong(HdfsClientConfigKeys.Prefetch.SIZE_KEY, size);
+    c.setInt(HdfsClientConfigKeys.Prefetch.THREADS_KEY, threads);
+    c.setInt(HdfsClientConfigKeys.Prefetch.THREADPOOL_SIZE_KEY, 8);
+    c.setLong(HdfsClientConfigKeys.Prefetch.MAX_BYTES_KEY, maxBytes);
+    return c;
+  }
+
+  /**
+   * Correctness: with prefetch enabled on a multi-block file, reads return
+   * exactly the bytes written, and the cache actually serves data. Small blocks
+   * for speed.
+   */
+  @Test
+  @Timeout(120)
+  public void testPrefetchReadsAreCorrect() throws Exception {
+    final int blockSize = 1024 * 1024;     // 1 MB
+    final int numBlocks = 4;               // 4 MB file
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-correct");
+    byte[] expected;
+    try (FileSystem fs = cluster.getFileSystem()) {
+      expected = writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      assertNotNull(dfsin.getPrefetcherForTesting(),
+          "prefetcher should be active for multi-block file");
+
+      byte[] got = readFully(in, expected.length);
+      assertArrayEquals(expected, got, "prefetched bytes must match written bytes");
+
+      BlockPrefetcher.Metrics m = dfsin.getPrefetcherForTesting().getMetrics();
+      LOG.info("prefetch metrics: hits={} misses={} bytesServed={} "
+              + "prefetchOk={} prefetchFailed={} cancellations={}",
+          m.hits, m.misses, m.bytesServed, m.prefetchOk, m.prefetchFailed,
+          m.cancellations);
+      assertTrue(m.hits > 0, "cache should have served some reads");
+      assertEquals(0, m.prefetchFailed, "no prefetch should have failed");
+    }
+  }
+
+  /** A single-block file must never create a prefetcher. */
+  @Test
+  @Timeout(60)
+  public void testSingleBlockFileNotPrefetched() throws Exception {
+    final int blockSize = 1024 * 1024;
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+    Path file = new Path("/single-block");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeFile(fs, file, blockSize, 1);
+    }
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      assertNull(dfsin.getPrefetcherForTesting(), "single-block file must not prefetch");
+    }
+  }
+
+  /** Run baseline (off) then prefetch (on) full reads; returns [baselineMs, prefetchMs]. */
+  private long[] measure(Path file, long totalLen, Configuration on,
+      BlockPrefetcher.Metrics[] metricsOut) throws IOException {
+    Configuration off = new Configuration(baseConf);
+    off.setBoolean(HdfsClientConfigKeys.Prefetch.ENABLED_KEY, false);
+
+    long baselineMs;
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), off)) {
+      baselineMs = timeRead(fs, file, totalLen);
+    }
+
+    long prefetchMs;
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on)) {
+      byte[] chunk = new byte[4 * 1024 * 1024];
+      long start = System.nanoTime();
+      try (FSDataInputStream in = fs.open(file)) {
+        DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+        assertNotNull(dfsin.getPrefetcherForTesting(), "prefetcher must be active");
+        long read = 0;
+        int n;
+        while ((n = in.read(chunk, 0, chunk.length)) > 0) {
+          read += n;
+        }
+        assertEquals(totalLen, read);
+        metricsOut[0] = dfsin.getPrefetcherForTesting().getMetrics();
+      }
+      prefetchMs = (System.nanoTime() - start) / 1_000_000L;
+    }
+    return new long[] {baselineMs, prefetchMs};
+  }
+
+  private static void report(String tag, long baselineMs, long prefetchMs,
+      BlockPrefetcher.Metrics m) {
+    double speedup = (double) baselineMs / Math.max(1, prefetchMs);
+    LOG.info("=== {} ===", tag);
+    LOG.info("baseline (no prefetch): {} ms", baselineMs);
+    LOG.info("with prefetch:          {} ms", prefetchMs);
+    LOG.info("speedup:                {}x", String.format("%.2f", speedup));
+    LOG.info("metrics: hits={} misses={} prefetchOk={} cancellations={} bytesServed={}",
+        m.hits, m.misses, m.prefetchOk, m.cancellations, m.bytesServed);
+    System.out.printf("PREFETCH PERF [%s]: baseline=%dms prefetch=%dms speedup=%.2fx "
+            + "prefetchOk=%d cancellations=%d%n",
+        tag, baselineMs, prefetchMs, speedup, m.prefetchOk, m.cancellations);
+  }
+
+  /**
+   * Assert the deterministic invariants of a prefetch perf run: the cache was
+   * actually used, and prefetch did not pathologically regress versus the
+   * no-prefetch baseline. The exact wall-clock speedup is intentionally NOT
+   * asserted: in a single-JVM {@link MiniDFSCluster} the emulated DataNodes
+   * share the same CPU and OS page cache, so the parallel-transfer win is muted
+   * and noisy (runs routinely land a few percent apart in either direction).
+   * The measured speedup is logged by {@link #report}, and the real,
+   * reproducible throughput numbers live in the design doc / commit message.
+   * The generous 2x no-regression bound still catches a gross correctness or
+   * performance regression without flaking on scheduling jitter.
+   */
+  private static void assertPrefetchEffective(BlockPrefetcher.Metrics m,
+      long[] r) {
+    assertTrue(m.hits > 0, "prefetch should serve from cache");
+    assertTrue(r[1] < r[0] * 2, "prefetch (" + r[1] + "ms) should not regress badly vs baseline ("
+        + r[0] + "ms)");
+  }
+
+  /**
+   * Heavyweight latency/throughput scenarios allocate hundreds of MB up to
+   * ~2 GB of prefetch buffers (plus the file payload), which OOMs or times out
+   * the default Apache Yetus unit-test JVM. Skip them unless explicitly opted
+   * in ({@code -Dtest.prefetch.heavy=true}) AND the JVM has enough heap
+   * headroom, so they stay runnable on demand for perf validation without
+   * breaking precommit CI. The small (1 MB-block) correctness tests always run.
+   */
+  private static void assumeHeavyPrefetchEnabled(long requiredBufferBytes) {
+    Assumptions.assumeTrue(
+        Boolean.getBoolean("test.prefetch.heavy"),
+        "heavyweight prefetch perf test; enable with -Dtest.prefetch.heavy=true");
+    long headroom = requiredBufferBytes + (512L << 20);
+    Assumptions.assumeTrue(
+        Runtime.getRuntime().maxMemory() >= headroom,
+        "insufficient -Xmx for heavyweight prefetch test: need >= " + headroom
+            + " bytes, have " + Runtime.getRuntime().maxMemory());
+  }
+
+  /** 512 MB file, 4 x 128 MB blocks, 512 MB budget (N=4), single DataNode. */
+  @Test
+  @Timeout(300)
+  public void testPrefetchLatency512MBFile() throws Exception {
+    assumeHeavyPrefetchEnabled(512L * 1024 * 1024);
+    final int blockSize = 128 * 1024 * 1024;
+    final int numBlocks = 4;
+    final long totalLen = (long) blockSize * numBlocks;
+
+    baseConf.setInt("dfs.bytes-per-checksum", 512);
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+    Path file = new Path("/prefetch-512mb");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeLargeFile(fs, file, blockSize, totalLen);
+    }
+    DFSClientFaultInjector.set(new LatencyInjector(300));
+
+    Configuration on = prefetchConf(baseConf, 4L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    BlockPrefetcher.Metrics[] m = new BlockPrefetcher.Metrics[1];
+    long[] r = measure(file, totalLen, on, m);
+    report("512MB file, 128MB blocks, N=4, 1 DataNode", r[0], r[1], m[0]);
+
+    assertPrefetchEffective(m[0], r);
+  }
+
+  /** 2 GB file, 4 x 512 MB blocks, 1 GB budget (N=2 -> one block ahead). */
+  @Test
+  @Timeout(600)
+  public void testPrefetchLatency2GBFile1GBBudget() throws Exception {
+    assumeHeavyPrefetchEnabled(1024L * 1024 * 1024);
+    final int blockSize = 512 * 1024 * 1024;
+    final int numBlocks = 4;
+    final long totalLen = (long) blockSize * numBlocks;
+
+    baseConf.setInt("dfs.bytes-per-checksum", 512);
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+    Path file = new Path("/prefetch-2gb-1gbudget");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeLargeFile(fs, file, blockSize, totalLen);
+    }
+    DFSClientFaultInjector.set(new LatencyInjector(300));
+
+    Configuration on = prefetchConf(baseConf, 1024L * 1024 * 1024, 4,
+        4L * 1024 * 1024 * 1024);
+    BlockPrefetcher.Metrics[] m = new BlockPrefetcher.Metrics[1];
+    long[] r = measure(file, totalLen, on, m);
+    report("2GB file, 512MB blocks, 1GB budget (N=2), 1 DataNode", r[0], r[1], m[0]);
+
+    assertPrefetchEffective(m[0], r);
+  }
+
+  /**
+   * 2 GB file, 4 x 512 MB blocks, 2 GB budget so N=4 per-block buffers and all
+   * blocks ahead of the cursor fetch concurrently (4 threads), each filled in
+   * 8 MB chunks. Single DataNode.
+   */
+  @Test
+  @Timeout(600)
+  public void testPrefetchParallel2GBFile2GBBudget() throws Exception {
+    assumeHeavyPrefetchEnabled(2L * 1024 * 1024 * 1024);
+    final int blockSize = 512 * 1024 * 1024;
+    final int numBlocks = 4;
+    final long totalLen = (long) blockSize * numBlocks;
+
+    baseConf.setInt("dfs.bytes-per-checksum", 512);
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+    Path file = new Path("/prefetch-2gb-parallel");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeLargeFile(fs, file, blockSize, totalLen);
+    }
+    DFSClientFaultInjector.set(new LatencyInjector(300));
+
+    Configuration on = prefetchConf(baseConf, 2L * 1024 * 1024 * 1024, 4,
+        4L * 1024 * 1024 * 1024);
+    BlockPrefetcher.Metrics[] m = new BlockPrefetcher.Metrics[1];
+    long[] r = measure(file, totalLen, on, m);
+    report("2GB file, 512MB blocks, 2GB budget (N=4 parallel), 1 DataNode",
+        r[0], r[1], m[0]);
+
+    assertPrefetchEffective(m[0], r);
+  }
+
+  /**
+   * Same 2 GB / 512 MB-block / 2 GB-budget v2 config but on FOUR DataNodes, so
+   * the blocks land on different nodes and the concurrent prefetches use
+   * independent disks/NICs — revealing the parallel-transfer speedup that a
+   * single DataNode's bandwidth hides.
+   */
+  @Test
+  @Timeout(600)
+  public void testPrefetchParallel2GBFileFourDataNodes() throws Exception {
+    assumeHeavyPrefetchEnabled(2L * 1024 * 1024 * 1024);
+    final int blockSize = 512 * 1024 * 1024;
+    final int numBlocks = 4;
+    final long totalLen = (long) blockSize * numBlocks;
+
+    baseConf.setInt("dfs.bytes-per-checksum", 512);
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(4).build();
+    cluster.waitActive();
+    Path file = new Path("/prefetch-2gb-4dn");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeLargeFile(fs, file, blockSize, totalLen);
+    }
+    DFSClientFaultInjector.set(new LatencyInjector(300));
+
+    Configuration on = prefetchConf(baseConf, 2L * 1024 * 1024 * 1024, 4,
+        4L * 1024 * 1024 * 1024);
+    BlockPrefetcher.Metrics[] m = new BlockPrefetcher.Metrics[1];
+    long[] r = measure(file, totalLen, on, m);
+    report("2GB file, 512MB blocks, 2GB budget (N=4 parallel), 4 DataNodes",
+        r[0], r[1], m[0]);
+
+    assertPrefetchEffective(m[0], r);
+  }
+
+  /**
+   * Verifies the client usage pattern documented in
+   * {@link PrefetchReadExample}: enable prefetch via Configuration, open and
+   * read a multi-block file normally, and get identical bytes back.
+   */
+  @Test
+  @Timeout(120)
+  public void testUsageExample() throws Exception {
+    final int blockSize = 1024 * 1024; // 1 MB
+    final int numBlocks = 8;           // 8 MB, 8 blocks
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-usage");
+    byte[] expected;
+    try (FileSystem fs = cluster.getFileSystem()) {
+      expected = writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    // This is the documented client recipe (see PrefetchReadExample):
+    Configuration conf = PrefetchReadExample.prefetchConfig();
+    conf.setBoolean(HdfsClientConfigKeys.Read.ShortCircuit.KEY, false);
+
+    long total = 0;
+    byte[] buffer = new byte[1024 * 1024];
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), conf);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      assertNotNull(dfsin.getPrefetcherForTesting(),
+          "prefetch should be active for the usage example");
+      int n;
+      int pos = 0;
+      while ((n = in.read(buffer, 0, buffer.length)) > 0) {
+        for (int i = 0; i < n; i++) {
+          assertEquals(expected[pos + i], buffer[i], "byte mismatch at " + (pos + i));
+        }
+        pos += n;
+        total += n;
+      }
+      assertEquals(expected.length, total);
+      assertTrue(dfsin.getPrefetcherForTesting().getMetrics().hits > 0,
+          "cache should have served reads");
+    }
+  }
+
+  /**
+   * Verifies the read-cache metrics: bytes served from cache vs. read directly
+   * from the DataNode are accounted separately and sum to the file length, and
+   * the metrics-logging path is exercised when enabled.
+   */
+  @Test
+  @Timeout(120)
+  public void testCacheVsDirectMetrics() throws Exception {
+    final int blockSize = 1024 * 1024; // 1 MB
+    final int numBlocks = 8;           // 8 MB, 8 blocks
+    final int totalLen = blockSize * numBlocks;
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-metrics");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    on.setBoolean(HdfsClientConfigKeys.Prefetch.METRICS_LOG_ENABLED_KEY, true);
+    on.setLong(HdfsClientConfigKeys.Prefetch.METRICS_LOG_INTERVAL_MS_KEY, 500);
+
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      byte[] buffer = new byte[256 * 1024];
+      while (in.read(buffer, 0, buffer.length) > 0) {
+        // Drain the stream fully to exercise the prefetch read path.
+      }
+      BlockPrefetcher.Metrics m = dfsin.getPrefetcherForTesting().getMetrics();
+      LOG.info("cache-vs-direct: cacheBytes={} directBytes={} hits={} misses={}",
+          m.bytesServed, m.bytesReadDirect, m.hits, m.misses);
+
+      assertEquals(totalLen, m.bytesServed + m.bytesReadDirect,
+          "cache + direct must equal file length");
+      assertTrue(m.bytesReadDirect > 0, "block 0 is read through directly");
+      assertTrue(m.bytesServed > 0, "later blocks should be served from cache");
+    }
+  }
+
+  /**
+   * Regression test: prefetch-served bytes must be counted in
+   * {@link org.apache.hadoop.hdfs.ReadStatistics} just like directly-read
+   * bytes, so cache hits are not invisible to monitoring/billing. Without the
+   * accounting in {@code consumePrefetched}, total bytes read would be
+   * under-reported by the cache hit portion.
+   */
+  @Test
+  @Timeout(120)
+  public void testPrefetchReadStatisticsAccounted() throws Exception {
+    final int blockSize = 1024 * 1024; // 1 MB
+    final int numBlocks = 8;           // 8 MB, 8 blocks
+    final long totalLen = (long) blockSize * numBlocks;
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-readstats");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      byte[] buffer = new byte[256 * 1024];
+      while (in.read(buffer, 0, buffer.length) > 0) {
+        // Drain the stream fully to exercise the prefetch read path.
+      }
+      BlockPrefetcher.Metrics m = dfsin.getPrefetcherForTesting().getMetrics();
+      assertTrue(m.hits > 0, "some bytes should have been served from cache");
+      assertTrue(m.bytesServed > 0, "cache should have served bytes");
+
+      // ReadStatistics must include cache-served bytes: the total must equal
+      // the whole file, i.e. cache-served bytes are not dropped.
+      assertEquals(totalLen, dfsin.getReadStatistics().getTotalBytesRead(),
+          "ReadStatistics total must count prefetch-served bytes");
+    }
+  }
+
+  /**
+   * Verify per-client isolation: a client that disables prefetch never
+   * prefetches, even when another client in the same JVM has already enabled
+   * prefetch and created the process-wide thread pool.
+   */
+  @Test
+  @Timeout(120)
+  public void testPrefetchDisabledIsPerClient() throws Exception {
+    final int blockSize = 1024 * 1024;
+    final int numBlocks = 4;
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-per-client");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    // Keep the prefetch-enabled client (and thus the process-wide pool) open
+    // while checking the disabled client, so the disabled client is gated by
+    // its own config rather than by the pool being absent.
+    try (FileSystem fs1 = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in1 = fs1.open(file)) {
+      DFSInputStream dfsin1 = (DFSInputStream) in1.getWrappedStream();
+      assertNotNull(dfsin1.getPrefetcherForTesting(), "prefetch-enabled client should prefetch");
+
+      Configuration off = new Configuration(baseConf);
+      off.setBoolean(HdfsClientConfigKeys.Prefetch.ENABLED_KEY, false);
+      try (FileSystem fs2 = FileSystem.newInstance(cluster.getURI(), off);
+           FSDataInputStream in2 = fs2.open(file)) {
+        DFSInputStream dfsin2 = (DFSInputStream) in2.getWrappedStream();
+        assertNull(dfsin2.getPrefetcherForTesting(),
+            "prefetch-disabled client must not prefetch even after "
+            + "another client in the JVM enabled it");
+      }
+    }
+  }
+
+  /**
+   * Verify cache-served bytes are attributed to the same
+   * local/remote/short-circuit bucket as the reader that prefetched them,
+   * rather than blindly counted as remote. The direct (landing block) read and
+   * the prefetched reads open readers the same way, so they share one locality;
+   * with short-circuit disabled every byte therefore lands in a single
+   * non-short-circuit bucket.
+   */
+  @Test
+  @Timeout(120)
+  public void testPrefetchReadStatisticsLocalitySplit() throws Exception {
+    final int blockSize = 1024 * 1024;
+    final int numBlocks = 8;
+    final long totalLen = (long) blockSize * numBlocks;
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-locality");
+    try (FileSystem fs = cluster.getFileSystem()) {
+      writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      byte[] buffer = new byte[256 * 1024];
+      while (in.read(buffer, 0, buffer.length) > 0) {
+        // Drain the stream fully to exercise the prefetch read path.
+      }
+      BlockPrefetcher.Metrics m = dfsin.getPrefetcherForTesting().getMetrics();
+      assertTrue(m.hits > 0, "some bytes should have been served from cache");
+
+      ReadStatistics rs = dfsin.getReadStatistics();
+      long total = rs.getTotalBytesRead();
+      long remote = rs.getRemoteBytesRead();
+      long local = rs.getTotalLocalBytesRead();
+      long sc = rs.getTotalShortCircuitBytesRead();
+      assertEquals(totalLen, total, "total must equal file length");
+      assertEquals(0L, sc, "short-circuit is disabled for this test");
+      assertTrue((remote == total && local == 0) || (local == total && remote == 0),
+          "cache-served bytes must share the direct read's locality "
+              + "bucket (no local/remote mixing): local=" + local
+              + " remote=" + remote);
+    }
+  }
+
+  /**
+   * Verify {@code unbuffer()} releases the stream's pooled prefetch buffers so
+   * an idle-but-open stream stops pinning heap: after {@code unbuffer()} the
+   * free-buffer pool is drained and the allocation high-water mark is reset,
+   * while the stream stays usable and re-allocates lazily on the next read.
+   */
+  @Test
+  @Timeout(120)
+  public void testUnbufferReleasesPrefetchBuffers() throws Exception {
+    final int blockSize = 1024 * 1024;
+    final int numBlocks = 8;
+    cluster = new MiniDFSCluster.Builder(baseConf).numDataNodes(1).build();
+    cluster.waitActive();
+
+    Path file = new Path("/prefetch-unbuffer");
+    byte[] expected;
+    try (FileSystem fs = cluster.getFileSystem()) {
+      expected = writeFile(fs, file, blockSize, numBlocks);
+    }
+
+    Configuration on = prefetchConf(baseConf, 8L * blockSize, 4,
+        2L * 1024 * 1024 * 1024);
+    try (FileSystem fs = FileSystem.newInstance(cluster.getURI(), on);
+         FSDataInputStream in = fs.open(file)) {
+      DFSInputStream dfsin = (DFSInputStream) in.getWrappedStream();
+      BlockPrefetcher p = dfsin.getPrefetcherForTesting();
+      byte[] buffer = new byte[256 * 1024];
+      // Read the first few blocks so the prefetcher allocates backing arrays.
+      for (int i = 0; i < 12; i++) {
+        if (in.read(buffer, 0, buffer.length) <= 0) {
+          break;
+        }
+      }
+      assertTrue(p.getAllocatedBuffers() > 0, "prefetcher should have allocated buffers");
+
+      // Quiesce outstanding fetches (no further reads schedule new ones) so the
+      // drain assertions below are deterministic: a fetch completing after
+      // unbuffer() would otherwise re-offer its array into the pool.
+      long deadline = System.currentTimeMillis() + 30_000;
+      while (p.getInFlight() > 0 && System.currentTimeMillis() < deadline) {
+        Thread.sleep(20);
+      }
+      assertEquals(0, p.getInFlight(), "no prefetch should still be in flight");
+
+      in.unbuffer();
+      assertEquals(0, p.getAllocatedBuffers(), "unbuffer must reset the allocation high-water mark");
+      assertEquals(0, p.getFreeBufferCount(),
+          "unbuffer must drain the free-buffer pool");
+
+      // The stream is still usable after unbuffer(): a re-read returns the
+      // correct bytes and the pool re-populates lazily.
+      in.seek(0);
+      byte[] got = readFully(in, expected.length);
+      assertArrayEquals(expected, got, "bytes after unbuffer must match");
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
@@ -45,6 +45,7 @@ public class TestHdfsConfigFields extends TestConfigurationFieldsBase {
         HdfsClientConfigKeys.StripedRead.class, DFSConfigKeys.class,
         HdfsClientConfigKeys.BlockWrite.class, HdfsClientConfigKeys.Write.class,
         HdfsClientConfigKeys.Read.class, HdfsClientConfigKeys.HedgedRead.class,
+        HdfsClientConfigKeys.Prefetch.class,
         HdfsClientConfigKeys.ShortCircuit.class,
         HdfsClientConfigKeys.Retry.class, HdfsClientConfigKeys.Mmap.class,
         HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.class,


### PR DESCRIPTION
### Description of PR

Large sequential scans, such as analytics,  bulk copies, and
columnar readers, open a `DFSInputStream` and read a file end-to-end.

Today, each block is fetched synchronously:

1. The reader thread opens a `BlockReader`.
2. It waits for the DataNode/network round trip.
3. It drains the block.
4. It repeats the process for the next block.

The per-block open latency and single-block-at-a-time pipeline leave the
client CPU idle while waiting on I/O and cap throughput well below what the
DataNodes and network can deliver.

This change adds an **opt-in, client-side read-ahead prefetcher** that fetches
blocks ahead of the reader's cursor using a shared background thread pool.
By the time the reader reaches a prefetched block, the block is already
resident in memory and can be served as an in-memory copy.

## Approach

### BlockPrefetcher

- Introduces a new `BlockPrefetcher` that maintains a bounded, sliding window
  of block-sized buffers ahead of the current read position.
- Blocks are filled in chunks using a shared, JVM-wide daemon thread pool.
- The thread pool uses:
  - `SynchronousQueue`
  - `AbortPolicy`
- When all workers are busy, a prefetch submission is rejected and skipped
  rather than blocking the foreground reader thread.

### DFSInputStream Integration

- `DFSInputStream.read(byte[])` and `read(ByteBuffer)` first attempt to serve
  data from the prefetch cache.
- On a cache hit:
  - The read position is advanced.
  - The stateful synchronous reader is invalidated.
  - Read statistics are updated exactly as they are on the direct path.
  - Locality is preserved across short-circuit, local, and remote reads.
- On a cache miss:
  - The normal synchronous read path is used.
  - Block locations are cached for subsequent prefetch operations.

### Prefetch Safety and Correctness

- Prefetch operates entirely using cached block locations.
- It never issues a `getBlockLocations` RPC.
- It does not mutate foreground retry state while a foreground read may hold
  `infoLock`.
- The following cases are excluded for correctness:
  - Non-uniform block sizes
  - Striped (EC) files
  - Under-construction files
  - Single-block files

### Metrics and Observability

- A shared, opt-in scheduled task periodically logs per-stream cache
  hit/miss ratios at `INFO` level.
- Metrics logging occurs only when metrics logging is enabled.

### Global Memory Budget

- A global byte budget bounds the total memory held by all prefetch buffers
  across the JVM.
- The budget grows to the largest configured value across clients.
- Memory is strictly reserved and released on a per-stream basis.

## Configuration

All configuration is client-side. The feature is **disabled by default**.

| Configuration | Description |
|---|---|
| `dfs.client.prefetch.enabled` | Enables client-side read-ahead prefetching |
| `dfs.client.prefetch.size` | Per-stream read-ahead window |
| `dfs.client.prefetch.max.bytes` | JVM-wide prefetch memory cap |
| `dfs.client.prefetch.chunk.size` | Prefetch fill granularity |
| `dfs.client.prefetch.threads` | Shared prefetch worker thread count |
| `dfs.client.prefetch.threadpool.size` | Shared prefetch worker thread pool size |
| `dfs.client.prefetch.ttl.ms` | Buffer time-to-live |
| `dfs.client.prefetch.metrics.log.enabled` | Enables periodic cache hit-ratio logging |

## Results

A single-client sequential read benchmark was run with:

- **File size:** 10 GB
- **Block size:** 512 MB
- **Prefetch threads:** 5
- **Prefetch window:** ~3 GB

### Performance

| Metric | Result |
|---|---:|
| Baseline throughput | 406.8 MB/s |
| Prefetch throughput | 1,419.5 MB/s |
| Average improvement | **~3.49x** |
| Peak throughput | **~1.58 GB/s** |
| Cache hit ratio | **~81%** |

The feature is **off by default** and has no impact on the read path until
explicitly enabled.




<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->


### How was this patch tested?
Tested by newly added unit test


### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

