### PR TITLE
HDFS-17977. Add a compact standalone HDFS DataNode read/write stress tester

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HdfsStressTest.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HdfsStressTest.md
@@ -1,0 +1,198 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+HDFS Stress Test
+================
+
+<!-- MACRO{toc|fromDepth=0|toDepth=2} -->
+
+
+Overview
+--------
+
+`HdfsStressTest` is a compact, self-contained HDFS read/write load generator for
+stress-testing a targeted set of DataNodes. It complements `TestDFSIO`.
+
+`TestDFSIO` is the standard HDFS I/O benchmark, but it runs as a MapReduce job
+scheduled by YARN across the whole cluster. That makes it hard to:
+
+* generate a *controlled* QPS / throughput,
+* target a specific subset of DataNodes (for example a single replica set),
+* obtain client-side latency *distributions* (p50/p95/p99), and
+* saturate just a subset of nodes quickly (it loads the entire cluster and can
+  take a long time to exhaust it).
+
+`HdfsStressTest` fills that gap with a single-process, no-MapReduce tool that:
+
+* drives a configurable, steady read and/or write throughput (MB/s) with a
+  global rate limiter, optionally ramping throughput up for acceleration tests;
+* targets specific DataNodes via HDFS favored-nodes hints, so load lands on a
+  chosen replica set;
+* uses a configurable block/file size;
+* pre-generates a cold-read corpus so measured reads bypass the OS page cache
+  (see [Cold reads](#Cold_reads:_avoiding_page-cache_hits) below); and
+* records client-side read/write latency distributions
+  (p50, p75, p95, p99, min, max, mean, stddev) and effective QPS.
+
+Because it is a plain `Tool`, it needs no YARN and only the HDFS client
+configuration on the classpath.
+
+
+How to run
+----------
+
+The tool ships in the `hadoop-hdfs` test jar. From a client host that has the
+target cluster's HDFS configuration on its classpath:
+
+```bash
+hadoop jar hadoop-hdfs-<version>-tests.jar \
+    org.apache.hadoop.hdfs.HdfsStressTest /path/to/stress.properties
+```
+
+The single argument is a Java properties file describing the workload (see
+[Configuration](#Configuration) below). Any property can also be overridden on
+the command line with a `-Dkey=value` ToolRunner option, which takes precedence
+over the file:
+
+```bash
+hadoop jar hadoop-hdfs-<version>-tests.jar \
+    org.apache.hadoop.hdfs.HdfsStressTest \
+    -DwriteThroughputMB=400 /path/to/stress.properties
+```
+
+The tool runs two phases:
+
+1. **Pre-test** &ndash; if a read workload is configured, it first writes the
+   cold-read corpus (see [Cold reads](#Cold_reads:_avoiding_page-cache_hits)).
+2. **Measurement** &ndash; it runs the write and/or read workloads concurrently
+   for `testDurationSeconds` and prints throughput, effective QPS and latency
+   percentiles for each.
+
+
+Configuration
+-------------
+
+All keys are read from the properties file (or overridden with `-Dkey=value`).
+Sizes are plain numbers in the unit named by the key.
+
+| Property | Default | Description |
+|:---------|:--------|:------------|
+| `favoredDataNodes` | (none) | Comma-separated `host:port` list of DataNode transfer ports. Written blocks are pinned to these nodes via HDFS favored-nodes hints, so load lands on a chosen replica set instead of the whole cluster. |
+| `replication` | `3` | Replication factor for files created by the tool. |
+| `blockSizeMB` | `128` | Block/file size in MB. Each write and each read operation moves one block-sized file, so this also sets the I/O unit for the latency stats. |
+| `testWriteDirectory` | (none) | HDFS directory for the write workload. Omit to disable writes. |
+| `writeThroughputMB` | `0` | Target sustained write throughput in MB/s (`0` disables writes). |
+| `endWriteThroughputMB` | `0` (no ramp) | If greater than `writeThroughputMB`, throughput ramps linearly from `writeThroughputMB` to this value over the run (acceleration / find-the-knee test); otherwise it stays constant. |
+| `writeThreads` | `-1` (auto) | Writer worker threads; `-1` uses a fixed pool and lets the rate limiter govern throughput. |
+| `testReadDirectories` | (none) | Comma-separated HDFS directories for the read workload and for the pre-test cold-read corpus. Omit to disable reads. |
+| `readThroughputMB` | `0` | Target sustained read throughput in MB/s (`0` disables reads). |
+| `endReadThroughputMB` | `0` (no ramp) | Optional linear read-throughput ramp end value; ramps only when greater than `readThroughputMB`. |
+| `readThreads` | `-1` (auto) | Reader worker threads; `-1` uses a fixed pool. |
+| `testReadFileSizeGB` | `0` | Total size of the cold-read corpus to pre-create, in GB. Set larger than the aggregate OS page cache of the target DataNodes (rule of thumb: ~2x their RAM) so reads cannot be served from cache. |
+| `preTestWriteThroughputMB` | `0` (unlimited) | Pacing (MB/s) applied while generating the cold-read corpus. `0` (or any non-positive value) builds the corpus as fast as the client can, which is usually what you want; set a positive value to keep the pre-test from itself saturating the cluster. |
+| `preTestWriteDurationSeconds` | `0` (unbounded) | Optional wall-clock safety cap on the pre-test phase; it stops when either the corpus reaches `testReadFileSizeGB` or, if this is positive, when this many seconds elapse. `0` (or any non-positive value) means no time cap. |
+| `testDurationSeconds` | `60` | Length of the measured read/write window. |
+
+
+### Example `stress.properties`
+
+```properties
+# Target a specific replica set (host:port of the DataNode xfer port).
+favoredDataNodes=dn1.example.com:9866,dn2.example.com:9866,dn3.example.com:9866
+replication=3
+blockSizeMB=128
+
+# Write workload.
+testWriteDirectory=/tmp/hdfs-stress/write
+writeThroughputMB=200
+
+# Read workload (cold reads from files created in the pre-test phase).
+testReadDirectories=/tmp/hdfs-stress/read
+readThroughputMB=200
+
+# Pre-test: create enough read data to exceed the DataNode page cache
+# (typically ~2x the DataNode memory) so reads are served from disk.
+testReadFileSizeGB=64
+preTestWriteThroughputMB=400
+preTestWriteDurationSeconds=600
+
+# Main measurement window.
+testDurationSeconds=300
+
+# Optional acceleration stress test: linearly ramp throughput from the
+# start value above to these end values over the test duration.
+endWriteThroughputMB=600
+endReadThroughputMB=600
+
+# -1 => auto (a fixed worker pool; the rate limiter enforces throughput).
+writeThreads=-1
+readThreads=-1
+```
+
+
+Cold reads: avoiding page-cache hits
+------------------------------------
+
+A read benchmark is only meaningful if it exercises the DataNode disks rather
+than the operating-system page cache. If reads keep hitting the same small set
+of recently written blocks, the DataNodes serve them straight from RAM and the
+numbers reflect memory bandwidth, not HDFS/disk performance.
+
+To force cold reads, the **pre-test phase writes a corpus of size
+`testReadFileSizeGB` once**, sized deliberately **larger than the combined page
+cache (main memory) of the target DataNodes**. Because the corpus does not fit
+in memory:
+
+* the kernel continuously evicts older pages as newer blocks are written, so
+* by the time the measured phase reads a given file again, its pages have
+  already been evicted and are **no longer in the page cache**, and
+* every measured read therefore falls through to disk &ndash; a true cold read.
+
+The read workload also spreads its picks across the whole corpus (rather than
+replaying a hot subset), keeping the page-cache hit rate near zero. Choose
+`testReadFileSizeGB` at roughly **twice the target DataNode RAM** for a
+comfortable margin. By default the pre-test builds that corpus as fast as the
+client can (`preTestWriteThroughputMB=0`, `preTestWriteDurationSeconds=0` &ndash;
+no rate or time cap); set `preTestWriteThroughputMB` to pace corpus creation, or
+`preTestWriteDurationSeconds` to time-box it, if you want to bound the pre-test.
+
+If you time-box the pre-test with `preTestWriteDurationSeconds`, the corpus may
+stop short of `testReadFileSizeGB`. When that happens the tool prints a
+`WARNING` that the corpus is smaller than requested and the measured reads may
+be served from the page cache (so the numbers can be optimistic); raise or
+remove the cap so the corpus reaches `testReadFileSizeGB`. Because reads are
+served only from files created in this phase, enabling the read workload
+(`readThroughputMB` &gt; 0) **requires** a positive `testReadFileSizeGB`; the
+tool fails fast on startup otherwise rather than silently running no readers.
+`blockSizeMB` must likewise be a positive number of MB.
+
+
+Distributing load across multiple clients
+-----------------------------------------
+
+A single client process is limited by its own CPU, NIC and JVM. To drive higher
+aggregate load, or to model many real writers/readers, **run the tool on several
+client hosts at once** against the same cluster. The total offered load is the
+sum of the per-client `writeThroughputMB` / `readThroughputMB`.
+
+Guidelines when running multiple clients:
+
+* Give each client a **distinct `testWriteDirectory`** (and, if pre-generating
+  separate corpora, distinct `testReadDirectories`) so clients do not collide on
+  paths.
+* Point all clients at the **same `favoredDataNodes`** to concentrate load on
+  one replica set, or at different sets to spread it.
+* **Start the clients together** so their measurement windows overlap.
+* Aggregate the per-client latency distributions and throughput to obtain the
+  cluster-wide result.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/HdfsStressTest.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/HdfsStressTest.java
@@ -1,0 +1,787 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+/**
+ * A compact, self-contained HDFS DataNode read/write stress tester.
+ *
+ * <p>{@code TestDFSIO} is the standard HDFS I/O benchmark, but it launches a
+ * MapReduce job scheduled by YARN over the whole cluster, which makes it hard
+ * to (a) generate a <em>controlled</em> QPS / throughput, (b) target a specific
+ * subset of DataNodes (e.g. a replica set), and (c) obtain client-side latency
+ * <em>distributions</em> (p50/p95/p99). It also loads the entire cluster and
+ * takes a long time to saturate a targeted set of nodes. This tool fills that
+ * gap with a single-process, no-MapReduce load generator that:
+ *
+ * <ul>
+ *   <li>drives a configurable, steady read and/or write throughput (MB/s) with
+ *       a global rate limiter (optionally ramping up for acceleration testing);</li>
+ *   <li>targets specific DataNodes via HDFS favored-nodes hints so load lands
+ *       on a chosen replica set;</li>
+ *   <li>uses a configurable block/file size;</li>
+ *   <li>runs a pre-test phase that pre-creates a large set of files so that the
+ *       measured reads are cold reads (larger than DataNode page cache);</li>
+ *   <li>records client-side read/write latency distributions
+ *       (p50, p75, p95, p99, min, max, mean, stddev) and effective QPS.</li>
+ * </ul>
+ *
+ * <h2>How to run</h2>
+ * <pre>
+ *   # From a client host with the HDFS configuration on the classpath. The
+ *   # tool ships in the hadoop-hdfs test jar:
+ *   hadoop jar hadoop-hdfs-&lt;version&gt;-tests.jar \
+ *       org.apache.hadoop.hdfs.HdfsStressTest /path/to/stress.properties
+ * </pre>
+ *
+ * <p>The single argument is a Java properties file describing the workload.
+ * Any property may also be supplied on the command line with
+ * {@code -D<key>=<value>} (ToolRunner options), which takes precedence.
+ *
+ * <h2>Example {@code stress.properties}</h2>
+ * <pre>
+ *   # Target a specific replica set (host:port of the DataNode xfer port).
+ *   favoredDataNodes=dn1.example.com:9866,dn2.example.com:9866,dn3.example.com:9866
+ *   replication=3
+ *   blockSizeMB=128
+ *
+ *   # Write workload.
+ *   testWriteDirectory=/tmp/hdfs-stress/write
+ *   writeThroughputMB=200
+ *
+ *   # Read workload (cold reads from files created in the pre-test phase).
+ *   testReadDirectories=/tmp/hdfs-stress/read
+ *   readThroughputMB=200
+ *
+ *   # Pre-test: create enough read files to exceed the DataNode page cache
+ *   # (typically ~2x the DataNode memory) so reads are served from disk.
+ *   testReadFileSizeGB=64
+ *   preTestWriteThroughputMB=400
+ *   preTestWriteDurationSeconds=600
+ *
+ *   # Main measurement window.
+ *   testDurationSeconds=300
+ *
+ *   # Optional acceleration stress test: linearly ramp throughput from the
+ *   # start value above to these end values over the test duration.
+ *   endWriteThroughputMB=600
+ *   endReadThroughputMB=600
+ *
+ *   # -1 => auto (a fixed worker pool; the rate limiter enforces throughput).
+ *   writeThreads=-1
+ *   readThreads=-1
+ * </pre>
+ *
+ * <h2>Configuration reference</h2>
+ * <p>All keys are read from the properties file (or overridden with
+ * {@code -Dkey=value}). Sizes are plain numbers in the unit named by the key.
+ * <table border="1">
+ *   <caption>HdfsStressTest properties</caption>
+ *   <tr><th>Property</th><th>Default</th><th>Description</th></tr>
+ *   <tr><td>{@code favoredDataNodes}</td><td>(none)</td>
+ *       <td>Comma-separated {@code host:port} list of DataNode transfer ports.
+ *       Written blocks are pinned to these nodes via HDFS favored-nodes hints,
+ *       so load lands on a chosen replica set instead of the whole cluster.</td></tr>
+ *   <tr><td>{@code replication}</td><td>3</td>
+ *       <td>Replication factor for files created by the tool.</td></tr>
+ *   <tr><td>{@code blockSizeMB}</td><td>128</td>
+ *       <td>Block/file size in MB. Each write and each read operation moves one
+ *       block-sized file, so this also sets the I/O unit for latency stats.</td></tr>
+ *   <tr><td>{@code testWriteDirectory}</td><td>(none)</td>
+ *       <td>HDFS directory for the write workload. Omit to disable writes.</td></tr>
+ *   <tr><td>{@code writeThroughputMB}</td><td>0</td>
+ *       <td>Target sustained write throughput in MB/s (0 disables writes).</td></tr>
+ *   <tr><td>{@code endWriteThroughputMB}</td><td>0 (no ramp)</td>
+ *       <td>If greater than {@code writeThroughputMB}, throughput ramps linearly
+ *       from {@code writeThroughputMB} to this value over the run (acceleration
+ *       / find-the-knee test); otherwise throughput stays constant.</td></tr>
+ *   <tr><td>{@code writeThreads}</td><td>-1 (auto)</td>
+ *       <td>Writer worker threads; {@code -1} uses a fixed pool and lets the
+ *       rate limiter govern throughput.</td></tr>
+ *   <tr><td>{@code testReadDirectories}</td><td>(none)</td>
+ *       <td>Comma-separated HDFS directories for the read workload and for the
+ *       pre-test cold-read corpus. Omit to disable reads.</td></tr>
+ *   <tr><td>{@code readThroughputMB}</td><td>0</td>
+ *       <td>Target sustained read throughput in MB/s (0 disables reads).</td></tr>
+ *   <tr><td>{@code endReadThroughputMB}</td><td>0 (no ramp)</td>
+ *       <td>Optional linear read-throughput ramp end value; ramps only when
+ *       greater than {@code readThroughputMB} (see the write ramp).</td></tr>
+ *   <tr><td>{@code readThreads}</td><td>-1 (auto)</td>
+ *       <td>Reader worker threads; {@code -1} uses a fixed pool.</td></tr>
+ *   <tr><td>{@code testReadFileSizeGB}</td><td>0</td>
+ *       <td>Total size of the cold-read corpus to pre-create, in GB. Set this
+ *       larger than the aggregate OS page cache of the target DataNodes (a good
+ *       rule of thumb is ~2x their RAM) so reads cannot be served from cache.</td></tr>
+ *   <tr><td>{@code preTestWriteThroughputMB}</td><td>0 (unlimited)</td>
+ *       <td>Throughput (MB/s) used while generating the cold-read corpus. The
+ *       default of {@code 0} (or any non-positive value) means "build the
+ *       corpus as fast as the client can" (no pacing), which is usually what
+ *       you want; set a positive value only to keep corpus creation from itself
+ *       saturating the cluster.</td></tr>
+ *   <tr><td>{@code preTestWriteDurationSeconds}</td><td>0 (unbounded)</td>
+ *       <td>Safety cap on the pre-test phase; it stops when either the corpus
+ *       reaches {@code testReadFileSizeGB} or this many seconds elapse.</td></tr>
+ *   <tr><td>{@code testDurationSeconds}</td><td>60</td>
+ *       <td>Length of the measured read/write window.</td></tr>
+ * </table>
+ *
+ * <h2>Cold reads: avoiding OS page-cache hits with a pre-test corpus</h2>
+ * <p>A read benchmark is only meaningful if it exercises the DataNode disks
+ * rather than the operating-system page cache. If reads keep hitting the same
+ * small set of recently written blocks, the DataNodes simply serve them from
+ * RAM and the numbers reflect memory bandwidth, not HDFS/disk performance.
+ *
+ * <p>To force cold reads, the pre-test phase writes a corpus of size
+ * {@code testReadFileSizeGB} <em>once</em>, sized deliberately larger than the
+ * combined page cache (main memory) of the target DataNodes. Because the corpus
+ * does not fit in memory, the kernel continuously evicts older pages as newer
+ * blocks are written, so by the time the measured phase reads a given file
+ * again its pages have already been evicted and are no longer in the page
+ * cache. Every measured read therefore falls through to disk, giving a true
+ * cold-read result. The read workload also spreads its picks across the whole
+ * corpus (rather than replaying a hot subset) to keep the page-cache hit rate
+ * near zero. Pick {@code testReadFileSizeGB} at roughly twice the target
+ * DataNode RAM for a comfortable margin.
+ *
+ * <h2>Distributing load across multiple clients</h2>
+ * <p>A single client process is limited by its own CPU, NIC and JVM. To drive
+ * higher aggregate load, or to model many real writers/readers, run the tool
+ * on several client hosts at once against the same cluster; the total offered
+ * load is the sum of the per-client {@code writeThroughputMB} /
+ * {@code readThroughputMB}. Give each client a distinct
+ * {@code testWriteDirectory} (and, if pre-generating separate corpora, distinct
+ * {@code testReadDirectories}) so the clients do not collide on paths, point
+ * them at the same {@code favoredDataNodes} to concentrate load on one replica
+ * set, and start them together so their measurement windows overlap. Aggregate
+ * the per-client latency distributions and throughput to get the cluster-wide
+ * result.
+ */
+public class HdfsStressTest extends Configured implements Tool {
+
+  private static final long MB = 1024L * 1024L;
+  private static final long GB = 1024L * MB;
+  private static final int IO_BUFFER_BYTES = (int) MB;
+  private static final int DEFAULT_AUTO_THREADS = 16;
+  // Below this many distinct cold-read files, reads concentrate on a handful of
+  // DataNodes and the corpus tends to stay resident in the OS page cache, so
+  // the measured read numbers stop reflecting real disk behavior.
+  private static final int MIN_SPREAD_READ_FILES = 20;
+
+  // ---- Workload configuration (populated from the properties file) ----
+  private InetSocketAddress[] favoredNodes;
+  private short replication;
+  private long blockSizeBytes;
+
+  private String writeDir;
+  private double writeThroughputMB;
+  private double endWriteThroughputMB;
+  private int writeThreads;
+
+  private List<String> readDirs;
+  private double readThroughputMB;
+  private double endReadThroughputMB;
+  private int readThreads;
+
+  private long readFileSizeBytes;
+  private double preTestWriteThroughputMB;
+  private long preTestWriteDurationSeconds;
+
+  private long testDurationSeconds;
+
+  @Override
+  public int run(String[] args) throws Exception {
+    if (args.length < 1) {
+      System.err.println("Usage: HdfsStressTest <config.properties>");
+      System.err.println("See the class javadoc for the list of properties.");
+      return 2;
+    }
+    loadConfig(args[0]);
+
+    DistributedFileSystem dfs = asDistributedFileSystem();
+    try {
+      // Pre-test: create the cold-read corpus.
+      List<Path> readFiles = new ArrayList<>();
+      if (readThroughputMB > 0 && readFileSizeBytes > 0) {
+        readFiles = preTestCreateReadFiles(dfs);
+        if (readFiles.isEmpty()) {
+          System.err.println("Pre-test produced no read files; disabling read "
+              + "workload for this run.");
+        }
+      }
+
+      // Test: run write and read workloads concurrently for the duration.
+      runTestPhase(dfs, readFiles);
+    } finally {
+      dfs.close();
+    }
+    return 0;
+  }
+
+  private DistributedFileSystem asDistributedFileSystem() throws IOException {
+    FileSystem fs = FileSystem.get(getConf());
+    if (!(fs instanceof DistributedFileSystem)) {
+      throw new IOException("HdfsStressTest requires an HDFS "
+          + "DistributedFileSystem, but got " + fs.getClass().getName());
+    }
+    return (DistributedFileSystem) fs;
+  }
+
+  /**
+   * Ensure {@code dir} exists as a directory, creating it if necessary.
+   *
+   * <p>{@code mkdirs()} is idempotent for an existing directory (it returns
+   * {@code true} rather than failing), so re-running the tool against
+   * directories used by a previous run is safe. This guard only adds an
+   * explicit check so a path that already exists as a <em>file</em> fails fast
+   * with a clear message instead of surfacing a confusing downstream error.
+   */
+  private static void ensureDirectory(DistributedFileSystem dfs, Path dir)
+      throws IOException {
+    if (dfs.exists(dir)) {
+      if (!dfs.getFileStatus(dir).isDirectory()) {
+        throw new IOException(
+            "Path already exists as a file, expected a directory: " + dir);
+      }
+      return;
+    }
+    dfs.mkdirs(dir);
+  }
+
+  // -------------------------------------------------------------------------
+  // Pre-test phase: pre-create cold-read files.
+  // -------------------------------------------------------------------------
+  @VisibleForTesting
+  List<Path> preTestCreateReadFiles(DistributedFileSystem dfs)
+      throws Exception {
+    final Path[] dirs = new Path[readDirs.size()];
+    for (int i = 0; i < dirs.length; i++) {
+      dirs[i] = new Path(readDirs.get(i));
+      ensureDirectory(dfs, dirs[i]);
+    }
+
+    final long totalFiles = Math.max(1, readFileSizeBytes / blockSizeBytes);
+    final List<Path> created = new ArrayList<>();
+    // A non-positive throughput means "build the corpus as fast as possible"
+    // (no pacing); a positive value paces corpus creation at that MB/s so the
+    // pre-test does not itself saturate the cluster. The previous code floored
+    // the rate at 1e-9 ops/s, which made the limiter sleep for ~centuries after
+    // the first file whenever the (default) pre-test throughput was 0.
+    final RateLimiter limiter = preTestWriteThroughputMB > 0
+        ? new RateLimiter(opsPerSecond(preTestWriteThroughputMB)) : null;
+    // A non-positive duration means "no time cap": run until the corpus reaches
+    // testReadFileSizeGB. The previous code set the deadline to now, so a 0
+    // (its documented "unbounded" default) created zero files and silently
+    // disabled the entire read workload.
+    final long deadline = preTestWriteDurationSeconds > 0
+        ? System.nanoTime() + preTestWriteDurationSeconds * 1_000_000_000L
+        : Long.MAX_VALUE;
+
+    System.out.printf("Pre-test: creating up to %d cold-read file(s) of %d MB "
+        + "across %d directory(ies)...%n",
+        totalFiles, blockSizeBytes / MB, dirs.length);
+
+    long index = 0;
+    while (index < totalFiles && System.nanoTime() < deadline) {
+      if (limiter != null) {
+        limiter.acquire();
+      }
+      Path dir = dirs[(int) (index % dirs.length)];
+      Path file = new Path(dir, "coldread-" + index + ".dat");
+      writeBlockFile(dfs, file);
+      created.add(file);
+      index++;
+    }
+    System.out.printf("Pre-test: created %d read file(s).%n", created.size());
+    if (created.size() < totalFiles) {
+      // The corpus stopped short of the requested cold size (typically because
+      // preTestWriteDurationSeconds capped it). A corpus that fits in the
+      // combined page cache cannot guarantee cold reads: the kernel may still
+      // hold recently written blocks in RAM, so the measured read numbers can
+      // be optimistic. Surface this so the result is not misread as cold-disk.
+      System.err.printf("WARNING: pre-test built only %d of %d target file(s) "
+          + "(%d of %d MB). The cold-read corpus is smaller than requested, so "
+          + "some reads may be served from the OS page cache and the reported "
+          + "read throughput/latency may be optimistic. Increase "
+          + "preTestWriteDurationSeconds (or remove the cap) so the corpus "
+          + "reaches testReadFileSizeGB (ideally ~2x the target-DataNode RAM).%n",
+          created.size(), totalFiles,
+          created.size() * (blockSizeBytes / MB),
+          totalFiles * (blockSizeBytes / MB));
+    }
+    return created;
+  }
+
+  // -------------------------------------------------------------------------
+  // Test phase: paced write + read workers with latency capture.
+  // -------------------------------------------------------------------------
+  @VisibleForTesting
+  void runTestPhase(DistributedFileSystem dfs, List<Path> readFiles)
+      throws Exception {
+    final long durationNanos = testDurationSeconds * 1_000_000_000L;
+    final long startNanos = System.nanoTime();
+    final long endNanos = startNanos + durationNanos;
+
+    final List<Thread> threads = new ArrayList<>();
+    final LatencyStats writeStats = new LatencyStats();
+    final LatencyStats readStats = new LatencyStats();
+    // Surfaces the first worker failure so the tool exits non-zero instead of
+    // silently reporting "success" after an I/O error swallowed inside a worker.
+    final AtomicReference<Throwable> workerError = new AtomicReference<>();
+
+    final boolean doWrite = writeThroughputMB > 0 && writeDir != null;
+    final boolean doRead = readThroughputMB > 0 && !readFiles.isEmpty();
+
+    final int wThreads = doWrite
+        ? (writeThreads > 0 ? writeThreads : DEFAULT_AUTO_THREADS) : 0;
+    final int rThreads = doRead
+        ? (readThreads > 0 ? readThreads : DEFAULT_AUTO_THREADS) : 0;
+
+    final CountDownLatch done = new CountDownLatch(wThreads + rThreads);
+
+    if (doWrite) {
+      ensureDirectory(dfs, new Path(writeDir));
+      final RateLimiter writeLimiter = new RateLimiter(
+          opsPerSecond(writeThroughputMB));
+      final AtomicLong seq = new AtomicLong();
+      for (int i = 0; i < wThreads; i++) {
+        Thread t = new Thread(() -> {
+          try {
+            while (System.nanoTime() < endNanos) {
+              rampRate(writeLimiter, writeThroughputMB, endWriteThroughputMB,
+                  startNanos, durationNanos);
+              writeLimiter.acquire();
+              Path file = new Path(writeDir,
+                  "stress-write-" + seq.getAndIncrement() + ".dat");
+              long t0 = System.nanoTime();
+              writeBlockFile(dfs, file);
+              writeStats.record(System.nanoTime() - t0);
+            }
+          } catch (Exception e) {
+            workerError.compareAndSet(null, e);
+            System.err.println("Write worker failed: " + e.getMessage());
+          } finally {
+            done.countDown();
+          }
+        }, "stress-write-" + i);
+        t.start();
+        threads.add(t);
+      }
+    }
+
+    if (doRead) {
+      final RateLimiter readLimiter = new RateLimiter(
+          opsPerSecond(readThroughputMB));
+      final Path[] files = readFiles.toArray(new Path[0]);
+      if (files.length < MIN_SPREAD_READ_FILES) {
+        System.err.printf("WARNING: the cold-read corpus contains only %d "
+            + "file(s). A very small corpus concentrates reads on the few "
+            + "DataNodes that host those blocks (so load is not spread across "
+            + "the target replica set) and is likely to stay resident in the OS "
+            + "page cache, so the measured read results may reflect cache hits "
+            + "rather than disk I/O. Increase testReadFileSizeGB (ideally so the "
+            + "corpus is ~2x the target-DataNode RAM) for representative "
+            + "cold-read numbers.%n", files.length);
+      }
+      for (int i = 0; i < rThreads; i++) {
+        Thread t = new Thread(() -> {
+          try {
+            while (System.nanoTime() < endNanos) {
+              rampRate(readLimiter, readThroughputMB, endReadThroughputMB,
+                  startNanos, durationNanos);
+              readLimiter.acquire();
+              Path file = files[ThreadLocalRandom.current().nextInt(files.length)];
+              long t0 = System.nanoTime();
+              readWholeFile(dfs, file);
+              readStats.record(System.nanoTime() - t0);
+            }
+          } catch (Exception e) {
+            workerError.compareAndSet(null, e);
+            System.err.println("Read worker failed: " + e.getMessage());
+          } finally {
+            done.countDown();
+          }
+        }, "stress-read-" + i);
+        t.start();
+        threads.add(t);
+      }
+    }
+
+    System.out.printf("Test: running for %d second(s) with %d write and %d read "
+        + "worker(s)...%n", testDurationSeconds, wThreads, rThreads);
+    done.await();
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    Throwable err = workerError.get();
+    if (err != null) {
+      throw new IOException("Stress workload failed: " + err, err);
+    }
+
+    double actualSeconds = (System.nanoTime() - startNanos) / 1e9;
+    double opBytesMB = blockSizeBytes / (double) MB;
+    printReport("WRITE", writeStats, actualSeconds, opBytesMB,
+        writeThroughputMB);
+    printReport("READ", readStats, actualSeconds, opBytesMB,
+        readThroughputMB);
+  }
+
+  // -------------------------------------------------------------------------
+  // HDFS I/O helpers.
+  // -------------------------------------------------------------------------
+  @VisibleForTesting
+  void writeBlockFile(DistributedFileSystem dfs, Path file)
+      throws IOException {
+    byte[] buf = new byte[IO_BUFFER_BYTES];
+    Arrays.fill(buf, (byte) 'a');
+    OutputStream out = dfs.create(file, FsPermission.getFileDefault(),
+        true, IO_BUFFER_BYTES, replication, blockSizeBytes, null, favoredNodes);
+    try {
+      long remaining = blockSizeBytes;
+      while (remaining > 0) {
+        int n = (int) Math.min(buf.length, remaining);
+        out.write(buf, 0, n);
+        remaining -= n;
+      }
+    } finally {
+      out.close();
+    }
+  }
+
+  @VisibleForTesting
+  void readWholeFile(DistributedFileSystem dfs, Path file)
+      throws IOException {
+    byte[] buf = new byte[IO_BUFFER_BYTES];
+    InputStream in = dfs.open(file);
+    try {
+      // Read to EOF and discard: we only care about read latency/throughput,
+      // not the bytes. Keeping the read call in the loop body (rather than an
+      // empty body) makes the drain explicit.
+      int n = in.read(buf);
+      while (n != -1) {
+        n = in.read(buf);
+      }
+    } finally {
+      in.close();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Rate control.
+  // -------------------------------------------------------------------------
+  /** Ops/sec required to sustain {@code throughputMB} at the block size. */
+  private double opsPerSecond(double throughputMB) {
+    double opMB = blockSizeBytes / (double) MB;
+    return Math.max(throughputMB / opMB, 1e-9);
+  }
+
+  /**
+   * Linearly ramp the limiter rate from the start throughput to the end
+   * throughput across the test duration (acceleration stress testing). A no-op
+   * when {@code endThroughputMB <= startThroughputMB}.
+   */
+  private void rampRate(RateLimiter limiter, double startThroughputMB,
+      double endThroughputMB, long startNanos, long durationNanos) {
+    if (endThroughputMB <= startThroughputMB || durationNanos <= 0) {
+      return;
+    }
+    double fraction = Math.min(1.0,
+        (System.nanoTime() - startNanos) / (double) durationNanos);
+    double current = startThroughputMB
+        + (endThroughputMB - startThroughputMB) * fraction;
+    limiter.setRate(opsPerSecond(current));
+  }
+
+  /**
+   * Minimal token-bucket rate limiter. {@link #acquire()} blocks so that calls
+   * are spaced to average {@code permitsPerSecond}. Thread-safe and supports a
+   * dynamically changing rate (for ramping).
+   */
+  static final class RateLimiter {
+    private double permitsPerSecond;
+    private long nextFreeTimeNanos;
+
+    RateLimiter(double permitsPerSecond) {
+      this.permitsPerSecond = Math.max(permitsPerSecond, 1e-9);
+      this.nextFreeTimeNanos = System.nanoTime();
+    }
+
+    synchronized void setRate(double newPermitsPerSecond) {
+      this.permitsPerSecond = Math.max(newPermitsPerSecond, 1e-9);
+    }
+
+    void acquire() throws InterruptedException {
+      long waitNanos;
+      synchronized (this) {
+        long now = System.nanoTime();
+        if (now > nextFreeTimeNanos) {
+          nextFreeTimeNanos = now;
+        }
+        waitNanos = nextFreeTimeNanos - now;
+        nextFreeTimeNanos += (long) (1_000_000_000L / permitsPerSecond);
+      }
+      if (waitNanos > 0) {
+        Thread.sleep(waitNanos / 1_000_000L, (int) (waitNanos % 1_000_000L));
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Latency statistics.
+  // -------------------------------------------------------------------------
+  /**
+   * Thread-safe collector of per-operation latencies (in nanoseconds).
+   *
+   * <p>Uses fixed-capacity reservoir sampling (Vitter's Algorithm R) so memory
+   * stays bounded regardless of how many operations a long-running stress test
+   * performs; the reported percentiles/mean/stddev are computed over a uniform
+   * random sample of the observed latencies, while {@link #count()} still
+   * reflects the exact total operation count (used for QPS/throughput).
+   */
+  static final class LatencyStats {
+    private static final int MAX_SAMPLES = 200_000;
+    private final long[] reservoir = new long[MAX_SAMPLES];
+    private final Random rng = new Random(0);
+    private int filled;
+    private long total;
+
+    synchronized void record(long nanos) {
+      if (filled < reservoir.length) {
+        reservoir[filled++] = nanos;
+      } else {
+        // total == number of items seen so far (0-indexed position of this one).
+        long j = Math.floorMod(rng.nextLong(), total + 1);
+        if (j < reservoir.length) {
+          reservoir[(int) j] = nanos;
+        }
+      }
+      total++;
+    }
+
+    synchronized long count() {
+      return total;
+    }
+
+    /** Sorted copy of the sampled latencies, in milliseconds. */
+    synchronized double[] sortedMillis() {
+      double[] ms = new double[filled];
+      for (int i = 0; i < filled; i++) {
+        ms[i] = reservoir[i] / 1_000_000.0;
+      }
+      Arrays.sort(ms);
+      return ms;
+    }
+  }
+
+  private static double percentile(double[] sorted, double p) {
+    if (sorted.length == 0) {
+      return 0;
+    }
+    int idx = (int) Math.ceil(p / 100.0 * sorted.length) - 1;
+    idx = Math.max(0, Math.min(sorted.length - 1, idx));
+    return sorted[idx];
+  }
+
+  private void printReport(String label, LatencyStats stats,
+      double seconds, double opBytesMB, double targetThroughputMB) {
+    long count = stats.count();
+    if (count == 0) {
+      return;
+    }
+    double[] sorted = stats.sortedMillis();
+    double sum = 0;
+    for (double v : sorted) {
+      sum += v;
+    }
+    double mean = sum / sorted.length;
+    double sqDiff = 0;
+    for (double v : sorted) {
+      sqDiff += (v - mean) * (v - mean);
+    }
+    double stddev = Math.sqrt(sqDiff / sorted.length);
+    double qps = count / seconds;
+    double throughputMB = count * opBytesMB / seconds;
+
+    System.out.println("----------------------------------------");
+    System.out.println(label + " results");
+    System.out.println("----------------------------------------");
+    System.out.printf("  operations       : %d%n", count);
+    System.out.printf("  duration (s)     : %.1f%n", seconds);
+    System.out.printf("  QPS              : %.2f%n", qps);
+    System.out.printf("  throughput (MB/s): %.2f%n", throughputMB);
+    System.out.printf("  latency ms  min  : %.2f%n", sorted[0]);
+    System.out.printf("  latency ms  p50  : %.2f%n", percentile(sorted, 50));
+    System.out.printf("  latency ms  p75  : %.2f%n", percentile(sorted, 75));
+    System.out.printf("  latency ms  p95  : %.2f%n", percentile(sorted, 95));
+    System.out.printf("  latency ms  p99  : %.2f%n", percentile(sorted, 99));
+    System.out.printf("  latency ms  max  : %.2f%n", sorted[sorted.length - 1]);
+    System.out.printf("  latency ms  mean : %.2f%n", mean);
+    System.out.printf("  latency ms stddev: %.2f%n", stddev);
+
+    if (targetThroughputMB > 0 && throughputMB < 0.8 * targetThroughputMB) {
+      System.err.printf("WARNING: measured %s throughput (%.2f MB/s) is well "
+          + "below the configured target (%.2f MB/s). This usually means this "
+          + "single client host - not the target DataNode(s) - is the "
+          + "bottleneck (client CPU/NIC or worker-thread count). Increase the "
+          + "read/write thread count, or drive higher aggregate load by running "
+          + "this tool on additional client hosts against the same cluster; the "
+          + "offered load is the sum of each client's configured throughput.%n",
+          label, throughputMB, targetThroughputMB);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Configuration parsing.
+  // -------------------------------------------------------------------------
+  @VisibleForTesting
+  void loadConfig(String propsPath) throws IOException {
+    Configuration conf = getConf();
+    Properties props = new Properties();
+    try (InputStream in = new java.io.FileInputStream(propsPath)) {
+      props.load(in);
+    }
+
+    this.favoredNodes = parseFavoredNodes(get(conf, props, "favoredDataNodes",
+        ""));
+    this.replication = (short) getInt(conf, props, "replication", 3);
+    this.blockSizeBytes = getLong(conf, props, "blockSizeMB", 128) * MB;
+
+    this.writeDir = get(conf, props, "testWriteDirectory", null);
+    this.writeThroughputMB = getDouble(conf, props, "writeThroughputMB", 0);
+    this.endWriteThroughputMB = getDouble(conf, props, "endWriteThroughputMB",
+        0);
+    this.writeThreads = getInt(conf, props, "writeThreads", -1);
+
+    String readDirsRaw = get(conf, props, "testReadDirectories", "");
+    this.readDirs = new ArrayList<>();
+    for (String d : readDirsRaw.split(",")) {
+      if (!d.trim().isEmpty()) {
+        readDirs.add(d.trim());
+      }
+    }
+    this.readThroughputMB = getDouble(conf, props, "readThroughputMB", 0);
+    this.endReadThroughputMB = getDouble(conf, props, "endReadThroughputMB", 0);
+    this.readThreads = getInt(conf, props, "readThreads", -1);
+
+    this.readFileSizeBytes = getLong(conf, props, "testReadFileSizeGB", 0) * GB;
+    this.preTestWriteThroughputMB = getDouble(conf, props,
+        "preTestWriteThroughputMB", 0);
+    this.preTestWriteDurationSeconds = getLong(conf, props,
+        "preTestWriteDurationSeconds", 0);
+
+    this.testDurationSeconds = getLong(conf, props, "testDurationSeconds", 60);
+
+    if (readDirs.isEmpty()) {
+      this.readThroughputMB = 0;
+    }
+
+    // Fail fast on configurations that would otherwise divide by zero, silently
+    // disable a workload the user explicitly asked for, or produce nonsense
+    // throughput/latency numbers.
+    if (blockSizeBytes <= 0) {
+      throw new IllegalArgumentException(
+          "blockSizeMB must be a positive integer number of MB, got: "
+              + (blockSizeBytes / MB));
+    }
+    if (readThroughputMB > 0 && readFileSizeBytes <= 0) {
+      throw new IllegalArgumentException(
+          "readThroughputMB=" + readThroughputMB + " enables the read workload,"
+              + " but testReadFileSizeGB is not set to a positive value. The"
+              + " cold-read corpus would be empty and the read workload would"
+              + " silently not run. Set testReadFileSizeGB (ideally ~2x the"
+              + " aggregate target-DataNode RAM) so reads exercise cold data.");
+    }
+  }
+
+  private static InetSocketAddress[] parseFavoredNodes(String raw) {
+    if (raw == null || raw.trim().isEmpty()) {
+      return null;
+    }
+    List<InetSocketAddress> nodes = new ArrayList<>();
+    for (String hp : raw.split(",")) {
+      hp = hp.trim();
+      if (hp.isEmpty()) {
+        continue;
+      }
+      int colon = hp.lastIndexOf(':');
+      if (colon < 0) {
+        throw new IllegalArgumentException(
+            "favoredDataNodes entry must be host:port, got: " + hp);
+      }
+      String host = hp.substring(0, colon);
+      int port = Integer.parseInt(hp.substring(colon + 1));
+      nodes.add(new InetSocketAddress(host, port));
+    }
+    return nodes.isEmpty() ? null : nodes.toArray(new InetSocketAddress[0]);
+  }
+
+  // Configuration (-D) overrides the properties file, which overrides defaults.
+  private static String get(Configuration conf, Properties props, String key,
+      String dflt) {
+    String v = conf.get(key);
+    if (v != null) {
+      return v;
+    }
+    return props.getProperty(key, dflt);
+  }
+
+  private static int getInt(Configuration conf, Properties props, String key,
+      int dflt) {
+    String v = get(conf, props, key, null);
+    return v == null ? dflt : Integer.parseInt(v.trim());
+  }
+
+  private static long getLong(Configuration conf, Properties props, String key,
+      long dflt) {
+    String v = get(conf, props, key, null);
+    return v == null ? dflt : Long.parseLong(v.trim());
+  }
+
+  private static double getDouble(Configuration conf, Properties props,
+      String key, double dflt) {
+    String v = get(conf, props, key, null);
+    return v == null ? dflt : Double.parseDouble(v.trim());
+  }
+
+  public static void main(String[] args) throws Exception {
+    int res = ToolRunner.run(new Configuration(), new HdfsStressTest(), args);
+    System.exit(res);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHdfsStressTest.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHdfsStressTest.java
@@ -1,0 +1,378 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests for {@link HdfsStressTest} against a {@link MiniDFSCluster}, covering
+ * the end-to-end Tool run as well as the individual pre-test (cold-read corpus
+ * generation), write and read building blocks.
+ */
+public class TestHdfsStressTest {
+
+  private MiniDFSCluster cluster;
+  private Configuration conf;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    conf = new HdfsConfiguration();
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    cluster.waitActive();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  @Timeout(120)
+  public void testWriteAndColdReadWorkload() throws Exception {
+    File props = File.createTempFile("hdfs-stress", ".properties",
+        GenericTestUtils.getTestDir());
+    props.deleteOnExit();
+    try (FileWriter fw = new FileWriter(props)) {
+      fw.write("replication=1\n");
+      fw.write("blockSizeMB=1\n");
+      fw.write("testWriteDirectory=/stress/write\n");
+      fw.write("writeThroughputMB=8\n");
+      fw.write("testReadDirectories=/stress/read\n");
+      fw.write("readThroughputMB=8\n");
+      // Bounded by preTestWriteDurationSeconds, so only a handful of files.
+      fw.write("testReadFileSizeGB=1\n");
+      fw.write("preTestWriteThroughputMB=32\n");
+      fw.write("preTestWriteDurationSeconds=2\n");
+      fw.write("testDurationSeconds=2\n");
+    }
+
+    int rc = ToolRunner.run(conf, new HdfsStressTest(),
+        new String[] {props.getAbsolutePath()});
+    assertEquals(0, rc, "HdfsStressTest should exit successfully");
+
+    FileSystem fs = cluster.getFileSystem();
+    assertTrue(fs.exists(new Path("/stress/write")),
+        "write directory should contain stress files");
+    assertTrue(fs.exists(new Path("/stress/read")),
+        "read corpus should have been created");
+    assertTrue(fs.listStatus(new Path("/stress/read")).length > 0,
+        "at least one cold-read file should exist");
+  }
+
+  /**
+   * The write building block must produce a file that is exactly one block
+   * long, with the configured replication and block size, filled with data.
+   */
+  @Test
+  @Timeout(60)
+  public void testWriteBlockFileProducesExactBlockSizedReplicatedFile()
+      throws Exception {
+    HdfsStressTest tool = newConfiguredTool(
+        "replication=2",
+        "blockSizeMB=2");
+    DistributedFileSystem dfs = cluster.getFileSystem();
+
+    Path f = new Path("/unit/write/block-0.dat");
+    tool.writeBlockFile(dfs, f);
+
+    FileStatus st = dfs.getFileStatus(f);
+    long twoMb = 2L * 1024 * 1024;
+    assertEquals(twoMb, st.getLen(), "file should be exactly one block long");
+    assertEquals(twoMb, st.getBlockSize(), "block size should match config");
+    assertEquals(2, st.getReplication(), "replication should match config");
+    try (FSDataInputStream in = dfs.open(f)) {
+      assertEquals('a', in.read(), "payload should be written");
+    }
+  }
+
+  /**
+   * The read building block must read a whole file to EOF without error, for
+   * every byte of a full block.
+   */
+  @Test
+  @Timeout(60)
+  public void testReadWholeFileReadsEntireFile() throws Exception {
+    HdfsStressTest tool = newConfiguredTool(
+        "replication=1",
+        "blockSizeMB=1");
+    DistributedFileSystem dfs = cluster.getFileSystem();
+
+    Path f = new Path("/unit/read/block-0.dat");
+    tool.writeBlockFile(dfs, f);
+    long oneMb = 1024L * 1024;
+    assertEquals(oneMb, dfs.getFileStatus(f).getLen(),
+        "precondition: file is one block");
+
+    // Should consume the whole file without throwing.
+    tool.readWholeFile(dfs, f);
+
+    // Independently confirm every byte is readable and is the written payload.
+    long read = 0;
+    try (FSDataInputStream in = dfs.open(f)) {
+      byte[] buf = new byte[64 * 1024];
+      int n;
+      while ((n = in.read(buf)) != -1) {
+        for (int i = 0; i < n; i++) {
+          assertEquals('a', buf[i], "payload byte mismatch");
+        }
+        read += n;
+      }
+    }
+    assertEquals(oneMb, read, "read path should see the full block");
+  }
+
+  /**
+   * The pre-test phase must create a cold-read corpus of block-sized files,
+   * round-robining across every configured read directory.
+   */
+  @Test
+  @Timeout(120)
+  public void testPreTestCreatesColdReadCorpusAcrossDirectories()
+      throws Exception {
+    HdfsStressTest tool = newConfiguredTool(
+        "replication=1",
+        "blockSizeMB=1",
+        "testReadDirectories=/unit/pre/a,/unit/pre/b",
+        "readThroughputMB=8",
+        "testReadFileSizeGB=1",
+        "preTestWriteThroughputMB=64",
+        "preTestWriteDurationSeconds=3");
+    DistributedFileSystem dfs = cluster.getFileSystem();
+
+    List<Path> created = tool.preTestCreateReadFiles(dfs);
+
+    assertFalse(created.isEmpty(), "pre-test should create at least one file");
+    long oneMb = 1024L * 1024;
+    for (Path p : created) {
+      assertTrue(p.getName().startsWith("coldread-"),
+          "corpus file should be named coldread-*");
+      assertEquals(oneMb, dfs.getFileStatus(p).getLen(),
+          "each corpus file should be one block long");
+    }
+
+    int inA = dfs.listStatus(new Path("/unit/pre/a")).length;
+    int inB = dfs.listStatus(new Path("/unit/pre/b")).length;
+    assertEquals(created.size(), inA + inB,
+        "all created files should be on disk");
+    if (created.size() >= 2) {
+      assertTrue(inA > 0, "first directory should receive files");
+      assertTrue(inB > 0, "second directory should receive files");
+    }
+  }
+
+  /**
+   * The pre-test phase must stop at the duration cap rather than creating the
+   * full target corpus.
+   */
+  @Test
+  @Timeout(60)
+  public void testPreTestStopsAtDurationCap() throws Exception {
+    // Target is 1 GB / 1 MB blocks = 1024 files, but only 1 second is allowed,
+    // which a MiniDFSCluster cannot fill, so the run must be duration-bounded.
+    HdfsStressTest tool = newConfiguredTool(
+        "replication=1",
+        "blockSizeMB=1",
+        "testReadDirectories=/unit/precap",
+        "readThroughputMB=8",
+        "testReadFileSizeGB=1",
+        "preTestWriteThroughputMB=1024",
+        "preTestWriteDurationSeconds=1");
+    DistributedFileSystem dfs = cluster.getFileSystem();
+
+    // Capture stderr so we can assert the tool warns that the capped corpus is
+    // smaller than requested (so its cold-read guarantee may not hold).
+    PrintStream origErr = System.err;
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    List<Path> created;
+    try {
+      System.setErr(new PrintStream(errBuf, true, "UTF-8"));
+      created = tool.preTestCreateReadFiles(dfs);
+    } finally {
+      System.setErr(origErr);
+    }
+
+    assertFalse(created.isEmpty(),
+        "some files should be created before the cap");
+    assertTrue(created.size() < 1024,
+        "duration cap should stop well below the 1024-file target");
+    String err = errBuf.toString("UTF-8");
+    boolean warned =
+        err.contains("WARNING") && err.contains("smaller than requested");
+    assertTrue(warned,
+        "capped corpus should warn about page-cache reads, was: " + err);
+  }
+
+  /**
+   * A write-only run (no read directories) drives the write path end-to-end via
+   * the Tool interface and must not create any read corpus.
+   */
+  @Test
+  @Timeout(120)
+  public void testWriteOnlyWorkloadCreatesOnlyWriteFiles() throws Exception {
+    File props = writeProps(
+        "replication=1",
+        "blockSizeMB=1",
+        "testWriteDirectory=/wo/write",
+        "writeThroughputMB=8",
+        "testDurationSeconds=2");
+
+    int rc = ToolRunner.run(conf, new HdfsStressTest(),
+        new String[] {props.getAbsolutePath()});
+    assertEquals(0, rc, "write-only run should succeed");
+
+    DistributedFileSystem dfs = cluster.getFileSystem();
+    FileStatus[] written = dfs.listStatus(new Path("/wo/write"));
+    assertTrue(written.length > 0,
+        "write-only run should produce write files");
+    long oneMb = 1024L * 1024;
+    for (FileStatus st : written) {
+      assertTrue(st.getPath().getName().startsWith("stress-write-"),
+          "write files should be named stress-write-*");
+      assertEquals(oneMb, st.getLen(),
+          "each write file should be one block long");
+      assertEquals(1, st.getReplication(),
+          "write replication should match config");
+    }
+    assertFalse(dfs.exists(new Path("/wo/read")),
+        "no read corpus should be created for a write-only run");
+  }
+
+  /**
+   * A non-positive {@code preTestWriteDurationSeconds} must mean "no time cap":
+   * the pre-test keeps building the corpus (previously a 0 duration set the
+   * deadline to "now", created zero files, and silently disabled reads).
+   */
+  @Test
+  @Timeout(60)
+  public void testPreTestZeroDurationIsUnbounded() throws Exception {
+    final HdfsStressTest tool = newConfiguredTool(
+        "replication=1",
+        "blockSizeMB=1",
+        "testReadDirectories=/unit/unbounded",
+        "readThroughputMB=8",
+        "testReadFileSizeGB=1",             // 1024-file target
+        "preTestWriteThroughputMB=16",      // paced so it will not finish fast
+        "preTestWriteDurationSeconds=0");   // unbounded (regression under test)
+    final DistributedFileSystem dfs = cluster.getFileSystem();
+    final Path dir = new Path("/unit/unbounded");
+
+    Thread worker = new Thread(() -> {
+      try {
+        tool.preTestCreateReadFiles(dfs);
+      } catch (Exception ignored) {
+        // Interrupted/aborted by the test once enough files exist.
+      }
+    }, "pretest-unbounded");
+    worker.setDaemon(true);
+    worker.start();
+
+    // With the bug, deadline == now, so zero files are ever created and this
+    // wait would time out. With the fix the corpus keeps growing.
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return dfs.exists(dir) && dfs.listStatus(dir).length >= 3;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 200, 30_000);
+
+    worker.interrupt();
+    worker.join(20_000);
+    assertTrue(dfs.listStatus(dir).length >= 3,
+        "zero-duration pre-test must keep creating files, not stop at 0");
+  }
+
+  /**
+   * A failure inside a workload worker must abort the run with a non-zero
+   * result instead of being swallowed and reported as success.
+   */
+  @Test
+  @Timeout(60)
+  public void testWorkerFailurePropagatesAsError() throws Exception {
+    HdfsStressTest tool = new HdfsStressTest() {
+      @Override
+      void writeBlockFile(DistributedFileSystem dfs, Path file)
+          throws java.io.IOException {
+        throw new java.io.IOException("injected write failure");
+      }
+    };
+    tool.setConf(conf);
+    tool.loadConfig(writeProps(
+        "replication=1",
+        "blockSizeMB=1",
+        "testWriteDirectory=/we/write",
+        "writeThroughputMB=64",
+        "writeThreads=1",
+        "testDurationSeconds=5").getAbsolutePath());
+    DistributedFileSystem dfs = cluster.getFileSystem();
+
+    try {
+      tool.runTestPhase(dfs, java.util.Collections.emptyList());
+      fail("runTestPhase should surface the worker failure");
+    } catch (java.io.IOException e) {
+      assertTrue(e.getMessage().contains("Stress workload failed"),
+          "should report the stress workload failure but was: "
+              + e.getMessage());
+    }
+  }
+
+  /** Build a tool whose config fields are populated from the given lines. */
+  private HdfsStressTest newConfiguredTool(String... lines) throws Exception {
+    HdfsStressTest tool = new HdfsStressTest();
+    tool.setConf(conf);
+    tool.loadConfig(writeProps(lines).getAbsolutePath());
+    return tool;
+  }
+
+  /** Write the given {@code key=value} lines to a temp properties file. */
+  private File writeProps(String... lines) throws Exception {
+    File props = File.createTempFile("hdfs-stress", ".properties",
+        GenericTestUtils.getTestDir());
+    props.deleteOnExit();
+    try (FileWriter fw = new FileWriter(props)) {
+      for (String line : lines) {
+        fw.write(line);
+        fw.write('\n');
+      }
+    }
+    return props;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHdfsStressTestHelpers.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHdfsStressTestHelpers.java
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsStressTest.LatencyStats;
+import org.apache.hadoop.hdfs.HdfsStressTest.RateLimiter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Fast, cluster-free unit tests for the {@link HdfsStressTest} rate-control and
+ * latency-statistics helpers that pace and measure the write/read workloads.
+ */
+public class TestHdfsStressTestHelpers {
+
+  /** A finite rate must space out {@code acquire()} calls. */
+  @Test
+  @Timeout(30)
+  public void testRateLimiterPacesAcquires() throws Exception {
+    // 20 permits/sec => ~50 ms between permits. Five acquires have four gaps,
+    // so the run must take at least ~200 ms; assert a conservative lower bound.
+    RateLimiter limiter = new RateLimiter(20);
+    long start = System.nanoTime();
+    for (int i = 0; i < 5; i++) {
+      limiter.acquire();
+    }
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+    assertTrue(elapsedMs >= 120,
+        "5 acquires at 20/s should take >= ~120 ms but took " + elapsedMs
+            + " ms");
+  }
+
+  /** A very high rate must not introduce meaningful blocking. */
+  @Test
+  @Timeout(30)
+  public void testRateLimiterHighRateDoesNotBlock() throws Exception {
+    RateLimiter limiter = new RateLimiter(1_000_000);
+    long start = System.nanoTime();
+    for (int i = 0; i < 1000; i++) {
+      limiter.acquire();
+    }
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+    assertTrue(elapsedMs < 2000,
+        "1000 acquires at 1e6/s should be fast but took " + elapsedMs + " ms");
+  }
+
+  /** Increasing the rate at runtime must shorten the spacing. */
+  @Test
+  @Timeout(30)
+  public void testRateLimiterSetRateTakesEffect() throws Exception {
+    RateLimiter limiter = new RateLimiter(2); // 500 ms spacing
+    limiter.acquire();                         // first is immediate
+    limiter.setRate(1_000_000);                // speed up dramatically
+    long start = System.nanoTime();
+    for (int i = 0; i < 100; i++) {
+      limiter.acquire();
+    }
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+    assertTrue(elapsedMs < 1000,
+        "after speeding up, acquires should be fast but took " + elapsedMs
+            + " ms");
+  }
+
+  /** Latencies must be reported sorted and converted from nanos to millis. */
+  @Test
+  @Timeout(30)
+  public void testLatencyStatsSortedAndConverted() {
+    LatencyStats stats = new LatencyStats();
+    stats.record(3_000_000L); // 3 ms
+    stats.record(1_000_000L); // 1 ms
+    stats.record(2_000_000L); // 2 ms
+
+    assertEquals(3, stats.count(), "count should reflect recorded samples");
+    double[] ms = stats.sortedMillis();
+    assertArrayEquals(new double[] {1.0, 2.0, 3.0}, ms, 1e-9,
+        "latencies should be sorted ms");
+  }
+
+  /** An empty collector must report zero count and no samples. */
+  @Test
+  @Timeout(30)
+  public void testLatencyStatsEmpty() {
+    LatencyStats stats = new LatencyStats();
+    assertEquals(0, stats.count());
+    assertEquals(0, stats.sortedMillis().length);
+  }
+
+  /**
+   * The collector must bound its memory: {@code count()} stays exact for an
+   * unbounded number of operations, while the retained sample is capped (via
+   * reservoir sampling) rather than growing without limit.
+   */
+  @Test
+  @Timeout(30)
+  public void testLatencyStatsBoundedMemory() {
+    LatencyStats stats = new LatencyStats();
+    int n = 500_000; // well past the internal reservoir capacity
+    for (int i = 0; i < n; i++) {
+      stats.record(1_000_000L); // 1 ms each
+    }
+    assertEquals(n, stats.count(),
+        "count must be exact even beyond the sample cap");
+    double[] ms = stats.sortedMillis();
+    assertTrue(ms.length < n,
+        "retained sample must be bounded well below the op count, was "
+            + ms.length);
+    assertTrue(ms.length > 0, "retained sample must be non-empty");
+    for (double v : ms) {
+      assertEquals(1.0, v, 1e-9,
+          "sampled latency should be the recorded value");
+    }
+  }
+
+  /**
+   * {@code blockSizeMB} sets the I/O unit and is a divisor when sizing the
+   * corpus and computing per-op rates, so a non-positive value must be rejected
+   * up front rather than dividing by zero at run time.
+   */
+  @Test
+  @Timeout(30)
+  public void testLoadConfigRejectsNonPositiveBlockSize() throws Exception {
+    HdfsStressTest tool = new HdfsStressTest();
+    tool.setConf(new Configuration());
+    File props = writeProps("blockSizeMB=0");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> tool.loadConfig(props.getAbsolutePath()));
+    assertTrue(e.getMessage().contains("blockSizeMB"),
+        "message should name blockSizeMB, was: " + e.getMessage());
+  }
+
+  /**
+   * Reads are served only from the pre-test corpus, so enabling the read
+   * workload without a positive {@code testReadFileSizeGB} would silently run
+   * zero readers and still exit success. That misconfiguration must fail fast.
+   */
+  @Test
+  @Timeout(30)
+  public void testLoadConfigRejectsReadWorkloadWithoutCorpusSize()
+      throws Exception {
+    HdfsStressTest tool = new HdfsStressTest();
+    tool.setConf(new Configuration());
+    File props = writeProps(
+        "blockSizeMB=1",
+        "testReadDirectories=/stress/read",
+        "readThroughputMB=8");
+    // testReadFileSizeGB deliberately omitted (defaults to 0).
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> tool.loadConfig(props.getAbsolutePath()));
+    assertTrue(e.getMessage().contains("testReadFileSizeGB"),
+        "message should name testReadFileSizeGB, was: " + e.getMessage());
+  }
+
+  /** A read workload with a positive corpus size must load without error. */
+  @Test
+  @Timeout(30)
+  public void testLoadConfigAcceptsValidReadWorkload() throws Exception {
+    HdfsStressTest tool = new HdfsStressTest();
+    tool.setConf(new Configuration());
+    File props = writeProps(
+        "blockSizeMB=1",
+        "testReadDirectories=/stress/read",
+        "readThroughputMB=8",
+        "testReadFileSizeGB=1");
+    tool.loadConfig(props.getAbsolutePath()); // must not throw
+  }
+
+  /** A write-only run must not require a read corpus size. */
+  @Test
+  @Timeout(30)
+  public void testLoadConfigAcceptsWriteOnlyWorkload() throws Exception {
+    HdfsStressTest tool = new HdfsStressTest();
+    tool.setConf(new Configuration());
+    File props = writeProps(
+        "blockSizeMB=1",
+        "testWriteDirectory=/stress/write",
+        "writeThroughputMB=8");
+    tool.loadConfig(props.getAbsolutePath()); // must not throw
+  }
+
+  private static File writeProps(String... lines) throws Exception {
+    File props = File.createTempFile("hdfs-stress-helpers", ".properties");
+    props.deleteOnExit();
+    try (FileWriter fw = new FileWriter(props)) {
+      for (String line : lines) {
+        fw.write(line);
+        fw.write('\n');
+      }
+    }
+    return props;
+  }
+}

--- a/hadoop-project/src/site/site.xml
+++ b/hadoop-project/src/site/site.xml
@@ -101,6 +101,7 @@
       <item name="Storage Policies" href="hadoop-project-dist/hadoop-hdfs/ArchivalStorage.html"/>
       <item name="Memory Storage Support" href="hadoop-project-dist/hadoop-hdfs/MemoryStorage.html"/>
       <item name="Synthetic Load Generator" href="hadoop-project-dist/hadoop-hdfs/SLGUserGuide.html"/>
+      <item name="Stress Test" href="hadoop-project-dist/hadoop-hdfs/HdfsStressTest.html"/>
       <item name="Erasure Coding" href="hadoop-project-dist/hadoop-hdfs/HDFSErasureCoding.html"/>
       <item name="Disk Balancer" href="hadoop-project-dist/hadoop-hdfs/HDFSDiskbalancer.html"/>
       <item name="Upgrade Domain" href="hadoop-project-dist/hadoop-hdfs/HdfsUpgradeDomain.html"/>


### PR DESCRIPTION
### Description of PR

`TestDFSIO` is the standard HDFS I/O benchmark, but it is a poor fit for
targeted DataNode stress testing:

- It launches a MapReduce job scheduled by YARN across the whole cluster, so
  it cannot generate controlled, steady QPS/throughput and takes a long time
  to saturate a targeted subset of nodes.
- It cannot target a specific set of DataNodes, such as a single replica set,
  which is required to reproduce and measure hot or overloaded nodes.
- It reports aggregate throughput only and does not provide client-side
  latency distributions such as p50/p95/p99, which are essential for
  characterizing tail latency and disk random-I/O behavior.
- It requires the MapReduce/YARN stack to be available.

## Approach

Add `HdfsStressTest`, a single-process, no-MapReduce load generator.

Because it depends only on the HDFS client (`DistributedFileSystem` plus
favored-nodes) and does not require MapReduce/YARN, it lives in the
`hadoop-hdfs` test tree (`org.apache.hadoop.hdfs`), alongside other standalone
HDFS benchmarks such as `BenchmarkThroughput`, rather than in the MapReduce
jobclient module.

The tool is intentionally compact, consisting of one tool class with small
nested helpers, and provides the controls that `TestDFSIO` lacks:

- **Controlled read/write throughput**
  - Uses a global token-bucket rate limiter.
  - Supports an optional linear ramp from start to end throughput for
    acceleration stress testing.

- **Targeted DataNodes**
  - Uses HDFS favored-nodes hints so that load is directed to a chosen
    replica set.

- **Configurable block and file size**
  - Supports configurable block size.
  - Supports configurable test file size.

- **Cold-read testing**
  - A pre-test phase creates a large corpus of files sized to exceed the
    DataNode page cache, for example, approximately 2x DataNode memory.
  - Because the corpus does not fit in main memory, the kernel evicts older
    pages as newer blocks are written.
  - By the time the measured phase re-reads a file, its pages are no longer
    expected to be cached, causing the measured read to fall through to disk.
  - The read workload spreads file selections across the entire corpus rather
    than replaying a hot subset, keeping the page-cache hit rate near zero.
  - This allows the tool to measure actual disk behavior rather than
    page-cache performance.

- **Client-side latency and throughput metrics**
  - Reports latency distributions for reads and writes:
    - p50
    - p75
    - p95
    - p99
    - min
    - max
    - mean
    - stddev
  - Reports effective QPS and throughput for both reads and writes.

## Multi-Client Scale-Out

Aggregate load can be scaled by running the tool concurrently on multiple
client hosts against the same cluster.

The offered load is the sum of each client's configured throughput.

Multi-client usage and guidance are documented, including:

- Using distinct write/read directories per client.
- Sharing the same `favoredDataNodes` configuration.
- Running multiple instances concurrently.

## Configuration

Workload configuration is specified through a properties file.

Supported properties include:

| Property | Description |
|---|---|
| `favoredDataNodes` | DataNodes to target using HDFS favored-nodes hints |
| `testWriteDirectory` | Directory used for write workload |
| `testReadDirectories` | Directories containing the read corpus |
| `blockSizeMB` | HDFS block size and I/O unit |
| `testDurationSeconds` | Measured workload duration |
| `writeThroughputMB` | Target write throughput |
| `readThroughputMB` | Target read throughput |
| `testReadFileSizeGB` | Size of the read corpus |
| `preTestWriteThroughputMB` | Pre-test corpus write throughput |
| `preTestWriteDurationSeconds` | Maximum duration of the pre-test phase |
| `endWriteThroughputMB` | Optional final write throughput for ramping |
| `endReadThroughputMB` | Optional final read throughput for ramping |

Any property can be overridden using `-D` through `ToolRunner`.

## Documentation

Every configuration property, the run command, cold-read/page-cache
rationale, and multi-client scale-out guidance are documented in:

- The `HdfsStressTest` class Javadoc.
- The new user guide:
  `hadoop-hdfs/src/site/markdown/HdfsStressTest.md`
- The HDFS site menu, which links to the new user guide.

### Run Example

```bash
hadoop jar hadoop-hdfs-<version>-tests.jar \
    org.apache.hadoop.hdfs.HdfsStressTest \
    /path/to/stress.properties
````

## Validation

`loadConfig` fails fast on misconfigurations that could otherwise produce
misleading results.

### Block Size Validation

`blockSizeMB` must be a positive number of MB.

The block size is used as the I/O unit, as well as a divisor when sizing the
corpus and calculating per-operation rates.

### Read Workload Validation

When the read workload is enabled:

```text
readThroughputMB > 0
```

`testReadFileSizeGB` must also be positive.

Reads are served only from the pre-test corpus. Without a valid corpus size,
the tool could silently run zero readers and still exit successfully.

### Cold-Read Corpus Validation

The pre-test phase creates a corpus large enough to exceed the DataNode page
cache so that subsequent reads fall through to disk.

The read workload distributes file selections across the entire corpus rather
than repeatedly reading a hot subset, keeping the page-cache hit rate near
zero.

If the pre-test is time-boxed using `preTestWriteDurationSeconds` and stops
before reaching `testReadFileSizeGB`, the tool prints a `WARNING`.

The warning indicates that some reads may be served from the page cache and
that the resulting numbers could therefore be optimistic, rather than
silently reporting warm reads as cold.

## Testing

### `TestHdfsStressTest`

Uses `MiniDFSCluster` to validate individual building blocks and the
end-to-end `Tool` execution.

The test verifies:

* `writeBlockFile`

  * Produces an exactly block-sized file.
  * Uses the configured replication factor and block size.
  * Writes the expected payload.

* `readWholeFile`

  * Reads a complete block through EOF.

* Pre-test phase

  * Creates a block-sized cold-read corpus.
  * Round-robins files across multiple directories.
  * Honors the configured duration cap.
  * Emits a warning to stderr when the capped corpus is smaller than the
    requested read corpus size.

* Write-only workload

  * Drives the write path through `ToolRunner`.
  * Does not create a read corpus.

### `TestHdfsStressTestHelpers`

Provides fast, cluster-free unit tests for pacing, measurement, and
configuration helpers.

#### Rate Limiter

Tests:

* Token-bucket pacing and request spacing.
* Runtime rate changes.

#### Latency Statistics

Tests:

* Nanosecond-to-millisecond conversion.
* Latency sorting.
* Bounded-memory reservoir sampling.

#### Configuration Validation

Tests:

* `blockSizeMB` must be positive.
* Enabling the read workload requires a positive
  `testReadFileSizeGB`.
* Valid read-only configurations load successfully.
* Valid write-only configurations load successfully.

These validations prevent configurations that would otherwise silently perform
no reads or produce misleading benchmark results.



### How was this patch tested?
Tested by newly added unit test

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html

