### PR TITLE
Upgrade JLine to 3.30.14 to fix CVE-2026-56740 and CVE-2026-56741

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -480,7 +480,7 @@ com.thoughtworks.paranamer:paranamer:2.3
 jakarta.activation:jakarta.activation-api:1.2.1
 org.checkerframework:checker-qual:3.49.0
 org.fusesource.leveldbjni:leveldbjni-all:1.8
-org.jline:jline:3.9.0
+org.jline:jline:3.30.14
 org.hamcrest:hamcrest-core:1.3
 org.ow2.asm:asm:5.0.4
 org.ow2.asm:asm-commons:6.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -231,7 +231,7 @@
     <junit.jupiter.version>5.13.3</junit.jupiter.version>
     <junit.platform.version>1.13.3</junit.platform.version>
     <assertj.version>3.12.2</assertj.version>
-    <jline.version>3.9.0</jline.version>
+    <jline.version>3.30.14</jline.version>
     <mockito.version>4.11.0</mockito.version>
     <solr.version>8.11.2</solr.version>
     <openssl-wildfly.version>2.2.5.Final</openssl-wildfly.version>


### PR DESCRIPTION
`Note: I don't have an ASF Jira account yet - a request is pending via the self-serve portal, so this PR isn't linked to a HADOOP issue. Happy to file one and rename the PR as soon as the account is approved; equally happy for a committer to file and link it if that's easier.`

Hadoop pins the org.jline:jline uber jar at 3.9.0. That jar bundles the jline-remote-telnet classes, which are affected by two high-severity denial-of-service issues:

* [CVE-2026-56740](https://github.com/advisories/GHSA-47qp-hqvx-6r3f) - the Telnet server does not limit the number of environment variables a client may inject via the NEW-ENVIRON option, so an unauthenticated client can exhaust the JVM heap.
* [CVE-2026-56741](https://github.com/advisories/GHSA-2r2c-cx56-8933) - the Telnet server does not bound terminal dimensions received via the NAWS option, so an unauthenticated client can force continuous expensive rendering work and exhaust CPU.

Both are fixed in JLine 3.30.14, 4.0.16 and 4.2.1. This moves the pinned version to 3.30.14, staying on the 3.x line to avoid the API changes that come with the 4.x major.

No Hadoop code starts a JLine Telnet server, so the vulnerable classes were never reachable at runtime; the upgrade removes them from the distribution so the artifacts no longer carry the affected code.

The only consumer of JLine is ContainerShellWebSocket in hadoop-yarn-client, which uses TerminalBuilder, LineReaderBuilder and LineReaderImpl.readCharacter(). All of those keep the same signatures in 3.30.14.

LICENSE-binary is updated to match. JLine remains BSD 3-Clause.

Contains content generated by Claude.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
