### PR TITLE
HADOOP-19986. MiniDFSCluster.shutdownDataNodes() should signal all DataNodes before joining any

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockPoolManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockPoolManager.java
@@ -110,10 +110,20 @@ class BlockPoolManager {
     }
   }
   
-  void shutDownAll(List<BPOfferService> bposList) throws InterruptedException {
+  /**
+   * Signal the services to stop without joining them. This is the first half
+   * of {@link #shutDownAll}, split out so a caller shutting down several
+   * DataNodes in one JVM can signal them all before joining any. stop() is
+   * idempotent, so shutDownAll may still be called afterwards.
+   */
+  void signalShutDownAll(List<BPOfferService> bposList) {
     for (BPOfferService bpos : bposList) {
       bpos.stop(); //interrupts the threads
     }
+  }
+
+  void shutDownAll(List<BPOfferService> bposList) throws InterruptedException {
+    signalShutDownAll(bposList);
     //now join
     for (BPOfferService bpos : bposList) {
       bpos.join();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2236,6 +2236,31 @@ public class DataNode extends ReconfigurableBase
     return blockPoolManager.getAllNamenodeThreads();
   }
 
+  /**
+   * Signal every block pool service to stop, without waiting for its threads
+   * to exit, so that a caller shutting down several DataNodes in one JVM can
+   * signal them all before joining any of them. A later {@code shutdown()} on
+   * this DataNode still does the joining; {@code stop()} is idempotent.
+   *
+   * <p>Joining one DataNode while the others still run can hang: DataNodes in
+   * a single JVM share an {@link org.apache.hadoop.ipc.Client} through
+   * ClientCache, so they share its per-address Connection objects too. A
+   * BPServiceActor that is still retrying a dead NameNode holds that
+   * Connection's monitor across its connect-retry sleeps, and an actor of the
+   * DataNode being shut down can sit BLOCKED on that monitor. A BLOCKED thread
+   * cannot observe the interrupt that {@code stop()} sends, so the join waits
+   * for as long as the surviving DataNodes keep re-acquiring the monitor.
+   * Signalling everyone first lets the holder abort its sleep and release it.
+   */
+  @VisibleForTesting
+  public void signalBlockPoolShutdown() {
+    if (blockPoolManager == null) {
+      return;
+    }
+    blockPoolManager.signalShutDownAll(
+        blockPoolManager.getAllNamenodeThreads());
+  }
+
   BPOfferService getBPOfferService(String bpid){
     return blockPoolManager.get(bpid);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -2218,6 +2218,20 @@ public class MiniDFSCluster implements AutoCloseable {
    * is left running so that new DataNodes may be started.
    */
   public void shutdownDataNodes() {
+    // Signal every DataNode before joining any of them. Shutting them down one
+    // at a time -- stop, join, next -- lets the DataNodes not yet reached keep
+    // hammering a NameNode the test has already killed. Because DataNodes in
+    // one JVM share an ipc.Client, and so its Connection objects, a surviving
+    // DataNode's BPServiceActor can hold a Connection monitor across its
+    // connect-retry sleeps while an actor of the DataNode being joined sits
+    // BLOCKED on it. Interrupts do not reach a BLOCKED thread, so the join
+    // waits on scheduling luck: it has been measured at 165s, overrunning the
+    // test's timeout. See DataNode#signalBlockPoolShutdown.
+    for (DataNodeProperties dnProp : dataNodes) {
+      if (dnProp.datanode != null) {
+        dnProp.datanode.signalBlockPoolShutdown();
+      }
+    }
     for (int i = dataNodes.size()-1; i >= 0; i--) {
       shutdownDataNode(i);
     }


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HADOOP-19986

`MiniDFSCluster.shutdownDataNodes()` tears DataNodes down strictly serially - stop one, join it, move to the next. The DataNodes not yet reached keep retrying a NameNode the test has already killed.

DataNodes in a single JVM share an `ipc.Client` through `ClientCache`, and therefore share its per-address `Connection` objects. A surviving DataNode's `BPServiceActor` holds a `Connection` monitor across its connect-retry sleeps in `handleConnectionFailure`, while an actor of the DataNode being joined sits BLOCKED on that same monitor in `Client.addCall`. `Thread.interrupt()` cannot dislodge a BLOCKED thread, so the `stop()` issued by `BlockPoolManager.shutDownAll` is ineffective and the join waits on scheduling luck: the holder releases and re-acquires roughly every 2s, and unfair monitors starve the blocked thread.

Measured on a 2-core runner: DataNode 2 took 165s to shut down, after which DN1 and DN0 finished in ~10ms. That overran the 180s timeout of `TestBalancerWithHANameNodes#testBalancerWithObserverWithFailedNode`, and runs that stayed under the deadline still burned ~115s in teardown.

The fix signals every DataNode before joining any, so the monitor holder aborts its sleep and releases it:

1. `BlockPoolManager#signalShutDownAll` - the stop-without-join half of the existing `shutDownAll`, which now delegates to it.
2. `DataNode#signalBlockPoolShutdown` - `@VisibleForTesting`, null-safe, signals every block pool service without waiting.
3. `MiniDFSCluster#shutdownDataNodes` - signals all DataNodes up front, then runs the existing per-DataNode shutdown loop unchanged.

`stop()` is idempotent, so the per-DataNode shutdown path behaves exactly as before; the only change is that the interrupts now all land before the first join.

### How was this patch tested?

20 runs of `TestBalancerWithHANameNodes#testBalancerWithObserverWithFailedNode` on a 2-core runner. Before: 4 of 20 anomalous (182.3s, 181.3s, 116.7s, 113.9s). After: 20 of 20 passed within 44-48s.

Full CI on the fork, all jobs green - `common`, `hdfs - other`, `hdfs - slow`, `hdfs-rbf`, `mr`, `other`, `yarn-server-rm` on Java 17, plus build-only on Java 21 and Java 25:
https://github.com/joseluisll/hadoop/actions/runs/34147776139

That run was on commit `1700e04b`; this branch has since been rebased onto current trunk with no change to the patch itself.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by Claude Code.
