### PR TITLE
HADOOP-19982. Re-enable TestDFSClientRetries and TestBalancerWithHANameNodes in GHA

### DIFF
--- a/.github/gha-tests/exclude-tests.txt
+++ b/.github/gha-tests/exclude-tests.txt
@@ -27,7 +27,6 @@
 **/org/apache/hadoop/hdfs/TestDecommission.java
 **/org/apache/hadoop/hdfs/TestDecommissionWithBackoffMonitor.java
 **/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
-**/org/apache/hadoop/hdfs/TestDFSClientRetries.java
 **/org/apache/hadoop/hdfs/TestDFSUtil.java
 **/org/apache/hadoop/hdfs/TestFileCreation.java
 **/org/apache/hadoop/hdfs/TestMaintenanceState.java
@@ -39,7 +38,6 @@
 **/org/apache/hadoop/hdfs/client/impl/TestBlockReaderLocal.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
-**/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
 **/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
 **/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFSStriped.java

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -694,6 +694,21 @@ class DataStreamer extends Daemon {
    */
   @Override
   public void run() {
+    try {
+      runLoop();
+    } finally {
+      // Whatever ends this thread -- a normal exit, or a Throwable that
+      // escapes the handler in runLoop(), such as the AssertionError the
+      // NullPointerException assertion raises -- closeInternal() has to run.
+      // It is what sets streamerClosed and wakes waitForAckedSeqno; without
+      // it a writer blocked in close() keeps waiting on a thread that no
+      // longer exists, until the datanode write timeout expires minutes
+      // later.
+      closeInternal();
+    }
+  }
+
+  private void runLoop() {
     TraceScope scope = null;
     while (!streamerClosed && dfsClient.clientRunning) {
       // if the Responder encountered an error, shutdown Responder
@@ -873,7 +888,6 @@ class DataStreamer extends Daemon {
         }
       }
     }
-    closeInternal();
   }
 
   private void waitForAllAcks() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSClientRetries.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSClientRetries.java
@@ -1301,6 +1301,19 @@ public class TestDFSClientRetries {
 
       doAnswer(new SleepFixedTimeAnswer(1500, testLatch)).when(spyNN).complete(
           anyString(), anyString(), any(ExtendedBlock.class), anyLong());
+      // Stub renewLease here, on the test thread, while nothing else is
+      // calling the spy. Mockito keeps its doAnswer-style stubbing state on
+      // the mock rather than per thread, so stubbing a spy that other threads
+      // are calling lets one of their invocations consume this stubbing:
+      // that call returns null without running the real method, and the
+      // SocketTimeoutException lands on whichever method it happened to be.
+      // Both outcomes were observed here -- the streamer's addBlock returning
+      // null, and an AssertionError raised inside Mockito on that same call.
+      // renewLease() is a no-op until a file is being written, so stubbing it
+      // before the client exists does not change what this test exercises:
+      // the renewer still fails on its first renewal after out1 is created.
+      Mockito.doThrow(new SocketTimeoutException()).when(spyNN)
+          .renewLease(anyString(), any());
       DFSClient client = new DFSClient(null, spyNN, conf, null);
       // Get hold of the lease renewer instance used by the client
       LeaseRenewer leaseRenewer = client.getLeaseRenewer();
@@ -1309,20 +1322,9 @@ public class TestDFSClientRetries {
 
       out1.write(new byte[256]);
 
-      Thread closeThread = new Thread(new Runnable() {
-        @Override public void run() {
-          try {
-            //1. trigger get LeaseRenewer lock
-            Mockito.doThrow(new SocketTimeoutException()).when(spyNN)
-                .renewLease(Mockito.anyString(), any());
-          } catch (IOException e) {
-            e.printStackTrace();
-          }
-        }
-      });
-      closeThread.start();
-
-      //2. trigger get DFSOutputStream lock
+      // The renewer is now failing its renewals and taking the LeaseRenewer
+      // monitor into the fault injector; close() needs that monitor to end the
+      // file lease.
       out1.close();
 
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
@@ -22,6 +22,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CreateFlag;
@@ -51,10 +53,12 @@ import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.hdfs.protocol.datatransfer.BlockConstructionStage;
 import org.apache.hadoop.hdfs.protocol.datatransfer.PacketHeader;
 import org.apache.hadoop.hdfs.protocol.datatransfer.PacketReceiver;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
+import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
@@ -68,10 +72,13 @@ import org.junit.jupiter.api.Timeout;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -575,4 +582,68 @@ public class TestDFSOutputStream {
       return closed;
     }, 1000, 5000);
   }
+
+  /**
+   * A DataStreamer that ends without running closeInternal() leaves
+   * streamerClosed false and leaves nobody to notify dataQueue, so a writer
+   * parked in waitForAckedSeqno waits on a thread that no longer exists. The
+   * wait is bounded only by the datanode write timeout, which is
+   * dfs.datanode.socket.write.timeout plus 5s per node -- 495s with the
+   * defaults, since the pipeline is not up yet and the node count falls back
+   * to three.
+   *
+   * addBlock() returning null drives the streamer into a NullPointerException
+   * in setupPipelineForCreate(). With assertions enabled, Surefire's default,
+   * the assertion in run()'s own handler then raises AssertionError from
+   * inside the error handling. Whichever way the thread ends, the writer has
+   * to be released promptly and told what went wrong.
+   */
+  @Test
+  @Timeout(value = 60)
+  public void testWriterIsReleasedWhenStreamerDies() throws Exception {
+    NamenodeProtocols spyNN = spy(cluster.getNameNodeRpc());
+    doReturn((LocatedBlock) null).when(spyNN).addBlock(anyString(),
+        anyString(), any(), any(), anyLong(), any(), any());
+
+    DFSClient client =
+        new DFSClient(null, spyNN, cluster.getConfiguration(0), null);
+    Thread closer = null;
+    try {
+      final OutputStream out =
+          client.create("/testWriterIsReleasedWhenStreamerDies", false);
+      out.write(new byte[256]);
+
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      closer = new Thread(() -> {
+        try {
+          out.close();
+        } catch (Throwable t) {
+          failure.set(t);
+        }
+      }, "closer");
+      closer.setDaemon(true);
+      closer.start();
+      closer.join(30000);
+
+      assertFalse(closer.isAlive(),
+          "close() was still blocked 30s after the streamer died. A streamer "
+              + "that ends without closeInternal() never sets streamerClosed "
+              + "and never notifies dataQueue, stranding the writer in "
+              + "waitForAckedSeqno until the datanode write timeout expires.");
+      assertNotNull(failure.get(),
+          "close() returned without reporting the failure that killed the "
+              + "streamer");
+    } finally {
+      // Drop the failed stream's lease, but only once the writer is out of
+      // close(): while it is blocked there it holds the DFSOutputStream
+      // monitor, and abort() takes that same monitor, so cleaning up would
+      // block too and turn a clear assertion failure into a hung fork.
+      // client.close() is not usable here either: it ends by stopping the
+      // namenode proxy, and this client was handed a Mockito spy.
+      if (closer == null || !closer.isAlive()) {
+        client.closeAllFilesBeingWritten(true);
+      }
+    }
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -296,8 +296,14 @@ public class TestBalancerWithHANameNodes {
    * the results should be the same.
    */
   @Test
-  @Timeout(value = 60)
+  @Timeout(value = 180)
   public void testGetLiveDatanodeStorageReport() throws Exception {
+    // 180s, not 60s: standing up the HA topology and its datanodes is the
+    // dominant cost here and is what stalls on a loaded CI agent, and 60s
+    // left no margin for that bring-up alone. 180s is the largest budget
+    // already used by the observer tests in this class, which do
+    // comparable cluster work; it is a precautionary ceiling, not a
+    // measured requirement.
     Configuration conf = new HdfsConfiguration();
     TestBalancer.initConf(conf);
     assertEquals(TEST_CAPACITIES.length, TEST_RACKS.length);


### PR DESCRIPTION
### Description of PR

Removes `TestDFSClientRetries` and `TestBalancerWithHANameNodes` from
`.github/gha-tests/exclude-tests.txt`. Both were excluded before the fixes for
their failure modes landed:

- **TestDFSClientRetries** — HDFS-17972 bounded the `DFSClientFaultInjector`
  latch wait and restores the previous injector in a `finally`, so a dying
  `testLeaseRenewAndDFSOutputStreamDeadLock` no longer hangs the rest of the class.
- **TestBalancerWithHANameNodes** — HDFS-17957 raised the two 60s timeouts to 300s and dropped the dead code pinning the default NameNode RPC port. 

This PRalso raises:
 - `testGetLiveDatanodeStorageReport`, the one method still on the
  original 60s budget, to 180s.
- ` TestDFSClientRetries#testLeaseRenewAndDFSOutputStreamDeadLock` from 120s to 300s.

### How was this patch tested?

Full GHA build on the branch: https://github.com/joseluisll/hadoop/actions/runs/34113842050 — all jobs green.Both classes run in the `hdfs - other` matrix entry, which passed.

Per `.github/gha-tests/README.md`, removals need 5 consecutive successful GHA
runs before they are considered stable; this is 1 of 5.

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id?

### AI Tooling

Contains content generated by Claude Code.

- [x] The PR includes the phrase "Contains content generated by <tool>".
- [x] My use of AI contributions follows the ASF legal policy https://www.apache.org/legal/generative-tooling.html