### PR TITLE
HADOOP-19987. ObserverReadProxyProvider's probing pool blocks when saturated instead of rejecting

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -26,10 +26,14 @@ import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.List;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -51,7 +55,7 @@ import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RpcInvocationHandler;
 import org.apache.hadoop.ipc.StandbyException;
-import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,8 +189,36 @@ public class ObserverReadProxyProvider<T>
 
   /**
    * Threadpool to send the getHAServiceState requests.
+   *
+   * <p>This must be an executor that <em>rejects</em> work once saturated
+   * rather than blocking the submitter: {@link #getHAServiceStateWithTimeout}
+   * relies on {@link RejectedExecutionException} to fall back to the active
+   * NameNode. See the constructor for why.
    */
-  private final BlockingThreadPoolExecutorService nnProbingThreadPool;
+  private final ExecutorService nnProbingThreadPool;
+
+  /** Threads kept by {@link #nnProbingThreadPool}. */
+  @VisibleForTesting
+  static final int PROBING_POOL_THREADS = 4;
+
+  /** Depth of the queue backing {@link #nnProbingThreadPool}. */
+  @VisibleForTesting
+  static final int PROBING_POOL_QUEUE_CAPACITY = 128;
+
+  /**
+   * Tasks the pool accepts before {@code submit()} starts rejecting: the
+   * threads that can be busy plus the queue behind them.
+   */
+  @VisibleForTesting
+  static final int PROBING_POOL_CAPACITY =
+      PROBING_POOL_THREADS + PROBING_POOL_QUEUE_CAPACITY;
+
+  /**
+   * Distinguishes the probing pools of the several proxy providers a single
+   * JVM may hold, one per nameservice, so that a thread dump says which one a
+   * thread belongs to.
+   */
+  private static final AtomicInteger PROBING_POOL_NUMBER = new AtomicInteger(1);
 
   /**
    * By default ObserverReadProxyProvider uses
@@ -252,13 +284,31 @@ public class ObserverReadProxyProvider<T>
     }
 
     /*
-     * At most 4 threads will be running and each thread will die after 10
-     * seconds of no use. Up to 132 tasks (4 active + 128 waiting) can be
-     * submitted simultaneously.
+     * At most PROBING_POOL_THREADS threads will be running and each thread
+     * will die after 10 seconds of no use. Up to PROBING_POOL_CAPACITY tasks
+     * (active + waiting) can be submitted simultaneously; past that submit()
+     * throws RejectedExecutionException and the caller falls back to the
+     * active NN.
+     *
+     * This deliberately does not use BlockingThreadPoolExecutorService. That
+     * one wraps the pool in a SemaphoredDelegatingExecutor whose submit()
+     * blocks on queueingPermits.acquire() instead of rejecting, so it can
+     * never throw RejectedExecutionException. The saturation fallback below
+     * was therefore unreachable, and a caller that should have been shed onto
+     * the active NN was instead parked -- while holding this provider's
+     * monitor, since changeProxy() is synchronized.
      */
-    nnProbingThreadPool =
-        BlockingThreadPoolExecutorService.newInstance(4, 128, 10L, TimeUnit.SECONDS,
-            "nn-ha-state-probing");
+    ThreadPoolExecutor probingPool = new ThreadPoolExecutor(
+        PROBING_POOL_THREADS, PROBING_POOL_THREADS, 10L, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<Runnable>(PROBING_POOL_QUEUE_CAPACITY),
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("nn-ha-state-probing-pool"
+                + PROBING_POOL_NUMBER.getAndIncrement() + "-t%d")
+            .build());
+    // Match the previous behaviour of retiring idle threads after 10s.
+    probingPool.allowCoreThreadTimeOut(true);
+    nnProbingThreadPool = probingPool;
   }
 
   public AlignmentContext getAlignmentContext() {
@@ -327,6 +377,15 @@ public class ObserverReadProxyProvider<T>
         initial == null ? "none" : initial.proxyInfo,
         currentProxy.proxyInfo);
     return currentProxy;
+  }
+
+  /**
+   * The pool the HA state probes are submitted to. Exposed so a test can fill
+   * it and assert that the next submit is rejected rather than parked.
+   */
+  @VisibleForTesting
+  ExecutorService getNnProbingThreadPool() {
+    return nnProbingThreadPool;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -26,11 +26,16 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
@@ -56,6 +61,7 @@ import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 import static org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -76,6 +82,8 @@ public class TestObserverReadProxyProvider {
   private final static long SLOW_RESPONSE_SLEEP_TIME = TimeUnit.SECONDS.toMillis(5); // 5 s
   private final static long NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT = TimeUnit.SECONDS.toMillis(2);
   private final static long NAMENODE_HA_STATE_PROBE_TIMEOUT_LONG = TimeUnit.SECONDS.toMillis(25);
+  /** Generous: this only has to be shorter than the @Timeout that backstops it. */
+  private final static long SATURATED_SUBMIT_DEADLINE_MS = TimeUnit.SECONDS.toMillis(20);
   private final GenericTestUtils.LogCapturer proxyLog =
       GenericTestUtils.LogCapturer.captureLogs(ObserverReadProxyProvider.LOG);
 
@@ -519,6 +527,106 @@ public class TestObserverReadProxyProvider {
     namenodeAnswers[3].setObserverState();
 
     doRead();
+  }
+
+  /**
+   * The probing pool must reject work once it is full instead of parking the
+   * submitter. {@link ObserverReadProxyProvider#getHAServiceStateWithTimeout}
+   * catches {@link RejectedExecutionException} to fall back to the active
+   * NameNode, so an executor that blocks in submit() makes that fallback
+   * unreachable -- and parks the caller while it holds the provider's monitor,
+   * since the probe is reached through the synchronized changeProxy().
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testProbingPoolRejectsOnceSaturated() throws Exception {
+    setupProxyProvider(1);
+    CountDownLatch release = new CountDownLatch(1);
+    ExecutorService pool = proxyProvider.getNnProbingThreadPool();
+    try {
+      fillProbingPool(pool, release);
+      Throwable thrown = runWithDeadline(() -> pool.submit(() -> null),
+          SATURATED_SUBMIT_DEADLINE_MS, "submit past capacity");
+      assertTrue(thrown instanceof RejectedExecutionException,
+          "submit past capacity should be rejected, but threw " + thrown);
+    } finally {
+      release.countDown();
+    }
+  }
+
+  /**
+   * With the pool saturated, the HA state probe must give up and return null
+   * so the caller falls back to the active NameNode.
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testFallsBackToActiveWhenProbingPoolSaturated() throws Exception {
+    proxyLog.clearOutput();
+    setupProxyProvider(1);
+    CountDownLatch release = new CountDownLatch(1);
+    ExecutorService pool = proxyProvider.getNnProbingThreadPool();
+    try {
+      fillProbingPool(pool, release);
+      @SuppressWarnings("unchecked")
+      NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+          (NNProxyInfo<ClientProtocol>) mock(NNProxyInfo.class);
+      AtomicReference<HAServiceState> state = new AtomicReference<>();
+      Throwable thrown = runWithDeadline(() -> {
+        state.set(proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo));
+        return null;
+      }, SATURATED_SUBMIT_DEADLINE_MS, "HA state probe on a saturated pool");
+      assertNull(thrown, "probe should not propagate " + thrown);
+      assertNull(state.get(),
+          "a saturated pool should yield no state, so the caller uses the active NN");
+      assertTrue(proxyLog.getOutput().contains(
+          "Run out of threads to submit the request to query HA state"),
+          "expected the fallback to be logged");
+    } finally {
+      release.countDown();
+      proxyLog.clearOutput();
+    }
+  }
+
+  /**
+   * Occupy every slot the probing pool has: PROBING_POOL_THREADS tasks parked
+   * on the latch plus PROBING_POOL_QUEUE_CAPACITY behind them. Tasks go
+   * straight to a worker while the pool is below its core size, so the split
+   * between running and queued is deterministic.
+   */
+  private static void fillProbingPool(ExecutorService pool,
+      CountDownLatch release) {
+    for (int i = 0; i < PROBING_POOL_CAPACITY; i++) {
+      pool.submit(() -> {
+        release.await();
+        return null;
+      });
+    }
+  }
+
+  /**
+   * Run {@code action} on another thread and return what it threw, failing if
+   * it has not finished within {@code timeoutMs}. The regression being guarded
+   * against is a submit() that never returns; a bare @Timeout would catch that
+   * too, but reports only "timed out after N seconds" without naming the call
+   * that hung.
+   */
+  private static Throwable runWithDeadline(Callable<?> action, long timeoutMs,
+      String what) throws InterruptedException {
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    Thread runner = new Thread(() -> {
+      try {
+        action.call();
+      } catch (Throwable t) {
+        thrown.set(t);
+      }
+    }, "deadline-" + what);
+    runner.setDaemon(true);
+    runner.start();
+    runner.join(timeoutMs);
+    assertFalse(runner.isAlive(),
+        what + " did not return within " + timeoutMs
+            + "ms: it blocked instead of failing fast");
+    return thrown.get();
   }
 
   private void doRead() throws Exception {


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HADOOP-19987

`getHAServiceStateWithTimeout` catches `RejectedExecutionException` to fall back to the active NameNode, but that fallback is unreachable: the probing pool was a `BlockingThreadPoolExecutorService`, whose `submit()` blocks on a semaphore instead of rejecting. A caller that should have been shed onto the active NN is parked instead — while holding the provider's monitor, since the probe runs inside the `synchronized changeProxy()`.

Latent today: the only production caller is inside `changeProxy()`, so there is at most one probe in flight per provider. Reaching saturation needs `dfs.client.failover.namenode.ha-state.probe.timeout` set above its `0` default plus probes that don't return on interrupt — but when it happens the monitor is held forever.

Fix: use a plain `ThreadPoolExecutor` with the same shape (4 threads, 128-deep queue, 10s idle timeout, daemon threads) and the default `AbortPolicy`. Capacity is unchanged at 132; the field type widens to `ExecutorService`. Thread names keep the `nn-ha-state-probing-pool<N>-t<M>` shape, with the per-thread counter now starting at `t0` and `<N>` counting probing pools alone.

### How was this patch tested?

Two new tests in `TestObserverReadProxyProvider`, each running the call under test on its own thread with an explicit deadline so a hang names the stuck call:

- `testProbingPoolRejectsOnceSaturated` — `submit()` past capacity throws instead of blocking.
- `testFallsBackToActiveWhenProbingPoolSaturated` — the HA-state probe returns and falls back to the active NN.

Both fail against the old pool, blocking for the full 20s deadline.

Full CI green on the fork (`common`, `hdfs - other`, `hdfs - slow`, `hdfs-rbf`, `mr`, `other`, `yarn-server-rm` on Java 17; build-only on Java 21 and 25): https://github.com/joseluisll/hadoop/actions/runs/34147776162

`common` needed a rerun for `TestZKDelegationTokenSecretManager#testNodesLoadedAfterRestart`, an unrelated pre-existing flake in `hadoop-common`; this patch only touches `hadoop-hdfs-client`.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

Contains content generated by Claude Code.
