### PR TITLE
HDFS-16021. heap-use-after-free in hdfsThreadDestructor

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
@@ -651,9 +651,14 @@ static char* getClassPath()
  * every thread.  You must be holding the jvmMutex when you call this
  * function.
  *
+ * @param[out] attachedByLibhdfs  Set to true if this call attached the current
+ *                                thread to the JVM, false if the thread was
+ *                                already attached by someone else. Only the
+ *                                former may be detached at thread exit.
+ *
  * @return          The JNIEnv on success; error code otherwise
  */
-static JNIEnv* getGlobalJNIEnv(void)
+static JNIEnv* getGlobalJNIEnv(bool *attachedByLibhdfs)
 {
     JavaVM* vmBuf[VM_BUF_LENGTH]; 
     JNIEnv *env;
@@ -672,6 +677,7 @@ static JNIEnv* getGlobalJNIEnv(void)
     JavaVM *vm;
     JavaVMOption *options;
 
+    *attachedByLibhdfs = false;
     rv = JNI_GetCreatedJavaVMs(&(vmBuf[0]), VM_BUF_LENGTH, &noVMs);
     if (rv != 0) {
         fprintf(stderr, "JNI_GetCreatedJavaVMs failed with error: %d\n", rv);
@@ -755,15 +761,30 @@ static JNIEnv* getGlobalJNIEnv(void)
                     "FileSystem: loadFileSystems failed");
             return NULL;
         }
+        *attachedByLibhdfs = true;
     } else {
-        //Attach this thread to the VM
         vm = vmBuf[0];
+        // Reuse an existing attachment rather than creating one. On a thread
+        // the JVM or the embedding application already attached,
+        // AttachCurrentThread succeeds and hands back the same JNIEnv, which
+        // would leave libhdfs believing it owns an attachment it did not make
+        // and detaching it at thread exit.
+        rv = (*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_2);
+        if (rv == JNI_OK) {
+            return env;
+        }
+        if (rv != JNI_EDETACHED) {
+            fprintf(stderr, "Call to GetEnv failed with error: %d\n", rv);
+            return NULL;
+        }
+        //Attach this thread to the VM
         rv = (*vm)->AttachCurrentThread(vm, (void*)&env, 0);
         if (rv != 0) {
             fprintf(stderr, "Call to AttachCurrentThread "
                     "failed with error: %d\n", rv);
             return NULL;
         }
+        *attachedByLibhdfs = true;
     }
 
     return env;
@@ -819,7 +840,7 @@ JNIEnv* getJNIEnv(void)
       return NULL;
     }
 
-    state->env = getGlobalJNIEnv();
+    state->env = getGlobalJNIEnv(&state->attachedByLibhdfs);
     if (!state->env) {
         mutexUnlock(&jvmMutex);
         goto fail;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
@@ -52,8 +52,11 @@ void hdfsThreadDestructor(void *v)
   jthrowable jthr;
   char thr_name[MAXTHRID];
 
-  /* Detach the current thread from the JVM */
-  if ((env != NULL) && (*env != NULL)) {
+  /* Detach only threads that libhdfs attached to the JVM. Detaching a thread
+   * that the JVM (or an embedding application) attached frees a JNIEnv its
+   * owner still holds, and by the time this destructor runs that env may
+   * already have been freed, so the dereference below reads freed memory. */
+  if (state->attachedByLibhdfs && (env != NULL) && (*env != NULL)) {
     ret = (*env)->GetJavaVM(env, &vm);
 
     if (ret != 0) {
@@ -158,6 +161,8 @@ struct ThreadLocalState* threadLocalStorageCreate()
       "threadLocalStorageCreate: OOM - Unable to allocate thread local state\n");
     return NULL;
   }
+  state->attachedByLibhdfs = false;
+  state->env = NULL;
   state->lastExceptionStackTrace = NULL;
   state->lastExceptionRootCause = NULL;
   return state;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/thread_local_storage.h
@@ -28,6 +28,8 @@
 
 #include <jni.h>
 
+#include <stdbool.h>
+
 /*
  * Most operating systems support the more efficient __thread construct, which
  * is initialized by the linker.  The following macros use this technique on the
@@ -52,6 +54,8 @@
 #endif
 
 struct ThreadLocalState {
+  /* Whether libhdfs attached this thread to the JVM. */
+  bool attachedByLibhdfs;
   /* The JNIEnv associated with the current thread */
   JNIEnv *env;
   /* The last exception stack trace that occurred on this thread */


### PR DESCRIPTION
### Description of PR

libhdfs registers a pthread TLS destructor, hdfsThreadDestructor, that detaches the current thread from the JVM whenever it finds a cached JNIEnv.  It does so regardless of who attached the thread.  When the JVM (or an embedding application) attached the thread, the JNIEnv it still holds may already have been freed by the time the destructor runs, so dereferencing it reads freed memory (heap-use-after-free, SIGSEGV).

Track in ThreadLocalState whether libhdfs attached the thread itself, determined in getGlobalJNIEnv via GetEnv before attaching, and skip the JNI detach in hdfsThreadDestructor for threads libhdfs did not attach.

The original patch is authored by Jeremy Coulon.
Assisted-by: OpenCode (GLM-5.3-Flash)

JIRA: HDFS-16021

### How was this patch tested?

The same fix is reviewed in Apache DataFusion Comet side: https://github.com/apache/datafusion-comet/pull/5890

### For code changes:

- [x] Does the title of this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: Have the integration tests been executed and the endpoint
      declared according to the connector-specific documentation? *Note: Automated CI
      testing doesn't cover all cases so manual testing with cloud storage is still
      required.*
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [x] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html
