### PR TITLE
HADOOP-19980. Document non-interactive start-build-env.sh usage and refresh build docs.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,22 @@
 
 This file orients automated and AI-assisted tools working in the Apache Hadoop repository.
 
+## Building and testing
+
+Ask the user before running Maven or tests directly on the host. Pure Java changes and
+tests with no native library requirement are fine to run on the host. For anything that
+needs the native profile or `-Drequire.*` libraries, prefer the Docker build environment
+from `start-build-env.sh`, which is the image Hadoop CI uses; [BUILDING.txt](BUILDING.txt)
+documents it, including the non-interactive form:
+
+```
+DOCKER_INTERACTIVE_RUN= ./start-build-env.sh ubuntu_24 <command> [args...]
+```
+
+- Without `-Dmaven.test.failure.ignore=false` (`hadoop-project/pom.xml` sets it to `true`),
+  Maven exits 0 even when Java tests fail. Check the result from
+  `<module>/target/surefire-reports/` or the `Tests run: ..., Failures: ...` line.
+
 ## Security
 
 Before investigating, reporting, or acting on any security issue in this repository, you

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -48,21 +48,24 @@ On Linux / Mac:
 The prompt which is then presented is located at a mounted version of the source tree
 and all required tools for testing and building have been installed and configured.
 
+The script can also run a single command instead of an interactive shell. Any
+arguments after the OS platform are executed inside the container, at the root of
+the mounted source tree, as the invoking user. Set DOCKER_INTERACTIVE_RUN to an
+empty string to drop the '-i -t' flags, so no TTY is needed and the script exits
+with the command's status:
+
+    $ DOCKER_INTERACTIVE_RUN= ./start-build-env.sh ubuntu_24 \
+        mvn -pl hadoop-common-project/hadoop-common test -Dtest=TestIPC
+
+The source tree and ~/.m2 are bind-mounted, so build output and surefire reports
+appear in the host tree and dependencies are downloaded once. The container is
+named 'hadoop-build_<OS platform>', so only one can run at a time; remove a stale
+one with 'docker rm -f hadoop-build_<OS platform>'.
+
 Note that from within this docker environment you ONLY have access to the Hadoop source
 tree from where you started. So if you need to run
     dev-support/bin/test-patch /path/to/my.patch
 then the patch must be placed inside the hadoop source tree.
-
-Known issues:
-- On Mac with Boot2Docker the performance on the mounted directory is currently extremely slow.
-  This is a known problem related to boot2docker on the Mac.
-  See:
-    https://github.com/boot2docker/boot2docker/issues/593
-  This issue has been resolved as a duplicate, and they point to a new feature for utilizing NFS mounts
-  as the proposed solution:
-    https://github.com/boot2docker/boot2docker/issues/64
-  An alternative solution to this problem is to install Linux native inside a virtual machine
-  and run your IDE and Docker etc inside that VM.
 
 ----------------------------------------------------------------------------------
 Installing required packages for clean install of Ubuntu 24.04 LTS Desktop.
@@ -418,6 +421,7 @@ Available package profiles:
   hadoop-aliyun-package
   hadoop-aws-package
   hadoop-azure-datalake-package
+  hadoop-bos-package
   hadoop-cos-package
   hadoop-gcp-package
   hadoop-huaweicloud-package
@@ -429,6 +433,7 @@ mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true \
  -Dhadoop-aliyun-package \
  -Dhadoop-aws-package \
  -Dhadoop-azure-datalake-package \
+ -Dhadoop-bos-package \
  -Dhadoop-cos-package \
  -Dhadoop-gcp-package \
  -Dhadoop-huaweicloud-package \
@@ -436,7 +441,7 @@ mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true \
 
 The resulting tar file will be too large to be distributable through ASF infrastructure.
 
-The hadoop-gcp and hadoop-tos artifacts include their dependencies as shaded
+The hadoop-bos, hadoop-gcp and hadoop-tos artifacts include their dependencies as shaded
 artifacts unless the distribution is built with -DskipShade.
 
 ----------------------------------------------------------------------------------

--- a/dev-support/docker/hadoop_env_checks.sh
+++ b/dev-support/docker/hadoop_env_checks.sh
@@ -100,9 +100,8 @@ function warnIfLowMemory {
 Your system is running on very little memory.
 This means it may work but it wil most likely be slower than needed.
 
-If you are running this via boot2docker you can simply increase
-the available memory to at least ${MINIMAL_MEMORY}KiB
-(you have ${INSTALLED_MEMORY}KiB )
+Suggest increasing the available memory to at least ${MINIMAL_MEMORY}KiB
+(you have ${INSTALLED_MEMORY}KiB)
 
 End-of-message
     fi


### PR DESCRIPTION
### Description of PR

Documentation only.

- Document the non-interactive form of `start-build-env.sh`, so a single command
  can be run in the CI image without a TTY.
- Add build and test guidance for AI agents to `AGENTS.md`.
- Drop all references to Boot2Docker. It is ancient technology, nobody uses it today.
- Add `hadoop-bos-package` (HDFS-11161) to the packaging section, which missed it.

### How was this patch tested?

Docs only. The documented commands were verified on macOS arm64 with the `ubuntu_24`
image.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: not applicable.
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? None added.
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files? Not applicable.

### AI Tooling

Contains content generated by Claude Code.

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
