### PR TITLE
HADOOP-19988: Register /mapreduce/app in MR AM tracking URL

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebApp.java
@@ -42,6 +42,7 @@ public class AMWebApp extends WebApp implements AMParams {
     route("/", AppController.class);
     route("/app", AppController.class);
     route("/mapreduce", AppController.class);
+    route("/mapreduce/app", AppController.class, "index");
     route(pajoin("/job", JOB_ID), AppController.class, "job");
     route(pajoin("/conf", JOB_ID), AppController.class, "conf");
     route(pajoin("/jobcounters", JOB_ID), AppController.class, "jobCounters");
@@ -59,5 +60,10 @@ public class AMWebApp extends WebApp implements AMParams {
   @Override
   protected Class<? extends Filter> getWebAppFilterClass() {
     return null;
+  }
+
+  @Override
+  public String getRedirectPath() {
+    return "/mapreduce/app";
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUriUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUriUtils.java
@@ -86,6 +86,18 @@ public class TestProxyUriUtils {
 
 
   @Test
+  void testGetProxyUriWithWebAppPath() throws Exception {
+    URI originalUri = new URI("http://host.com:13562/mapreduce/app");
+    URI proxyUri = new URI("http://proxy.net:8080/");
+    ApplicationId id = BuilderUtils.newApplicationId(6384623L, 5);
+    URI expected = new URI(
+        "http://proxy.net:8080/proxy/application_6384623_0005/mapreduce/app");
+    URI result = ProxyUriUtils.getProxyUri(originalUri, proxyUri, id);
+    assertEquals(expected, result);
+  }
+
+
+  @Test
   void testGetProxyUriNull() throws Exception {
     URI originalUri = null;
     URI proxyUri = new URI("http://proxy.net:8080/");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
On the YARN UI clicking on the application tracking URL results in 404; Appending /mapreduce/app at the end of URL will render to the correct page.

### How was this patch tested?
tested patch manually 

### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

