### PR TITLE
HDFS-17976. HDFS DataNode add configurable inactivity-based timeout for DataNode block transfers

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1659,6 +1659,14 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       DFS_DATANODE_TRANSFER_SOCKET_RECV_BUFFER_SIZE_DEFAULT =
       HdfsConstants.DEFAULT_DATA_SOCKET_SIZE;
 
+  // Timeout for completing an entire block transfer on the DataNode. When no
+  // packet is received for (timeout/2) the stalled transfer is terminated.
+  // Set to 0 (default) or a negative value to disable.
+  public static final String DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS =
+      "dfs.datanode.last.packet.receive.timeout.ms";
+  public static final long DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS_DEFAULT =
+      0;
+
   public static final String
       DFS_DATA_TRANSFER_SERVER_TCPNODELAY =
       "dfs.data.transfer.server.tcpnodelay";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -33,12 +33,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.zip.Checksum;
 
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.fs.FSOutputSummer;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSPacket;
 import org.apache.hadoop.hdfs.DFSUtilClient;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -149,6 +154,17 @@ class BlockReceiver implements Closeable {
   private final AtomicLong lastSentTime = new AtomicLong(0L);
   private long maxSendIdleTime;
 
+  // Timeout for receiving the last packet of a block transfer. When enabled
+  // (> 0), a stalled transfer (no packet received within timeoutMs/2) is
+  // safely terminated so the DataNode can reclaim the transfer thread.
+  private final long lastPacketReceiveTimeoutMs;
+  private volatile ScheduledFuture<?> timeoutTask;
+  private volatile long lastPacketReceivedTime = Time.monotonicNow();
+
+  private static final AtomicLongFieldUpdater<BlockReceiver>
+      LAST_PACKET_RECEIVED_TIME_UPDATER = AtomicLongFieldUpdater.newUpdater(
+          BlockReceiver.class, "lastPacketReceivedTime");
+
   BlockReceiver(final ExtendedBlock block, final StorageType storageType,
       final DataInputStream in,
       final String inAddr, final String myAddr,
@@ -192,6 +208,22 @@ class BlockReceiver implements Closeable {
       // the interval of 0.5*readTimeout. Here, we set 0.9*readTimeout to be
       // the threshold for detecting congestion.
       this.maxSendIdleTime = (long) (readTimeout * 0.9);
+      this.lastPacketReceiveTimeoutMs = datanode.getConf().getLong(
+          DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS,
+          DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS_DEFAULT);
+      // A healthy but idle client (hflush/hsync then wait) still sends heartbeat
+      // packets about every 0.5*readTimeout. Since a stall is declared after no
+      // packet for timeoutMs/2, the timeout must be comfortably larger than the
+      // socket read timeout or those healthy idle streams could be aborted.
+      if (this.lastPacketReceiveTimeoutMs > 0
+          && this.lastPacketReceiveTimeoutMs <= readTimeout) {
+        LOG.warn("{} ({} ms) is <= the DataNode socket read timeout ({} ms); "
+            + "healthy idle hflush/hsync streams that only send periodic "
+            + "heartbeats (about every {} ms) may be aborted. Configure it "
+            + "well above the socket read timeout (e.g. >= 2x).",
+            DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS,
+            this.lastPacketReceiveTimeoutMs, readTimeout, readTimeout / 2);
+      }
       if (LOG.isDebugEnabled()) {
         LOG.debug(getClass().getSimpleName() + ": " + block
             + "\n storageType=" + storageType + ", inAddr=" + inAddr
@@ -205,6 +237,7 @@ class BlockReceiver implements Closeable {
             + "\n allowLazyPersist=" + allowLazyPersist + ", pinning=" + pinning
             + ", isClient=" + isClient + ", isDatanode=" + isDatanode
             + ", responseInterval=" + responseInterval
+            + ", lastPacketReceiveTimeoutMs=" + lastPacketReceiveTimeoutMs
             + ", storageID=" + (storageId != null ? storageId : "null")
         );
       }
@@ -279,7 +312,10 @@ class BlockReceiver implements Closeable {
       // write data chunk header if creating a new replica
       if (isCreate) {
         BlockMetadataHeader.writeHeader(checksumOut, diskChecksum);
-      } 
+      }
+
+      // Start the block transfer timer for the entire block transfer
+      startBlockTransferTimer();
     } catch (ReplicaAlreadyExistsException | ReplicaNotFoundException
         | DiskOutOfSpaceException e) {
       throw e;
@@ -323,10 +359,127 @@ class BlockReceiver implements Closeable {
   }
 
   /**
+   * Starts the timeout task for the block transfer using the DataNode's shared
+   * ScheduledExecutorService. If the timeout is not configured (&lt;= 0), this
+   * method does nothing. This timer covers the entire block transfer and is not
+   * reset per packet; instead {@link #handleBlockTransferTimeout()} inspects the
+   * last-packet timestamp when it fires.
+   */
+  private synchronized void startBlockTransferTimer() {
+    if (lastPacketReceiveTimeoutMs <= 0) {
+      return; // Timeout not enabled
+    }
+
+    ScheduledExecutorService executorService =
+        datanode.getBlockTransferTimeoutService();
+    if (executorService == null) {
+      LOG.warn("Block transfer timeout is configured ({} ms) but executor "
+          + "service is not initialized for block {} from client {}. Timeout "
+          + "will not be enforced.", lastPacketReceiveTimeoutMs,
+          block.getBlockName(), clientname);
+      return;
+    }
+
+    timeoutTask = executorService.schedule(this::handleBlockTransferTimeout,
+        timeoutPollIntervalMs(), TimeUnit.MILLISECONDS);
+
+    LOG.info("Scheduled block transfer timeout task (timeout {} ms, polling "
+        + "every {} ms) for block {} from client {}", lastPacketReceiveTimeoutMs,
+        timeoutPollIntervalMs(), block.getBlockName(), clientname);
+  }
+
+  /**
+   * Poll interval for the stall check. A stall is declared when no packet has
+   * arrived for {@code timeout/2}, so polling every {@code timeout/2} bounds the
+   * detection latency to between {@code timeout/2} and {@code timeout} after the
+   * client stops sending.
+   */
+  private long timeoutPollIntervalMs() {
+    return Math.max(1L, lastPacketReceiveTimeoutMs / 2);
+  }
+
+  /** Cancels the block transfer timeout task if it exists. */
+  private synchronized void cancelBlockTransferTimer() {
+    if (timeoutTask != null) {
+      timeoutTask.cancel(false);
+      timeoutTask = null;
+    }
+  }
+
+  /**
+   * Handles a scheduled stall check for the block transfer. If a packet was
+   * received within the last {@code timeout/2} the stream is considered active
+   * and the check is scheduled again. Otherwise the transfer is treated as
+   * stalled and aborted by closing the input stream, which unblocks the receive
+   * thread's blocked socket read so it unwinds and runs its own cleanup.
+   *
+   * <p>This runs on the shared DataNode scheduler thread, so it deliberately
+   * does <em>no</em> disk I/O: the on-disk streams ({@code out}/
+   * {@code checksumOut}) are written by the receive thread <em>without</em>
+   * holding this monitor, so flushing them from here would race those writes and
+   * could corrupt the replica. Data that was already acknowledged to the client
+   * is already durable on disk, and the replica is left in RBW state so the
+   * NameNode's lease recovery can finalize it without data loss.
+   */
+  private synchronized void handleBlockTransferTimeout() {
+    // block already closed successfully; timeout task was cancelled/nulled.
+    if (timeoutTask == null) {
+      return;
+    }
+    long timeSinceLastPacket =
+        Time.monotonicNow() - LAST_PACKET_RECEIVED_TIME_UPDATER.get(this);
+    long halfTimeout = lastPacketReceiveTimeoutMs / 2;
+
+    if (timeSinceLastPacket < halfTimeout) {
+      // Packet was received recently, stream is active - schedule next check.
+      LOG.debug("Block transfer timer fired for block {}, but packet was "
+          + "received {} ms ago (threshold is {} ms). Rescheduling check.",
+          block.getBlockName(), timeSinceLastPacket, halfTimeout);
+
+      ScheduledExecutorService executorService =
+          datanode.getBlockTransferTimeoutService();
+      if (executorService == null) {
+        LOG.warn("Cannot reschedule timeout task for block {} - executor "
+            + "service not available", block.getBlockName());
+        timeoutTask = null;
+        return;
+      }
+
+      timeoutTask = executorService.schedule(this::handleBlockTransferTimeout,
+          timeoutPollIntervalMs(), TimeUnit.MILLISECONDS);
+      return;
+    }
+
+    // No packet received within timeout/2 - abort the stalled transfer. Mark it
+    // handled first so a concurrent close() sees nothing left to cancel.
+    timeoutTask = null;
+    LOG.warn("Block transfer timeout ({} ms) occurred for block {}. Client {} "
+        + "did not send a packet for {} ms (threshold {} ms). Aborting the "
+        + "stalled transfer.", lastPacketReceiveTimeoutMs, block.getBlockName(),
+        clientname, timeSinceLastPacket, halfTimeout);
+
+    // Close input stream to interrupt the blocked socket read; the receive
+    // thread then unwinds and performs its own (single-threaded) disk cleanup.
+    try {
+      if (in != null) {
+        in.close();
+        LOG.info("Closed input stream for block {} to abort stalled transfer",
+            block.getBlockName());
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to close input stream during timeout for block {}",
+          block.getBlockName(), e);
+    }
+  }
+
+  /**
    * close files and release volume reference.
    */
   @Override
   public void close() throws IOException {
+    // Cancel the block transfer timer if it's still running.
+    cancelBlockTransferTimer();
+
     Span span = Tracer.getCurrentSpan();
     if (span != null) {
       span.addKVAnnotation("maxWriteToDiskMs",
@@ -552,6 +705,12 @@ class BlockReceiver implements Closeable {
   private int receivePacket() throws IOException {
     // read the next packet
     packetReceiver.receiveNextPacket(in);
+
+    // Update timestamp for last packet received (for timeout tracking). Only
+    // update when the timeout is configured to avoid unnecessary atomic writes.
+    if (lastPacketReceiveTimeoutMs > 0) {
+      LAST_PACKET_RECEIVED_TIME_UPDATER.set(this, Time.monotonicNow());
+    }
 
     PacketHeader header = packetReceiver.getHeader();
     long seqno = header.getSeqno();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -144,6 +144,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -271,6 +272,7 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hadoop.thirdparty.com.google.common.cache.CacheLoader;
 import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 
 import org.slf4j.Logger;
@@ -471,6 +473,11 @@ public class DataNode extends ReconfigurableBase
 
   private final ExecutorService xferService;
 
+  // Shared scheduled executor service for block transfer timeout tasks. Only
+  // initialized if the timeout is configured (lazy initialization).
+  @Nullable
+  private volatile ScheduledExecutorService blockTransferTimeoutService;
+
   @Nullable
   private final StorageLocationChecker storageLocationChecker;
 
@@ -518,6 +525,9 @@ public class DataNode extends ReconfigurableBase
     volumeChecker = new DatasetVolumeChecker(conf, new Timer());
     this.xferService =
         HadoopExecutors.newCachedThreadPool(new Daemon.DaemonFactory());
+
+    // Initialize block transfer timeout service if configured.
+    initBlockTransferTimeoutService(conf);
     double congestionRationTmp = conf.getDouble(DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO,
         DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT);
     this.congestionRatio = congestionRationTmp > 0 ?
@@ -566,6 +576,9 @@ public class DataNode extends ReconfigurableBase
     this.volumeChecker = new DatasetVolumeChecker(conf, new Timer());
     this.xferService =
         HadoopExecutors.newCachedThreadPool(new Daemon.DaemonFactory());
+
+    // Initialize block transfer timeout service if configured.
+    initBlockTransferTimeoutService(conf);
 
     // Determine whether we should try to pass file descriptors to clients.
     if (conf.getBoolean(HdfsClientConfigKeys.Read.ShortCircuit.KEY,
@@ -2596,6 +2609,12 @@ public class DataNode extends ReconfigurableBase
     LOG.info("Waiting up to 30 seconds for transfer threads to complete");
     HadoopExecutors.shutdown(this.xferService, LOG, 15L, TimeUnit.SECONDS);
 
+    // Shutdown block transfer timeout service.
+    if (this.blockTransferTimeoutService != null) {
+      HadoopExecutors.shutdown(this.blockTransferTimeoutService, LOG, 5L,
+          TimeUnit.SECONDS);
+    }
+
     // wait for all data receiver threads to exit
     if (this.threadGroup != null) {
       int sleepMs = 2;
@@ -4215,6 +4234,38 @@ public class DataNode extends ReconfigurableBase
 
   public Tracer getTracer() {
     return tracer;
+  }
+
+  private void initBlockTransferTimeoutService(Configuration conf) {
+    long timeoutMs = conf.getLong(
+        DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS,
+        DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS_DEFAULT);
+    if (timeoutMs > 0) {
+      LOG.info("Initializing block transfer timeout service (timeout: {} ms)",
+          timeoutMs);
+      ScheduledThreadPoolExecutor exec = new ScheduledThreadPoolExecutor(2,
+          new ThreadFactoryBuilder().setNameFormat("BlockTransferTimeout-%d")
+              .setDaemon(true).build());
+      // Per-block checks are cancelled when a transfer completes; remove the
+      // cancelled futures from the queue immediately (instead of letting them
+      // accumulate until their delay elapses) and do not run delayed tasks
+      // after shutdown.
+      exec.setRemoveOnCancelPolicy(true);
+      exec.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+      this.blockTransferTimeoutService = exec;
+    } else {
+      this.blockTransferTimeoutService = null;
+    }
+  }
+
+  /**
+   * Returns the shared ScheduledExecutorService for block transfer timeout
+   * tasks. The executor service is initialized at DataNode startup only if the
+   * timeout is configured (&gt; 0).
+   * @return the block transfer timeout service, or null if not configured
+   */
+  public ScheduledExecutorService getBlockTransferTimeoutService() {
+    return blockTransferTimeoutService;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4839,6 +4839,26 @@
 </property>
 
 <property>
+  <name>dfs.datanode.last.packet.receive.timeout.ms</name>
+  <value>0</value>
+  <description>
+    Timeout in milliseconds for completing an entire block transfer on the
+    DataNode. If no packet is received for (timeout/2) the transfer is treated
+    as stalled and is safely aborted by closing the client socket, which
+    unblocks the stalled receive thread so it can be reclaimed. Data that was
+    already acknowledged to the client is already durable on disk and the
+    replica is left in the RBW state so the NameNode's lease recovery can
+    finalize it without data loss. If a packet is received within (timeout/2)
+    the stream is considered active. The stall is polled every (timeout/2), so a
+    stalled transfer is detected within (timeout/2) to (timeout). Set this well
+    above dfs.datanode.socket.write.timeout / the client socket read timeout so
+    that healthy idle hflush/hsync streams (which send heartbeat packets about
+    every half the socket timeout) are not aborted. Set to 0 or a negative value
+    to disable (default: 0). A typical enabled value is 600000 (10 min).
+  </description>
+</property>
+
+<property>
   <name>dfs.data.transfer.max.packet.size</name>
   <value>16777216</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverLastPacketTimeout.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverLastPacketTimeout.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests the DataNode-side wiring of the block-transfer inactivity timeout: the
+ * shared scheduler is created only when the timeout is enabled, and is
+ * configured with the correct lifecycle policies (remove-on-cancel so the
+ * per-block checks cancelled on completion do not accumulate, and no execution
+ * of delayed tasks after shutdown). This exercises the actual feature behavior
+ * rather than only round-tripping the configuration value.
+ */
+public class TestBlockReceiverLastPacketTimeout {
+
+  private MiniDFSCluster cluster;
+
+  @AfterEach
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  private ScheduledExecutorService startAndGetService(Long timeoutMs)
+      throws IOException {
+    Configuration conf = new HdfsConfiguration();
+    if (timeoutMs != null) {
+      conf.setLong(DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS,
+          timeoutMs);
+    }
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    cluster.waitActive();
+    return cluster.getDataNodes().get(0).getBlockTransferTimeoutService();
+  }
+
+  /**
+   * When the timeout is enabled the DataNode must create the scheduler and
+   * configure it so cancelled per-block checks are removed from the queue
+   * immediately and no delayed tasks run after shutdown.
+   */
+  @Test
+  @Timeout(60)
+  public void testSchedulerCreatedAndConfiguredWhenEnabled() throws Exception {
+    ScheduledExecutorService svc = startAndGetService(600_000L);
+    assertNotNull(svc, "scheduler should be created when timeout > 0");
+    assertTrue(svc instanceof ScheduledThreadPoolExecutor,
+        "scheduler should be a ScheduledThreadPoolExecutor");
+    ScheduledThreadPoolExecutor exec = (ScheduledThreadPoolExecutor) svc;
+    assertTrue(exec.getRemoveOnCancelPolicy(),
+        "cancelled timeout checks must be removed from the queue "
+        + "immediately");
+    assertFalse(exec.getExecuteExistingDelayedTasksAfterShutdownPolicy(),
+        "delayed checks must not run after shutdown");
+  }
+
+  /** With the default (unset) config the scheduler must not be created. */
+  @Test
+  @Timeout(60)
+  public void testSchedulerAbsentByDefault() throws Exception {
+    assertNull(startAndGetService(null), "scheduler should not be created by default (disabled)");
+  }
+
+  /** A zero timeout disables the feature, so no scheduler is created. */
+  @Test
+  @Timeout(60)
+  public void testSchedulerAbsentWhenZero() throws Exception {
+    assertNull(startAndGetService(0L), "scheduler should not be created when timeout == 0");
+  }
+
+  /** A negative timeout disables the feature, so no scheduler is created. */
+  @Test
+  @Timeout(60)
+  public void testSchedulerAbsentWhenNegative() throws Exception {
+    assertNull(startAndGetService(-1L), "scheduler should not be created when timeout < 0");
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverTransferTimeout.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReceiverTransferTimeout.java
@@ -1,0 +1,253 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration tests for the DataNode block-transfer inactivity timeout
+ * ({@code dfs.datanode.last.packet.receive.timeout.ms}).
+ *
+ * <p>The timeout is intentionally configured smaller than the client socket
+ * timeout so that the stall threshold ({@code timeout/2 = 2.5s}) is shorter than
+ * the client's idle-heartbeat interval ({@code socketTimeout/2 = 5s}); this
+ * makes the abort fire deterministically before any heartbeat could reset it.
+ * The abort test uses a single DataNode with datanode replacement disabled so
+ * that a broken pipeline cannot be silently recovered, making the client-visible
+ * failure deterministic.
+ */
+public class TestBlockReceiverTransferTimeout {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TestBlockReceiverTransferTimeout.class);
+
+  /** Timeout used by the tests; stall threshold is TIMEOUT_MS/2 = 2.5s. */
+  private static final long TIMEOUT_MS = 5000;
+  /** Client socket read timeout; idle heartbeat interval is half of this. */
+  private static final int SOCKET_TIMEOUT_MS = 10000;
+
+  private MiniDFSCluster cluster;
+  private DistributedFileSystem fs;
+
+  @AfterEach
+  public void tearDown() {
+    IOUtils.closeStream(fs);
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  private Configuration baseConf(long timeoutMs) {
+    Configuration conf = new HdfsConfiguration();
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_LAST_PACKET_RECEIVE_TIMEOUT_MS,
+        timeoutMs);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024); // 1 MB
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 512);
+    conf.setInt(DFSConfigKeys.DFS_CLIENT_SOCKET_TIMEOUT_KEY, SOCKET_TIMEOUT_MS);
+    return conf;
+  }
+
+  private void startCluster(Configuration conf, int numDataNodes)
+      throws IOException {
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(numDataNodes)
+        .build();
+    cluster.waitActive();
+    fs = cluster.getFileSystem();
+  }
+
+  private static byte[] payload(int size) {
+    byte[] data = new byte[size];
+    for (int i = 0; i < size; i++) {
+      data[i] = (byte) (i % 256);
+    }
+    return data;
+  }
+
+  /**
+   * A genuinely stalled client (writes then stops sending, without closing) must
+   * be aborted by the DataNode: the client's pipeline breaks and any further use
+   * of the stream fails. This is asserted unconditionally.
+   */
+  @Test
+  @Timeout(60)
+  public void testStuckClientIsAborted() throws Exception {
+    Configuration conf = baseConf(TIMEOUT_MS);
+    // A single DataNode with replacement disabled means a broken pipeline cannot
+    // be recovered, so the abort is deterministically visible to the client.
+    conf.setBoolean(
+        "dfs.client.block.write.replace-datanode-on-failure.enable", false);
+    startCluster(conf, 1);
+
+    Path testFile = new Path("/testStuckClient");
+    FSDataOutputStream out = fs.create(testFile, (short) 1);
+    try {
+      // Send a partial block and stop; the DataNode receives no further packets.
+      out.write(payload(512 * 1024));
+      out.hflush();
+      LOG.info("Data flushed; simulating a stuck client (no more packets).");
+
+      // Stall threshold is 2.5s and the check polls every 2.5s, so the abort
+      // fires within ~5s; wait comfortably beyond that.
+      Thread.sleep(TIMEOUT_MS + TIMEOUT_MS / 2 + 3000);
+
+      // The transfer was aborted, so continued use of the stream must fail.
+      try {
+        out.write(payload(512 * 1024));
+        out.hflush();
+        out.close();
+        fail("Expected an IOException after the stalled transfer was aborted");
+      } catch (IOException expected) {
+        LOG.info("Got expected failure after abort: {}",
+            expected.getMessage());
+      }
+    } finally {
+      IOUtils.closeStream(out);
+    }
+  }
+
+  /** A complete transfer must succeed and be readable with the timeout on. */
+  @Test
+  @Timeout(30)
+  public void testNormalBlockTransferWithTimeoutEnabled() throws Exception {
+    startCluster(baseConf(TIMEOUT_MS), 3);
+    Path testFile = new Path("/testNormalTransfer");
+    byte[] data = payload(512 * 1024);
+    DFSTestUtil.writeFile(fs, testFile, data);
+
+    assertTrue(fs.exists(testFile), "File should exist");
+    assertEquals(data.length, fs.getFileStatus(testFile).getLen(), "File size should match");
+    assertArrayEquals(data, DFSTestUtil.readFileAsBytes(fs, testFile), "File content should match");
+  }
+
+  /**
+   * A slow-but-steady writer sends packets every 300ms, always within the 2.5s
+   * stall threshold, so the timer keeps resetting and the transfer completes.
+   */
+  @Test
+  @Timeout(30)
+  public void testSlowWriterCompletesBeforeTimeout() throws Exception {
+    startCluster(baseConf(TIMEOUT_MS), 3);
+    Path testFile = new Path("/testSlowWriter");
+    FSDataOutputStream out = fs.create(testFile, (short) 3);
+    try {
+      byte[] chunk = payload(10 * 1024);
+      for (int i = 0; i < 10; i++) {
+        out.write(chunk);
+        out.hflush();
+        Thread.sleep(300); // well within the 2.5s threshold
+      }
+      out.close();
+      assertTrue(fs.exists(testFile), "File should exist");
+      assertEquals(chunk.length * 10, fs.getFileStatus(testFile).getLen(),
+          "File size should match");
+    } finally {
+      IOUtils.closeStream(out);
+    }
+  }
+
+  /**
+   * Packets arriving every 2s stay within the 2.5s stall threshold, so even
+   * though the total transfer time (&gt; 6s) exceeds the 5s timeout, the timer
+   * resets on each packet and the transfer completes without a false abort.
+   */
+  @Test
+  @Timeout(40)
+  public void testTimerResetsWithPacketsNearThreshold() throws Exception {
+    startCluster(baseConf(TIMEOUT_MS), 3);
+    Path testFile = new Path("/testTimerReset");
+    FSDataOutputStream out = fs.create(testFile, (short) 3);
+    try {
+      byte[] chunk = payload(10 * 1024);
+      // 4 chunks, 2s apart => ~6s total (> 5s timeout) but each gap < 2.5s.
+      for (int i = 0; i < 4; i++) {
+        out.write(chunk);
+        out.hflush();
+        if (i < 3) {
+          Thread.sleep(2000); // 2s < 2.5s threshold => timer resets
+        }
+      }
+      out.close();
+      assertTrue(fs.exists(testFile), "File should exist");
+      assertEquals(chunk.length * 4, fs.getFileStatus(testFile).getLen(), "File size should match");
+    } finally {
+      IOUtils.closeStream(out);
+    }
+  }
+
+  /**
+   * With the timeout disabled (0), even a long idle gap must not abort the
+   * transfer: the stream can resume writing and close successfully.
+   */
+  @Test
+  @Timeout(30)
+  public void testTimeoutDisabledDoesNotAbortIdleStream() throws Exception {
+    startCluster(baseConf(0), 3);
+    Path testFile = new Path("/testTimeoutDisabled");
+    FSDataOutputStream out = fs.create(testFile, (short) 3);
+    try {
+      byte[] chunk = payload(64 * 1024);
+      out.write(chunk);
+      out.hflush();
+      // Idle well past what would be the stall threshold if enabled.
+      Thread.sleep(TIMEOUT_MS + 2000);
+      // Must still be usable because the feature is disabled.
+      out.write(chunk);
+      out.hflush();
+      out.close();
+      assertTrue(fs.exists(testFile), "File should exist");
+      assertEquals(chunk.length * 2, fs.getFileStatus(testFile).getLen(), "File size should match");
+    } finally {
+      IOUtils.closeStream(out);
+    }
+  }
+
+  /** Several full transfers with the timeout enabled must all succeed. */
+  @Test
+  @Timeout(30)
+  public void testMultipleConcurrentTransfersWithTimeout() throws Exception {
+    startCluster(baseConf(TIMEOUT_MS), 3);
+    int numFiles = 5;
+    for (int i = 0; i < numFiles; i++) {
+      Path f = new Path("/testConcurrent" + i);
+      DFSTestUtil.writeFile(fs, f, payload(256 * 1024));
+      assertTrue(fs.exists(f), "File " + i + " should exist");
+    }
+  }
+}


### PR DESCRIPTION
### Description of PR

A block written to a DataNode remains active until the client sends the final
packet and the block is finalized.

When a client crashes, loses network connectivity, or hangs before sending the
last packet, the DataNode transfer thread can remain blocked indefinitely while
waiting for input. Over time, these stalled transfers can accumulate and cause:

- Transfer-thread starvation
- Resource leakage
- Degraded DataNode responsiveness

Today, there is no built-in inactivity detection to reclaim resources from
stalled transfers. The system relies on client behavior or eventual lease
recovery, which may occur long after the actual failure.

## Solution

Introduce a configurable, inactivity-based timeout for block transfers on the
DataNode.

When enabled, the DataNode tracks packet-arrival activity for each ongoing
block write using a monotonic clock. A single scheduled check per transfer
runs every `timeout / 2` and compares the time since the last received packet
against `timeout / 2`.

### Transfer Activity Detection

- If a packet arrived within `timeout / 2`:
  - The stream is considered active.
  - The check is rescheduled.
  - This provides an automatic reset for healthy streams.

- Otherwise:
  - The transfer is considered stalled.
  - The transfer is aborted.

Polling every `timeout / 2` bounds the detection latency to between
`timeout / 2` and `timeout` after the client stops sending.

### Safe Transfer Abort

The abort runs on the shared scheduler thread and deliberately performs **no
disk I/O**.

The on-disk streams (`out` / `checksumOut`) are written by the receive thread
**without holding the `BlockReceiver` monitor**. Flushing these streams from
the scheduler thread could race with those writes and potentially corrupt the
replica.

Instead, the scheduler:

1. Closes only the client input stream.
2. This unblocks the receive thread's blocked socket read.
3. The receive thread unwinds and performs its own single-threaded cleanup.

Data already acknowledged to the client is already durable on disk. The
replica remains in the **RBW (Replica Being Written)** state, allowing the
NameNode's existing lease-recovery / block-synchronization path to finalize
the block without data loss.

## Scheduler Design

The timeout checks use a shared `ScheduledThreadPoolExecutor` with **2 daemon
threads**.

The scheduler:

- Is created lazily at DataNode startup only when the timeout is configured.
- Adds **zero threads and zero overhead when the feature is disabled**.
- Uses `remove-on-cancel` so per-block checks cancelled when a transfer
  completes do not accumulate in the delay queue.
- Does not execute delayed tasks after shutdown.

The last-packet timestamp is updated only when the timeout feature is enabled,
avoiding unnecessary atomic writes on the hot path when the feature is
disabled.

## Client Socket Timeout Considerations

Because a stall is declared after no packet is received for `timeout / 2`,
the DataNode timeout must be configured comfortably larger than the client
socket read timeout.

A healthy idle `hflush` / `hsync` stream still sends heartbeat packets roughly
every half of the socket timeout.

The DataNode logs a warning if the configured transfer timeout is not
sufficiently larger than the client socket timeout.

## Configuration

| Configuration | Default | Description |
|---|---:|---|
| `dfs.datanode.last.packet.receive.timeout.ms` | `0` | Last-packet inactivity timeout in milliseconds. `0` disables the feature. |

A typical enabled value is:

```text
dfs.datanode.last.packet.receive.timeout.ms=600000
````

This corresponds to a **10-minute timeout**.

The change is fully backward compatible and disabled by default.

## Testing

### `TestBlockReceiverLastPacketTimeout`

Verifies the DataNode-side scheduler wiring:

* The shared scheduler is created only when the timeout is enabled.
* `remove-on-cancel` is configured correctly.
* Delayed tasks do not execute after scheduler shutdown.

### `TestBlockReceiverTransferTimeout`

Runs an end-to-end test using `MiniDFSCluster` and verifies that a genuinely
stuck client is deterministically aborted.

The test uses a single DataNode with DataNode replacement disabled so that a
broken pipeline cannot be silently recovered.

It also verifies that healthy streams are never falsely aborted, including:

* Full transfers
* Slow-but-steady writers
* Writers whose packet gaps remain just below the timeout threshold, even
  when the total transfer time exceeds the timeout
* Disabled timeout configuration
* Multiple concurrent transfers



### How was this patch tested?
Tested by newly added unit test


### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

