### PR TITLE
HADOOP-19978. Upgrade maven-surefire-plugin to 3.6.

### DIFF
--- a/hadoop-common-project/hadoop-registry/pom.xml
+++ b/hadoop-common-project/hadoop-registry/pom.xml
@@ -274,7 +274,6 @@
           <test.cache.data>${test.cache.data}</test.cache.data>
           <test.build.classes>${test.build.classes}</test.build.classes>
 
-          <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
           <java.security.krb5.conf>${project.build.directory}/test-classes/krb5.conf</java.security.krb5.conf>
           <java.security.egd>${java.security.egd}</java.security.egd>
           <require.test.libhadoop>${require.test.libhadoop}</require.test.libhadoop>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -187,8 +187,13 @@
     </extraJavaTestArgs>
 
     <!-- Plugin versions and config -->
-    <maven-surefire-plugin.argLine>-Xmx4096m -Xss4m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
-    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <!-- java.net.preferIPv4Stack must be a JVM startup argument, not a
+         systemPropertyVariable: from maven-surefire-plugin 3.6.0 the forked
+         booter initialises networking before it applies the configured
+         system properties, so the flag would be read too late and the fork
+         would fall back to IPv6. See HADOOP-19978. -->
+    <maven-surefire-plugin.argLine>-Djava.net.preferIPv4Stack=true -Xmx4096m -Xss4m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
+    <maven-surefire-plugin.version>3.6.0</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
     <!-- Flag to stop surefire from shortening test stacks  -->
@@ -2313,6 +2318,12 @@
             <!-- @{argLine} injects the JaCoCo agent when coverage is enabled;
                  see the maven-surefire-plugin configuration below for details. -->
             <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
+            <!-- maven-failsafe-plugin 3.6.0 dropped the ${skipTests} binding on
+                 its own skipTests parameter (SUREFIRE-823), so -DskipTests no
+                 longer skips integration tests. Bind it back, so -DskipTests
+                 means "no tests at all" as it did before. -DskipITs still skips
+                 only the integration tests. -->
+            <skipTests>${skipTests}</skipTests>
           </configuration>
         </plugin>
         <plugin>
@@ -2621,7 +2632,6 @@
             <test.cache.data>${test.cache.data}</test.cache.data>
             <test.build.classes>${project.build.directory}/test-classes</test.build.classes>
 
-            <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
             <java.security.krb5.conf>${project.build.directory}/test-classes/krb5.conf</java.security.krb5.conf>
             <java.security.egd>${java.security.egd}</java.security.egd>
             <require.test.libhadoop>${require.test.libhadoop}</require.test.libhadoop>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -283,6 +283,15 @@
             <artifactId>hadoop-common</artifactId>
         </dependency>
 
+        <!-- TimedOutTestsListener, registered as a surefire listener by the
+             hadoop-yarn parent pom. -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
@@ -167,6 +167,15 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
 
+    <!-- TimedOutTestsListener, registered as a surefire listener by the
+         hadoop-yarn parent pom. -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-annotations</artifactId>


### PR DESCRIPTION
### Description of PR

Upgrades `maven-surefire-plugin` from 3.5.3 to 3.6.0, plus the three changes the new version needs.

3.6.0 is the first release that registers surefire's `listener` property as a JUnit Platform `TestExecutionListener` (SUREFIRE-1639). Eight poms already carry that property for `TimedOutTestsListener`, and on 3.5.3 it does nothing at all. This bump is what lets HADOOP-19964's listener bind, so a timed-out test prints a thread dump again. Until 19964 lands the listener stays dormant — this change is what unblocks it.

**`java.net.preferIPv4Stack` moves into `maven-surefire-plugin.argLine`.** As a `systemPropertyVariable` it is applied only after the forked JVM has started. 3.6.0 initialises the fork's networking before applying those properties, so the flag arrives too late and the fork falls back to IPv6, turning 5 of 7 CI test jobs red; 3.5.3 applies them before any networking class loads, which is why the same configuration works there. As an argLine entry the flag is a real JVM startup argument and cannot be late. All the `<argLine>` overrides in the tree interpolate the property and maven-failsafe-plugin shares it, so it propagates everywhere. `hadoop-registry` carried a second copy of the same ineffective setting; removed.

**`-DskipTests` is restored over the integration tests.** SUREFIRE-823 removed the `${skipTests}` binding from maven-failsafe-plugin's own `skipTests` parameter, so on 3.6.0 `-DskipTests` skips surefire only and failsafe runs regardless. Measured on a plain `mvn install -DskipTests`: `hadoop-client-integration-tests` executed five integration tests including a MiniCluster, and `hadoop-azure` forked its entire ABFS suite. This binds the parameter back in `hadoop-project`, so `-DskipTests` again means no tests at all. `skipITs` is untouched, so `-DskipITs` still skips only integration tests and the `auth-keys.xml` gating in `hadoop-aws`, `hadoop-gcp` and `hadoop-bos` keeps working.

**`hadoop-common`'s test-jar added to `hadoop-yarn-services-core` and `hadoop-yarn-applications-catalog-webapp`.** Both inherit the listener property from `hadoop-yarn` but resolve only `hadoop-common`'s main jar, so the listener class cannot be loaded there and surefire silently drops it.

### How was this patch tested?

WSL2 Ubuntu 24.04, OpenJDK 17, Maven 3.9.16. Full reactor build clean.

Full suites on the modules this touches, all green: `hadoop-registry` (164 tests), `hadoop-yarn-services-core` (145), `hadoop-yarn-applications-catalog-webapp` (5).

`hadoop-common` full suite run against unpatched trunk at the same commit as a control: every failure reproduces on the baseline, and the two that did not pass on rerun. No new failures.

The tests that fail when 3.6.0 is bumped without the argLine fix all pass: `TestDNS`, `TestNameNodeRpcServer`, `TestBlockRecovery2`, `TestWebHdfsTokens`, `TestHSAdminServer`.

Skip semantics verified on `hadoop-azure`, `hadoop-aws` and `hadoop-client-integration-tests`: with the fix, `-DskipTests` skips both surefire and failsafe in all three; without it, the first and third ran integration tests.

### Notes on 3.6.0

3.6.0 removes the legacy `surefire-junit3`/`junit4`/`junit47`/`testng` providers. The tree has no JUnit 4 or TestNG tests and pins no provider, so this does not apply. Checked and unaffected: stack-trace handling (reimplemented upstream, but output is identical with `trimStackTrace=false`), `@Nested` selection, `@Suite` flake classification, `runOrder`, and rerun handling under `-Dsurefire.rerunFailingTestsCount=2`.

Three reporting changes, none needing infrastructure work:

- `<testsuite>` gains a `flakes` attribute.
- A failure in `@AfterAll`/`@AfterClass` is reported as `<class>.executionError`; on 3.5.3 it produced an empty testcase name.
- Assumption-skipped tests are counted where 3.5.3 reported zero, which raises `hadoop-common`'s skip count by 40 (two OpenSSL codec classes).

Yetus is unaffected: its `junit.sh` takes failed-test names from the report filename and greps `<failure|<error` at file level, so it reads none of these. `dorny/test-reporter` in `report_cloud_aws.yml` does publish skipped counts, which will rise.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>" where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy https://www.apache.org/legal/generative-tooling.html

Contains content generated by Claude Code.
