### PR TITLE
YARN-11991. Fix counting virtual memory in cgroup v2

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsResourceCalculator.java
@@ -58,19 +58,16 @@ public abstract class AbstractCGroupsResourceCalculator extends ResourceCalculat
 
   private final List<String> totalJiffiesKeys;
   private final String rssMemoryKey;
-  private final String virtualMemoryKey;
 
   protected AbstractCGroupsResourceCalculator(
       String pid,
       List<String> totalJiffiesKeys,
-      String rssMemoryKey,
-      String virtualMemoryKey
+      String rssMemoryKey
   ) {
     super(pid);
     this.pid = pid;
     this.totalJiffiesKeys = totalJiffiesKeys;
     this.rssMemoryKey = rssMemoryKey;
-    this.virtualMemoryKey = virtualMemoryKey;
   }
 
   @Override
@@ -94,8 +91,27 @@ public abstract class AbstractCGroupsResourceCalculator extends ResourceCalculat
 
   @Override
   public long getVirtualMemorySize(int olderThanAge) {
-    return 1 < olderThanAge ? UNAVAILABLE : getStat(virtualMemoryKey);
+    return 1 < olderThanAge ? UNAVAILABLE : calculateVirtualMemory();
   }
+
+  /**
+   * Calculates the virtual memory size of the process tree.
+   *
+   * The way the virtual memory is derived from the cgroup interface files
+   * differs between cgroup v1 and v2, therefore each implementation provides
+   * its own calculation:
+   * <ul>
+   *   <li>cgroup v1 exposes memory+swap in a single file
+   *   ({@code memory.memsw.usage_in_bytes}).</li>
+   *   <li>cgroup v2 exposes the swap usage separately
+   *   ({@code memory.swap.current}) and it has to be combined with the
+   *   RSS (resident memory ({@code memory.stat#anon})) to obtain the virtual memory size.</li>
+   * </ul>
+   *
+   * @return the virtual memory size in bytes, {@link #UNAVAILABLE} if it
+   *         cannot be calculated.
+   */
+  protected abstract long calculateVirtualMemory();
 
   @Override
   public String getProcessTreeDump() {
@@ -157,7 +173,7 @@ public abstract class AbstractCGroupsResourceCalculator extends ResourceCalculat
     return reduce == 0 ? UNAVAILABLE : reduce;
   }
 
-  private long getStat(String key) {
+  protected long getStat(String key) {
     return Long.parseLong(stats.getOrDefault(key, String.valueOf(UNAVAILABLE)));
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsResourceCalculator.java
@@ -109,9 +109,15 @@ public class CGroupsResourceCalculator extends AbstractCGroupsResourceCalculator
     super(
         pid,
         Arrays.asList(CPU_STAT + "#user", CPU_STAT + "#system"),
-        MEM_STAT,
-        MEMSW_STAT
+        MEM_STAT
     );
+  }
+
+  @Override
+  protected long calculateVirtualMemory() {
+    // In cgroup v1 memory.memsw.usage_in_bytes already accounts for
+    // memory + swap, i.e. the virtual memory of the process tree.
+    return getStat(MEMSW_STAT);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2ResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2ResourceCalculator.java
@@ -110,9 +110,22 @@ public class CGroupsV2ResourceCalculator extends AbstractCGroupsResourceCalculat
     super(
         pid,
         Collections.singletonList(CPU_STAT),
-        MEM_STAT,
-        MEMSW_STAT
+        MEM_STAT
     );
+  }
+
+  @Override
+  protected long calculateVirtualMemory() {
+    // Unlike cgroup v1, cgroup v2 does not expose a combined memory+swap
+    // counter. The virtual memory has to be derived by adding the swap usage
+    // (memory.swap.current) to the resident anonymous memory
+    // (memory.stat#anon).
+    long anon = getStat(MEM_STAT);
+    long swap = getStat(MEMSW_STAT);
+    if (anon == UNAVAILABLE || swap == UNAVAILABLE) {
+      return UNAVAILABLE;
+    }
+    return anon + swap;
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2ResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2ResourceCalculator.java
@@ -87,7 +87,10 @@ public class TestCGroupsV2ResourceCalculator {
 
     assertEquals(333000L, calculator.getCumulativeCpuTime(), 0L);
     assertEquals(22000L, calculator.getRssMemorySize(), 0L);
-    assertEquals(11000L, calculator.getVirtualMemorySize(), 0L);
+    // Virtual memory in cgroup v2 is the resident anonymous memory
+    // (memory.stat#anon = 22000) plus the swap usage
+    // (memory.swap.current = 11000).
+    assertEquals(33000L, calculator.getVirtualMemorySize(), 0L);
     assertEquals(-1L, calculator.getRssMemorySize(2), 0L);
     assertEquals(-1L, calculator.getVirtualMemorySize(2), 0L);
   }


### PR DESCRIPTION
On hosts using cgroup v2, CGroupsV2ResourceCalculator#getVirtualMemorySize()
returns only the swap usage (memory.swap.current) instead of the real
virtual memory of the container process tree.

AbstractCGroupsResourceCalculator takes a single "virtualMemoryKey" and
reads it directly:
```java
getVirtualMemorySize() -> getStat(virtualMemoryKey)
```
This is correct for cgroup v1, where memory.memsw.usage_in_bytes already
contains memory + swap in one counter.

cgroup v2 has no combined memory+swap counter. The v2 calculator maps
MEMSW_STAT to memory.swap.current, which is swap usage only. The resident
part (memory.stat#anon) is never added, so the reported virtual memory is
much lower than reality.